### PR TITLE
Increase no_output_timeout from 10m default to 30m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,11 @@ jobs:
       - run:
           name: Validate training benchmark suite
           command: . ~/miniconda3/etc/profile.d/conda.sh; conda activate base; python test.py
+          no_output_timeout: "30m"
       - run:
           name: Validate pytest-benchmark invocation of training suite
           command: ./scripts/run_bench_and_upload.sh
+          no_output_timeout: "30m"
 
 workflows:
   version: 2


### PR DESCRIPTION
Unclear whether 10m timeout is due to legitimate slow models, but its a tight limit.