### PR TITLE
Add skip_cpu_governor_check option for benchmarks

### DIFF
--- a/scripts/benchmark_common.py
+++ b/scripts/benchmark_common.py
@@ -3,9 +3,10 @@ import warnings
 import sys
 
 
-def init(cpu, gpu):
+def init(cpu, gpu, skip_cpu_governor_check=False):
     cpu_pin(cpu)
-    check_cpu_governor(cpu)
+    if not skip_cpu_governor_check:
+        check_cpu_governor(cpu)
 
 
 # NB: Be careful with this when benchmarking backward; backward

--- a/scripts/cudnn_lstm.py
+++ b/scripts/cudnn_lstm.py
@@ -13,18 +13,19 @@ import sys
 
 def main():
     parser = argparse.ArgumentParser(description="PyTorch CuDNN LSTM benchmark.")
-    parser.add_argument('--cpu',          type=int, default=0,    help="CPU to run on")
-    parser.add_argument('--gpu',          type=int, default=0,    help="GPU to run on")
-    parser.add_argument('--batch-size',   type=int, default=1,    help="Batch size")
-    parser.add_argument('--input-size',   type=int, default=256,  help="Input size")
-    parser.add_argument('--hidden-size',  type=int, default=512,  help="Hidden size")
-    parser.add_argument('--layers',       type=int, default=1,    help="Layers")
-    parser.add_argument('--seq-len',      type=int, default=512,  help="Sequence length")
-    parser.add_argument('--warmup',       type=int, default=10,   help="Warmup iterations")
-    parser.add_argument('--benchmark',    type=int, default=30,   help="Benchmark iterations")
+    parser.add_argument('--cpu',                     type=int,  default=0,    help="CPU to run on")
+    parser.add_argument('--gpu',                     type=int,  default=0,    help="GPU to run on")
+    parser.add_argument('--batch-size',              type=int,  default=1,    help="Batch size")
+    parser.add_argument('--input-size',              type=int,  default=256,  help="Input size")
+    parser.add_argument('--hidden-size',             type=int,  default=512,  help="Hidden size")
+    parser.add_argument('--layers',                  type=int,  default=1,    help="Layers")
+    parser.add_argument('--seq-len',                 type=int,  default=512,  help="Sequence length")
+    parser.add_argument('--warmup',                  type=int,  default=10,   help="Warmup iterations")
+    parser.add_argument('--benchmark',               type=int,  default=30,   help="Benchmark iterations")
+    parser.add_argument('--skip-cpu-governor-check', action='store_true',     help="Skip checking whether CPU governor is set to `performance`")
     args = parser.parse_args()
 
-    benchmark_common.init(args.cpu, args.gpu)
+    benchmark_common.init(args.cpu, args.gpu, args.skip_cpu_governor_check)
 
     pprint.pprint(vars(args))
 

--- a/scripts/lstm.py
+++ b/scripts/lstm.py
@@ -61,19 +61,20 @@ def unfused_lstm(input, hidden, w_ih, w_hh):
 
 def main():
     parser = argparse.ArgumentParser(description="PyTorch LSTM benchmark.")
-    parser.add_argument('--cpu',          type=int, default=0,    help="CPU to run on")
-    parser.add_argument('--gpu',          type=int, default=0,    help="GPU to run on")
-    parser.add_argument('--batch-size',   type=int, default=1,    help="Batch size")
-    parser.add_argument('--input-size',   type=int, default=256,  help="Input size")
-    parser.add_argument('--hidden-size',  type=int, default=512,  help="Hidden size")
-    parser.add_argument('--seq-len',      type=int, default=None,  help="Sequence length")
-    parser.add_argument('--warmup',       type=int, default=10,   help="Warmup iterations")
-    parser.add_argument('--benchmark',    type=int, default=20,   help="Benchmark iterations")
-    parser.add_argument('--autograd',     action='store_true',    help="Use autograd")
-    parser.add_argument('--variable',     action='store_true',    help="Use Variable, but not autograd (measure baseline overhead)")
-    parser.add_argument('--fused',        action='store_true',    help="Use fused cell")
-    parser.add_argument('--jit',          action='store_true',    help="Use JIT compiler (implies --autograd)")
-    parser.add_argument('--backward',     action='store_true',    help="Run backwards computation")
+    parser.add_argument('--cpu',                     type=int, default=0,     help="CPU to run on")
+    parser.add_argument('--gpu',                     type=int, default=0,     help="GPU to run on")
+    parser.add_argument('--batch-size',              type=int, default=1,     help="Batch size")
+    parser.add_argument('--input-size',              type=int, default=256,   help="Input size")
+    parser.add_argument('--hidden-size',             type=int, default=512,   help="Hidden size")
+    parser.add_argument('--seq-len',                 type=int, default=None,  help="Sequence length")
+    parser.add_argument('--warmup',                  type=int, default=10,    help="Warmup iterations")
+    parser.add_argument('--benchmark',               type=int, default=20,    help="Benchmark iterations")
+    parser.add_argument('--autograd',                action='store_true',     help="Use autograd")
+    parser.add_argument('--variable',                action='store_true',     help="Use Variable, but not autograd (measure baseline overhead)")
+    parser.add_argument('--fused',                   action='store_true',     help="Use fused cell")
+    parser.add_argument('--jit',                     action='store_true',     help="Use JIT compiler (implies --autograd)")
+    parser.add_argument('--backward',                action='store_true',     help="Run backwards computation")
+    parser.add_argument('--skip-cpu-governor-check', action='store_true',     help="Skip checking whether CPU governor is set to `performance`")
     args = parser.parse_args()
 
     if args.jit:
