### PR TITLE
fix model_accuracy.py argument parser issue.

### DIFF
--- a/accuracy/model_accuracy.py
+++ b/accuracy/model_accuracy.py
@@ -14,6 +14,11 @@ import subprocess
 import torchvision.models as models
 
 
+model_names = sorted(name for name in models.__dict__
+                     if not (not (name.islower() and not name.startswith("__"))
+                             or not callable(models.__dict__[name])))
+
+                     
 parser = argparse.ArgumentParser(description="PyTorch model accuracy benchmark.")
 parser.add_argument('--repeat', type=int, default=5,
                     help="Number of Runs")
@@ -25,12 +30,6 @@ parser.add_argument('--filename', type=str, default='perf_test',
                     help='name of the output file')
 parser.add_argument('--data-dir', type=str, required=True,
                     help='path to imagenet dataset')
-
-
-model_names = sorted(name for name in models.__dict__
-                     if not (not (name.islower() and not name.startswith("__"))
-                             or not callable(models.__dict__[name])))
-
 
 def get_env_pytorch_examples():
     pytorch_examples_home = os.environ.get('EXAMPLES_HOME')


### PR DESCRIPTION
there is an issue when executing model_accuracy.py

./model_accuracy.py
Traceback (most recent call last):
  File "./model_accuracy.py", line 22, in <module>
    parser.add_argument('--arch', type=str, default='all', choices=model_names, nargs='+',
NameError: name 'model_names' is not defined