### PR TITLE
Add some variable sequence length LSTM benchmarks

### DIFF
--- a/rnns/fastrnns/runner.py
+++ b/rnns/fastrnns/runner.py
@@ -4,7 +4,8 @@ import torch
 import torchvision.models as cnn
 
 from .factory import pytorch_lstm_creator, lstm_creator, lstm_premul_creator, \
-    lstm_multilayer_creator, lstm_simple_creator, imagenet_cnn_creator
+    lstm_multilayer_creator, lstm_simple_creator, imagenet_cnn_creator, \
+    varlen_pytorch_lstm_creator, varlen_lstm_creator
 
 
 class DisableCuDNN():
@@ -45,6 +46,9 @@ def get_rnn_runners(*names):
 
 rnn_runners = {
     'cudnn': RNNRunner('cudnn', pytorch_lstm_creator, DummyContext),
+    'vl_cudnn': RNNRunner('vl_cudnn', varlen_pytorch_lstm_creator, DummyContext),
+    'vl_jit': RNNRunner('vl_jit', partial(varlen_lstm_creator, script=True), DummyContext),
+    'vl_py': RNNRunner('vl_py', varlen_lstm_creator, DummyContext),
     'aten': RNNRunner('aten', pytorch_lstm_creator, DisableCuDNN),
     'jit': RNNRunner('jit', lstm_creator, DummyContext),
     'jit_premul': RNNRunner('jit_premul', lstm_premul_creator, DummyContext),


### PR DESCRIPTION
Added three benchmarks:
1) pack_sequence + pytorch native LSTM
2) custom JIT LSTM
3) python LSTM (in other words, the JIT LSTM without torchscript)

fastrnns.bench / fastrnns.test now take a '--variable_lstms' argument to
turn on benchmarking / testing for them. It's not enabled by default
because benchmarks (2) and (3) are pretty slow (on the order of
magnitude of seconds) vs 10's of ms for (1).