### PR TITLE
Fix loss summation

### DIFF
--- a/scripts/mini_sequence_labeler/main.py
+++ b/scripts/mini_sequence_labeler/main.py
@@ -134,7 +134,7 @@ def test_wsj():
                 # print('output=%s, truth=%s' % (output, ex.labels))
 
             loss.backward()
-            total_loss += loss.data.numpy()[0]
+            total_loss += float(loss)
             optimizer.step()
         print(total_loss)
 


### PR DESCRIPTION
The loss summation relies on data being 1-d. Once Tensor and Variable
are merged the loss.data will be 0-d.