### PR TITLE
Update run_bench_and_upload.sh

### DIFF
--- a/scripts/run_bench_and_upload.sh
+++ b/scripts/run_bench_and_upload.sh
@@ -34,29 +34,23 @@ else
     python scripts/upload_scribe.py --pytest_bench_json ${BENCHMARK_ABS_FILENAME} --torchbench_score ${TORCHBENCH_SCORE}
 fi
 
-
-git clone https://github.com/wconstab/pytorch_benchmark_data
-pushd pytorch_benchmark_data
-git config --global user.name "pytorchbot"
-git config --global --unset url.ssh://git@github.com.insteadof || true
-
 # Store the files with respect to the repo that their hash refers to
 # separate master and pull_requests just for conveneince in the UI
 if [ "$CIRCLE_BRANCH" = "master" ]
 then
+    git clone https://github.com/wconstab/pytorch_benchmark_data
+    pushd pytorch_benchmark_data
+    git config --global user.name "pytorchbot"
+    git config --global --unset url.ssh://git@github.com.insteadof || true
     SUBDIR="${CIRCLE_PROJECT_REPONAME}/master"
-else
-    SUBDIR="${CIRCLE_PROJECT_REPONAME}/pull_requests"
-fi
-mkdir -p $SUBDIR/
-cp ${BENCHMARK_ABS_FILENAME} $SUBDIR/
-git add ${SUBDIR}/${BENCHMARK_FILENAME}
-if [ "$CIRCLE_BRANCH" = "master" ]
-then
+    mkdir -p $SUBDIR/
+    cp ${BENCHMARK_ABS_FILENAME} $SUBDIR/
+    git add ${SUBDIR}/${BENCHMARK_FILENAME}
     ln -s -f ${SUBDIR}/${BENCHMARK_FILENAME} ${SUBDIR}/latest
     echo ${BENCHMARK_FILENAME} >> ${SUBDIR}/history
     git add ${SUBDIR}/latest ${SUBDIR}/history
+    git commit -m"Add ${BENCHMARK_FILENAME} - to reproduce results, see pytorch and machine versions in .json"
+    git push origin master
 fi
-git commit -m"Add ${BENCHMARK_FILENAME} - to reproduce results, see pytorch and machine versions in .json"
-git push origin master
+
 popd

--- a/scripts/run_bench_and_upload.sh
+++ b/scripts/run_bench_and_upload.sh
@@ -51,6 +51,6 @@ then
     git add ${SUBDIR}/latest ${SUBDIR}/history
     git commit -m"Add ${BENCHMARK_FILENAME} - to reproduce results, see pytorch and machine versions in .json"
     git push origin master
+    popd
 fi
 
-popd


### PR DESCRIPTION
Pushing from PRs worked fine if the PR was from a branch on the pytorch/benchmark repo, but broke if the PR was from a forked repo.  This is becuase circle CI only provides the credentials that can push the data to github to the jobs that are from the trusted fork for security reasons.

Rather than fixing the logic for PRs I'm disabling it and only archiving for master.  The results from this CI job aren't critical anyway, and we're building new infra to run the real benchmarks so we'll revisit then.