### PR TITLE
Add nightly-sweep build workflow.

### DIFF
--- a/.github/scripts/run-docker.sh
+++ b/.github/scripts/run-docker.sh
@@ -9,9 +9,13 @@ CONFIG_VER=v0
 RUN_SCRIPT=$1
 CONFIG_DIR=${PWD}/score/configs/${CONFIG_VER}
 CONFIG_ENV=${CONFIG_DIR}/config-${CONFIG_VER}.env
-DATA_DIR=${HOME}/benchmark-results/gh${GITHUB_RUN_ID}
 # Use the latest pytorch-benchmark image
 TORCH_IMAGE_ID=torchbench/pytorch-benchmark:latest
+if [ -z "$2" ]; then
+    DATA_DIR=${HOME}/benchmark-results/gh${GITHUB_RUN_ID}
+else
+    DATA_DIR=$2
+fi
 
 # Load environment variables
 set -a;

--- a/.github/scripts/run-sweep-benchmark.sh
+++ b/.github/scripts/run-sweep-benchmark.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -xeo pipefail
+
+for CONFIG in /output/configs/*; do
+    # Create a new conda version from base
+    CONFIG_BASE=$(basename ${CONFIG})
+    CONFIG_VER=$(echo ${CONFIG} | sed 's/.*-\(.*\)\.txt/\1/')
+    conda create --name ${CONFIG_VER} python=3.7
+    . activate ${CONFIG_VER}
+    pip install -r $CONFIG
+    pushd /workspace/benchmark
+    # workaround the maskrcnn_benchmark undefined symbol problem
+    find . -name "*.so" -delete
+    python install.py
+    bash /workspace/benchmark/.github/scripts/run-benchmark.sh
+done
+

--- a/.github/scripts/run-sweep.sh
+++ b/.github/scripts/run-sweep.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -xeo pipefail
+
+SWEEP_DIR="${HOME}/nightly-sweep"
+
+# Run benchmark
+bash ./.github/scripts/run-docker.sh \
+    /workspace/benchmark/.github/scripts/run-sweep-benchmark.sh \
+    ${SWEEP_DIR}
+

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,0 +1,9 @@
+name: pytorch-nightly-sweep
+on:
+  workflow_dispatch:
+
+jobs:
+  run-sweep:
+    runs-on: [self-hosted, bm-ec2]
+    steps:
+      - run: bash ./.github/scripts/run-sweep.sh


### PR DESCRIPTION
The workflow relies on a nightly-sweep directory on the runner. The directory should have the following orgs:
nightly-sweep/
|-- configs/
      |-- configs/requirements-1.6.0.dev20200526.txt
      |-- configs/requirements-1.6.0.dev20200527.txt
      |-- ...
The workflow will load the first requirements-*.txt file, then run the benchmark, then run the second requirements.txt file, etc.
The result will be stored under the nightly-sweep/ directory.