### PR TITLE
Add cudnn layernorm lowerbound benchmark

### DIFF
--- a/rnns/fastrnns/bench.py
+++ b/rnns/fastrnns/bench.py
@@ -150,7 +150,8 @@ if __name__ == '__main__':
     rnns = args.rnns or ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_simple',
                          'jit_multilayer', 'py']
     # TODO: Maybe add a separate section for the layernorm/dropout lstms
-    # 'jit_layernorm', 'jit_layernom_decom', 'jit', 'jit_dropout', 'cudnn_dropout'
+    # 'cudnn_layernorm', jit_layernorm', 'jit_layernom_decom',
+    # 'jit', 'jit_dropout', 'cudnn_dropout'
     vlrnns = ['vl_cudnn', 'vl_jit', 'vl_py']
     cnns = ['resnet18', 'resnet18_jit', 'resnet50', 'resnet50_jit']
     if args.print_json:

--- a/rnns/fastrnns/factory.py
+++ b/rnns/fastrnns/factory.py
@@ -267,6 +267,43 @@ def varlen_lstm_creator(script=False, **kwargs):
         backward=simple_backward)
 
 
+# cudnn_layernorm_lstm: since cudnn does not have Layernorm LSTM, we cannot benchmark
+# the lowerbound directly. Instead, we only benchmark the foward pass by mimicing the
+# computation of a cudnn lstm + seq_len * 3 layernorm computation. This should serve
+# as a perf lowerbound for the Layernorm LSTM forward pass(given that Layernorm itself
+# is invariant), the lowerbound of backward pass is hard to get since we lose the
+# intermediate results, we can still optimize the layernorm implementation to make
+# a faster foward lowerbound though.
+def layernorm_pytorch_lstm_creator(**kwargs):
+    input, hidden, _, module = lstm_inputs(return_module=True, **kwargs)
+    batch_size = kwargs['miniBatch']
+    hidden_size = kwargs['hiddenSize']
+    ln_i = torch.nn.LayerNorm(4 * hidden_size).cuda()
+    ln_h = torch.nn.LayerNorm(4 * hidden_size).cuda()
+    ln_c = torch.nn.LayerNorm(hidden_size).cuda()
+    ln_input1 = torch.randn(batch_size, 4 * hidden_size, device='cuda')
+
+    def forward(input, hidden):
+        out, new_hidden = module(input, hidden)
+        # plus (seq_len * three laynorm cell computation) to mimic the lower bound of
+        # Layernorm cudnn LSTM in the forward pass
+        seq_len = len(input.unbind(0))
+        hy, cy = new_hidden
+        for i in range(seq_len):
+            ln_i_output = ln_i(ln_input1)
+            ln_h_output = ln_h(ln_input1)
+            cy = ln_c(cy)
+
+        return out, (hy, cy)
+
+    return ModelDef(
+        inputs=[input, hidden],
+        params=flatten_list(module.all_weights),
+        forward=forward,
+        backward_setup=lstm_backward_setup,
+        backward=simple_backward)
+
+
 # input: lstm.all_weights format (wih, whh, bih, bhh = lstm.all_weights[layer])
 # output: packed_weights with format
 # packed_weights[0] is wih with size (layer, 4*hiddenSize, inputSize)

--- a/rnns/fastrnns/factory.py
+++ b/rnns/fastrnns/factory.py
@@ -301,7 +301,7 @@ def layernorm_pytorch_lstm_creator(**kwargs):
         params=flatten_list(module.all_weights),
         forward=forward,
         backward_setup=lstm_backward_setup,
-        backward=simple_backward)
+        backward=None)
 
 
 # input: lstm.all_weights format (wih, whh, bih, bhh = lstm.all_weights[layer])

--- a/rnns/fastrnns/runner.py
+++ b/rnns/fastrnns/runner.py
@@ -45,6 +45,7 @@ def get_rnn_runners(*names):
 rnn_runners = {
     'cudnn': RNNRunner('cudnn', pytorch_lstm_creator, DummyContext),
     'cudnn_dropout': RNNRunner('cudnn_dropout', partial(pytorch_lstm_creator, dropout=0.4), DummyContext),
+    'cudnn_layernorm': RNNRunner('cudnn_layernorm', layernorm_pytorch_lstm_creator, DummyContext),
     'vl_cudnn': RNNRunner('vl_cudnn', varlen_pytorch_lstm_creator, DummyContext),
     'vl_jit': RNNRunner('vl_jit', partial(varlen_lstm_creator, script=True), DummyContext),
     'vl_py': RNNRunner('vl_py', varlen_lstm_creator, DummyContext),


### PR DESCRIPTION
Benchmark results:

```
Benchmarking LSTMs...
            name        avg_fwd          std_fwd          avg_bwd          std_bwd
cudnn_layernorm          32.71           0.7494            10.43          0.08965
jit_layernorm            41.25           0.7082            98.66             2.56
jit_layernorm_de         34.41           0.7501            113.3            1.037
```
only forward pass is valid