### PR TITLE
Include date in benchmark filename

### DIFF
--- a/scripts/run_bench_and_upload.sh
+++ b/scripts/run_bench_and_upload.sh
@@ -19,7 +19,7 @@ fi
 
 BENCHMARK_DATA="`pwd`/.data"
 mkdir -p ${BENCHMARK_DATA}
-BENCHMARK_FILENAME=${CIRCLE_SHA1}.json
+BENCHMARK_FILENAME=${CIRCLE_SHA1}_$(date +"%Y%m%d_%H%M%S").json
 BENCHMARK_ABS_FILENAME=${BENCHMARK_DATA}/${BENCHMARK_FILENAME}
 pytest test_bench.py --setup-show --benchmark-sort=Name --benchmark-json=${BENCHMARK_ABS_FILENAME} -k "$PYTEST_FILTER"
 


### PR DESCRIPTION
- same SHA (e.g. latest benchmark repo version) may be benchmarked
  multiple times, rather than overwrite just keep them all