@@ -96,7 +97,7 @@ def main():
 
     pprint.pprint(vars(args))
 
-    benchmark_common.init(args.cpu, args.gpu)
+    benchmark_common.init(args.cpu, args.gpu, args.skip_cpu_governor_check)
 
     if args.variable:
         V = lambda x, requires_grad=False: Variable(x, requires_grad=False)

--- a/scripts/mlstm.py
+++ b/scripts/mlstm.py
@@ -30,17 +30,18 @@ def mlstm_raw(input, hx, cx, w_xm, w_hm, w_ih, w_mh):
 
 def main():
     parser = argparse.ArgumentParser(description="PyTorch LSTM benchmark.")
-    parser.add_argument('--cpu',          type=int, default=0,    help="CPU to run on")
-    parser.add_argument('--gpu',          type=int, default=0,    help="GPU to run on")
-    parser.add_argument('--batch-size',   type=int, default=1,    help="Batch size")
-    parser.add_argument('--input-size',   type=int, default=205,  help="Input size")
-    parser.add_argument('--hidden-size',  type=int, default=1900, help="Hidden size")
-    parser.add_argument('--embed-size',   type=int, default=None, help="Embed size")
-    parser.add_argument('--seq-len',      type=int, default=20,   help="Sequence length")
-    parser.add_argument('--warmup',       type=int, default=10,   help="Warmup iterations")
-    parser.add_argument('--benchmark',    type=int, default=20,   help="Benchmark iterations")
-    parser.add_argument('--autograd',     action='store_true',    help="Use autograd")
-    parser.add_argument('--jit',          action='store_true',    help="Use JIT compiler (implies --autograd)")
+    parser.add_argument('--cpu',                     type=int, default=0,     help="CPU to run on")
+    parser.add_argument('--gpu',                     type=int, default=0,     help="GPU to run on")
+    parser.add_argument('--batch-size',              type=int, default=1,     help="Batch size")
+    parser.add_argument('--input-size',              type=int, default=205,   help="Input size")
+    parser.add_argument('--hidden-size',             type=int, default=1900,  help="Hidden size")
+    parser.add_argument('--embed-size',              type=int, default=None,  help="Embed size")
+    parser.add_argument('--seq-len',                 type=int, default=20,    help="Sequence length")
+    parser.add_argument('--warmup',                  type=int, default=10,    help="Warmup iterations")
+    parser.add_argument('--benchmark',               type=int, default=20,    help="Benchmark iterations")
+    parser.add_argument('--autograd',                action='store_true',     help="Use autograd")
+    parser.add_argument('--jit',                     action='store_true',     help="Use JIT compiler (implies --autograd)")
+    parser.add_argument('--skip-cpu-governor-check', action='store_true',     help="Skip checking whether CPU governor is set to `performance`")
     args = parser.parse_args()
 
     if args.embed_size is None:
@@ -51,7 +52,7 @@ def main():
 
     pprint.pprint(vars(args))
 
-    benchmark_common.init(args.cpu, args.gpu)
+    benchmark_common.init(args.cpu, args.gpu, args.skip_cpu_governor_check)
 
     if args.autograd:
         V = Variable


### PR DESCRIPTION
It seems that we can't reliably set the CPU scaling governor to `performance` because EC2 only allows such setting in their highest tier instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html). Adding an option to disable this check so that the warning won't show up in the perf tests.