### PR TITLE
Fix four undefined names found by flake8

### DIFF
--- a/accuracy/model_accuracy.py
+++ b/accuracy/model_accuracy.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
-from os.path import join
-from datetime import datetime
-import logging
-from tqdm import tqdm
-import os
 import gc
 import itertools
-import sys
+import logging
+import os
 import shlex
 import subprocess
+import sys
+from datetime import datetime
+from os.path import join
+
 import torchvision.models as models
+from tqdm import tqdm
 
-
+model_names = sorted(name for name in models.__dict__
+                     if not (not (name.islower() and not name.startswith("__"))
+                             or not callable(models.__dict__[name])))
 
 parser = argparse.ArgumentParser(description="PyTorch model accuracy benchmark.")
 parser.add_argument('--repeat', type=int, default=5,
@@ -27,11 +29,6 @@ parser.add_argument('--filename', type=str, default='perf_test',
                     help='name of the output file')
 parser.add_argument('--data-dir', type=str, required=True,
                     help='path to imagenet dataset')
-
-
-model_names = sorted(name for name in models.__dict__
-                     if not (not (name.islower() and not name.startswith("__"))
-                             or not callable(models.__dict__[name])))
 
 
 def get_env_pytorch_examples():
@@ -89,6 +86,7 @@ def cmd_string(examples_home, model, data_path):
 
     cmd = ' '.join(['python3', examples_home, '-a', model, '--lr', str(lr), data_path])
     return cmd
+
 
 def log_init():
     if not os.path.exists(temp_dir):

--- a/setup/bench_conf.py
+++ b/setup/bench_conf.py
@@ -99,7 +99,7 @@ def isolate_bench_subset(cpus):
     bench_cpus = [cpu for cpu in cpus if cpu.physical_id == 0]
     bg_cpus = [cpu for cpu in cpus if cpu.physical_id != 0]
     assert len(bench_cpus) > 0, "No CPUs on NUMA node 0!"
-    assert len(remaining_cpus) > 0, "Expected at least two NUMA nodes!"
+    assert len(bg_cpus) > 0, "Expected at least two NUMA nodes!"
     return bench_cpus, bg_cpus
 
 ################################################################################

--- a/setup/bench_conf.py
+++ b/setup/bench_conf.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 from pprint import pprint
 from collections import namedtuple


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/pytorch/benchmark on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./setup/bench_conf.py:101:16: F821 undefined name 'remaining_cpus'
    assert len(remaining_cpus) > 0, "Expected at least two NUMA nodes!"
               ^
./setup/bench_conf.py:120:14: F821 undefined name 'argparse'
    parser = argparse.ArgumentParser(description='Configure benchmarking environment')
             ^
./accuracy/model_accuracy.py:22:64: F821 undefined name 'model_names'
parser.add_argument('--arch', type=str, default='all', choices=model_names, nargs='+',
                                                               ^
./accuracy/model_accuracy.py:23:63: F821 undefined name 'model_names'
                    help='model architectures: ' + ' | '.join(model_names) + ' (default: all)')
                                                              ^
4     F821 undefined name 'model_names'
4
```