### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/vocab.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/vocab.py
@@ -16,7 +16,7 @@ class TorchVocab(object):
     def __init__(self, counter, max_size=None, min_freq=1, specials=['<pad>', '<oov>'],
                  vectors=None, unk_init=None, vectors_cache=None):
         """Create a Vocab object from a collections.Counter.
-        Arguments:
+        Args:
             counter: collections.Counter object holding the frequencies of
                 each value found in the data.
             max_size: The maximum size of the vocabulary, or None for no

--- a/torchbenchmark/models/demucs/demucs/separate.py
+++ b/torchbenchmark/models/demucs/demucs/separate.py
@@ -36,7 +36,7 @@ def download_file(url, target):
     """
     Download a file with a progress bar.
 
-    Arguments:
+    Args:
         url (str): url to download
         target (Path): target path to write to
         sha256 (str or None): expected sha256 hexdigest of the file

--- a/torchbenchmark/models/fastNLP/fastNLP/modules/encoder/gpt2.py
+++ b/torchbenchmark/models/fastNLP/fastNLP/modules/encoder/gpt2.py
@@ -515,7 +515,7 @@ class GPT2PreTrainedModel(nn.Module):
     def prune_heads(self, heads_to_prune):
         """ Prunes heads of the base model.
 
-            Arguments:
+            Args:
 
                 heads_to_prune: dict with keys being selected layer indices (`int`) and associated values being the list of heads to prune in said layer (list of `int`).
                 E.g. {1: [0, 2], 2: [2, 3]} will prune heads 0 and 2 on layer 1 and heads 2 and 3 on layer 2.

--- a/torchbenchmark/models/maskrcnn_benchmark/demo/predictor.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/demo/predictor.py
@@ -198,7 +198,7 @@ class COCODemo(object):
 
     def run_on_opencv_image(self, image):
         """
-        Arguments:
+        Args:
             image (np.ndarray): an image as returned by OpenCV
 
         Returns:
@@ -223,7 +223,7 @@ class COCODemo(object):
 
     def compute_prediction(self, original_image):
         """
-        Arguments:
+        Args:
             original_image (np.ndarray): an image as returned by OpenCV
 
         Returns:
@@ -263,7 +263,7 @@ class COCODemo(object):
         Select only predictions which have a `score` > self.confidence_threshold,
         and returns the predictions in descending order of score
 
-        Arguments:
+        Args:
             predictions (BoxList): the result of the computation by the model.
                 It should contain the field `scores`.
 
@@ -291,7 +291,7 @@ class COCODemo(object):
         """
         Adds the predicted boxes on top of the image
 
-        Arguments:
+        Args:
             image (np.ndarray): an image as returned by OpenCV
             predictions (BoxList): the result of the computation by the model.
                 It should contain the field `labels`.
@@ -315,7 +315,7 @@ class COCODemo(object):
         Adds the instances contours for each predicted object.
         Each label has a different color.
 
-        Arguments:
+        Args:
             image (np.ndarray): an image as returned by OpenCV
             predictions (BoxList): the result of the computation by the model.
                 It should contain the field `mask` and `labels`.
@@ -350,7 +350,7 @@ class COCODemo(object):
         Create a montage showing the probability heatmaps for each one one of the
         detected objects
 
-        Arguments:
+        Args:
             image (np.ndarray): an image as returned by OpenCV
             predictions (BoxList): the result of the computation by the model.
                 It should contain the field `mask`.
@@ -386,7 +386,7 @@ class COCODemo(object):
         Adds detected class names and scores in the positions defined by the
         top-left corner of the predicted bounding box
 
-        Arguments:
+        Args:
             image (np.ndarray): an image as returned by OpenCV
             predictions (BoxList): the result of the computation by the model.
                 It should contain the field `scores` and `labels`.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
@@ -17,7 +17,7 @@ from .transforms import build_transforms
 
 def build_dataset(dataset_list, transforms, dataset_catalog, is_train=True):
     """
-    Arguments:
+    Args:
         dataset_list (list[str]): Contains the names of the datasets, i.e.,
             coco_2014_train, coco_2014_val, etc
         transforms (callable): transforms to apply to each (image, target) sample

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/datasets/cityscapes.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/datasets/cityscapes.py
@@ -28,7 +28,7 @@ class CityScapesDataset(AbstractDataset):
         mini=None,
     ):
         """
-        Arguments:
+        Args:
             img_dir: /path/to/leftImg8bit/      has to contain {train,val,test}
             ann_dir: /path/to/gtFine/           has to contain {train,val,test}
             split: "train" or "val" or "test"

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/samplers/distributed.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/samplers/distributed.py
@@ -15,7 +15,7 @@ class DistributedSampler(Sampler):
     and load a subset of the original dataset that is exclusive to it.
     .. note::
         Dataset is assumed to be of constant size.
-    Arguments:
+    Args:
         dataset: Dataset used for sampling.
         num_replicas (optional): Number of processes participating in
             distributed training.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/samplers/grouped_batch_sampler.py
@@ -13,7 +13,7 @@ class GroupedBatchSampler(BatchSampler):
     It also tries to provide mini-batches which follows an ordering which is
     as close as possible to the ordering from the original sampler.
 
-    Arguments:
+    Args:
         sampler (Sampler): Base sampler.
         batch_size (int): Size of mini-batch.
         drop_uneven (bool): If ``True``, the sampler will drop the batches whose

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/backbone/fpn.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/backbone/fpn.py
@@ -15,7 +15,7 @@ class FPN(nn.Module):
         self, in_channels_list, out_channels, conv_block, top_blocks=None
     ):
         """
-        Arguments:
+        Args:
             in_channels_list (list[int]): number of channels for each feature map that
                 will be fed
             out_channels (int): number of channels of the FPN representation
@@ -42,7 +42,7 @@ class FPN(nn.Module):
 
     def forward(self, x):
         """
-        Arguments:
+        Args:
             x (list[Tensor]): feature maps for each feature level.
         Returns:
             results (tuple[Tensor]): feature maps after FPN layers.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/balanced_positive_negative_sampler.py
@@ -9,7 +9,7 @@ class BalancedPositiveNegativeSampler(object):
 
     def __init__(self, batch_size_per_image, positive_fraction):
         """
-        Arguments:
+        Args:
             batch_size_per_image (int): number of elements to be selected per image
             positive_fraction (float): percentage of positive elements per batch
         """
@@ -18,7 +18,7 @@ class BalancedPositiveNegativeSampler(object):
 
     def __call__(self, matched_idxs):
         """
-        Arguments:
+        Args:
             matched idxs: list of tensors containing -1, 0 or positive values.
                 Each tensor corresponds to a specific image.
                 -1 values are ignored, 0 are considered as negatives and > 0 as

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/box_coder.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/box_coder.py
@@ -12,7 +12,7 @@ class BoxCoder(object):
 
     def __init__(self, weights, bbox_xform_clip=math.log(1000. / 16)):
         """
-        Arguments:
+        Args:
             weights (4-element tuple)
             bbox_xform_clip (float)
         """
@@ -24,7 +24,7 @@ class BoxCoder(object):
         Encode a set of proposals with respect to some
         reference boxes
 
-        Arguments:
+        Args:
             reference_boxes (Tensor): reference boxes
             proposals (Tensor): boxes to be encoded
         """
@@ -54,7 +54,7 @@ class BoxCoder(object):
         From a set of original boxes and encoded relative box offsets,
         get the decoded boxes.
 
-        Arguments:
+        Args:
             rel_codes (Tensor): encoded boxes
             boxes (Tensor): reference boxes.
         """

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/detector/generalized_rcnn.py
@@ -32,7 +32,7 @@ class GeneralizedRCNN(nn.Module):
 
     def forward(self, images, targets=None):
         """
-        Arguments:
+        Args:
             images (list[Tensor] or ImageList): images to be processed
             targets (list[BoxList]): ground-truth boxes present in the image (optional)
 

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/poolers.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/poolers.py
@@ -15,7 +15,7 @@ class LevelMapper(object):
 
     def __init__(self, k_min, k_max, canonical_scale=224, canonical_level=4, eps=1e-6):
         """
-        Arguments:
+        Args:
             k_min (int)
             k_max (int)
             canonical_scale (int)
@@ -30,7 +30,7 @@ class LevelMapper(object):
 
     def __call__(self, boxlists):
         """
-        Arguments:
+        Args:
             boxlists (list[BoxList])
         """
         # Compute level ids
@@ -54,7 +54,7 @@ class Pooler(nn.Module):
 
     def __init__(self, output_size, scales, sampling_ratio):
         """
-        Arguments:
+        Args:
             output_size (list[tuple[int]] or list[int]): output size for the pooled region
             scales (list[float]): scales for each Pooler
             sampling_ratio (int): sampling ratio for ROIAlign
@@ -90,7 +90,7 @@ class Pooler(nn.Module):
 
     def forward(self, x, boxes):
         """
-        Arguments:
+        Args:
             x (list[Tensor]): feature maps for each level
             boxes (list[BoxList]): boxes to be used to perform the pooling operation.
         Returns:

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/box_head.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/box_head.py
@@ -23,7 +23,7 @@ class ROIBoxHead(torch.nn.Module):
 
     def forward(self, features, proposals, targets=None):
         """
-        Arguments:
+        Args:
             features (list[Tensor]): feature-maps from possibly several levels
             proposals (list[BoxList]): proposal boxes
             targets (list[BoxList], optional): the ground-truth targets.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/inference.py
@@ -26,7 +26,7 @@ class PostProcessor(nn.Module):
         bbox_aug_enabled=False
     ):
         """
-        Arguments:
+        Args:
             score_thresh (float)
             nms (float)
             detections_per_img (int)
@@ -44,7 +44,7 @@ class PostProcessor(nn.Module):
 
     def forward(self, x, boxes):
         """
-        Arguments:
+        Args:
             x (tuple[tensor, tensor]): x contains the class logits
                 and the box_regression from the model.
             boxes (list[BoxList]): bounding boxes that are used as

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/loss.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/box_head/loss.py
@@ -26,7 +26,7 @@ class FastRCNNLossComputation(object):
         cls_agnostic_bbox_reg=False
     ):
         """
-        Arguments:
+        Args:
             proposal_matcher (Matcher)
             fg_bg_sampler (BalancedPositiveNegativeSampler)
             box_coder (BoxCoder)
@@ -85,7 +85,7 @@ class FastRCNNLossComputation(object):
         the sampled proposals.
         Note: this function keeps a state.
 
-        Arguments:
+        Args:
             proposals (list[BoxList])
             targets (list[BoxList])
         """
@@ -120,7 +120,7 @@ class FastRCNNLossComputation(object):
         Computes the loss for Faster R-CNN.
         This requires that the subsample method has been called beforehand.
 
-        Arguments:
+        Args:
             class_logits (list[Tensor])
             box_regression (list[Tensor])
 

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/keypoint_head.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/keypoint_head.py
@@ -18,7 +18,7 @@ class ROIKeypointHead(torch.nn.Module):
 
     def forward(self, features, proposals, targets=None):
         """
-        Arguments:
+        Args:
             features (list[Tensor]): feature-maps from possibly several levels
             proposals (list[BoxList]): proposal boxes
             targets (list[BoxList], optional): the ground-truth targets.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/loss.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/keypoint_head/loss.py
@@ -54,7 +54,7 @@ def _within_box(points, boxes):
 class KeypointRCNNLossComputation(object):
     def __init__(self, proposal_matcher, fg_bg_sampler, discretization_size):
         """
-        Arguments:
+        Args:
             proposal_matcher (Matcher)
             fg_bg_sampler (BalancedPositiveNegativeSampler)
             discretization_size (int)
@@ -114,7 +114,7 @@ class KeypointRCNNLossComputation(object):
         the sampled proposals.
         Note: this function keeps a state.
 
-        Arguments:
+        Args:
             proposals (list[BoxList])
             targets (list[BoxList])
         """

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/inference.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/inference.py
@@ -26,7 +26,7 @@ class MaskPostProcessor(nn.Module):
 
     def forward(self, x, boxes):
         """
-        Arguments:
+        Args:
             x (Tensor): the mask logits
             boxes (list[BoxList]): bounding boxes that are used as
                 reference, one for each image

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/loss.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/loss.py
@@ -16,7 +16,7 @@ def project_masks_on_boxes(segmentation_masks, proposals, discretization_size):
     boxes. This prepares the masks for them to be fed to the
     loss computation as the targets.
 
-    Arguments:
+    Args:
         segmentation_masks: an instance of SegmentationMask
         proposals: an instance of BoxList
     """
@@ -45,7 +45,7 @@ def project_masks_on_boxes(segmentation_masks, proposals, discretization_size):
 class MaskRCNNLossComputation(object):
     def __init__(self, proposal_matcher, discretization_size):
         """
-        Arguments:
+        Args:
             proposal_matcher (Matcher)
             discretization_size (int)
         """
@@ -101,7 +101,7 @@ class MaskRCNNLossComputation(object):
 
     def __call__(self, proposals, mask_logits, targets):
         """
-        Arguments:
+        Args:
             proposals (list[BoxList])
             mask_logits (Tensor)
             targets (list[BoxList])

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/mask_head.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/mask_head.py
@@ -15,7 +15,7 @@ def keep_only_positive_boxes(boxes):
     Given a set of BoxList containing the `labels` field,
     return a set of BoxList for which `labels > 0`.
 
-    Arguments:
+    Args:
         boxes (list of BoxList)
     """
     assert isinstance(boxes, (list, tuple))
@@ -45,7 +45,7 @@ class ROIMaskHead(torch.nn.Module):
 
     def forward(self, features, proposals, targets=None):
         """
-        Arguments:
+        Args:
             features (list[Tensor]): feature-maps from possibly several levels
             proposals (list[BoxList]): proposal boxes
             targets (list[BoxList], optional): the ground-truth targets.

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/roi_heads/mask_head/roi_mask_feature_extractors.py
@@ -21,7 +21,7 @@ class MaskRCNNFPNFeatureExtractor(nn.Module):
 
     def __init__(self, cfg, in_channels):
         """
-        Arguments:
+        Args:
             num_classes (int): number of output classes
             input_size (int): number of channels of the input once it's flattened
             representation_size (int): size of the intermediate representation

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/inference.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/inference.py
@@ -27,7 +27,7 @@ class RPNPostProcessor(torch.nn.Module):
         fpn_post_nms_per_batch=True,
     ):
         """
-        Arguments:
+        Args:
             pre_nms_top_n (int)
             post_nms_top_n (int)
             nms_thresh (float)
@@ -52,7 +52,7 @@ class RPNPostProcessor(torch.nn.Module):
 
     def add_gt_proposals(self, proposals, targets):
         """
-        Arguments:
+        Args:
             proposals: list[BoxList]
             targets: list[BoxList]
         """
@@ -75,7 +75,7 @@ class RPNPostProcessor(torch.nn.Module):
 
     def forward_for_single_feature_map(self, anchors, objectness, box_regression):
         """
-        Arguments:
+        Args:
             anchors: list[BoxList]
             objectness: tensor of size N, A, H, W
             box_regression: tensor of size N, A * 4, H, W
@@ -124,7 +124,7 @@ class RPNPostProcessor(torch.nn.Module):
 
     def forward(self, anchors, objectness, box_regression, targets=None):
         """
-        Arguments:
+        Args:
             anchors: list[list[BoxList]]
             objectness: list[tensor]
             box_regression: list[tensor]

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/loss.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/loss.py
@@ -26,7 +26,7 @@ class RPNLossComputation(object):
     def __init__(self, proposal_matcher, fg_bg_sampler, box_coder,
                  generate_labels_func):
         """
-        Arguments:
+        Args:
             proposal_matcher (Matcher)
             fg_bg_sampler (BalancedPositiveNegativeSampler)
             box_coder (BoxCoder)
@@ -91,7 +91,7 @@ class RPNLossComputation(object):
 
     def __call__(self, anchors, objectness, box_regression, targets):
         """
-        Arguments:
+        Args:
             anchors (list[list[BoxList]])
             objectness (list[Tensor])
             box_regression (list[Tensor])

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/inference.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/inference.py
@@ -27,7 +27,7 @@ class RetinaNetPostProcessor(RPNPostProcessor):
         box_coder=None,
     ):
         """
-        Arguments:
+        Args:
             pre_nms_thresh (float)
             pre_nms_top_n (int)
             nms_thresh (float)
@@ -59,7 +59,7 @@ class RetinaNetPostProcessor(RPNPostProcessor):
     def forward_for_single_feature_map(
             self, anchors, box_cls, box_regression):
         """
-        Arguments:
+        Args:
             anchors: list[BoxList]
             box_cls: tensor of size N, A * C, H, W
             box_regression: tensor of size N, A * 4, H, W

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/loss.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/loss.py
@@ -27,7 +27,7 @@ class RetinaNetLossComputation(RPNLossComputation):
                  bbox_reg_beta=0.11,
                  regress_norm=1.0):
         """
-        Arguments:
+        Args:
             proposal_matcher (Matcher)
             box_coder (BoxCoder)
         """
@@ -42,7 +42,7 @@ class RetinaNetLossComputation(RPNLossComputation):
 
     def __call__(self, anchors, box_cls, box_regression, targets):
         """
-        Arguments:
+        Args:
             anchors (list[BoxList])
             box_cls (list[Tensor])
             box_regression (list[Tensor])

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/retinanet.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/retinanet/retinanet.py
@@ -17,7 +17,7 @@ class RetinaNetHead(torch.nn.Module):
 
     def __init__(self, cfg, in_channels):
         """
-        Arguments:
+        Args:
             in_channels (int): number of channels of the input feature
             num_anchors (int): number of anchors to be predicted
         """
@@ -111,7 +111,7 @@ class RetinaNetModule(torch.nn.Module):
 
     def forward(self, images, features, targets=None):
         """
-        Arguments:
+        Args:
             images (ImageList): images for which we want to compute the predictions
             features (list[Tensor]): features computed from the images that are
                 used for computing the predictions. Each tensor in the list

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/rpn.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/modeling/rpn/rpn.py
@@ -18,7 +18,7 @@ class RPNHeadConvRegressor(nn.Module):
 
     def __init__(self, cfg, in_channels, num_anchors):
         """
-        Arguments:
+        Args:
             cfg              : config
             in_channels (int): number of channels of the input feature
             num_anchors (int): number of anchors to be predicted
@@ -48,7 +48,7 @@ class RPNHeadFeatureSingleConv(nn.Module):
 
     def __init__(self, cfg, in_channels):
         """
-        Arguments:
+        Args:
             cfg              : config
             in_channels (int): number of channels of the input feature
         """
@@ -78,7 +78,7 @@ class RPNHead(nn.Module):
 
     def __init__(self, cfg, in_channels, num_anchors):
         """
-        Arguments:
+        Args:
             cfg              : config
             in_channels (int): number of channels of the input feature
             num_anchors (int): number of anchors to be predicted
@@ -139,7 +139,7 @@ class RPNModule(torch.nn.Module):
 
     def forward(self, images, features, targets=None):
         """
-        Arguments:
+        Args:
             images (ImageList): images for which we want to compute the predictions
             features (list[Tensor]): features computed from the images that are
                 used for computing the predictions. Each tensor in the list

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/boxlist_ops.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/boxlist_ops.py
@@ -11,7 +11,7 @@ def boxlist_nms(boxlist, nms_thresh, max_proposals=-1, score_field="scores"):
     Performs non-maximum suppression on a boxlist, with scores specified
     in a boxlist field via score_field.
 
-    Arguments:
+    Args:
         boxlist(BoxList)
         nms_thresh (float)
         max_proposals (int): if > 0, then only the top max_proposals are kept
@@ -35,7 +35,7 @@ def remove_small_boxes(boxlist, min_size):
     """
     Only keep boxes with both sides >= min_size
 
-    Arguments:
+    Args:
         boxlist (Boxlist)
         min_size (int)
     """
@@ -54,7 +54,7 @@ def boxlist_iou(boxlist1, boxlist2):
     """Compute the intersection over union of two set of boxes.
     The box order must be (xmin, ymin, xmax, ymax).
 
-    Arguments:
+    Args:
       box1: (BoxList) bounding boxes, sized [N,4].
       box2: (BoxList) bounding boxes, sized [M,4].
 
@@ -105,7 +105,7 @@ def cat_boxlist(bboxes):
     Concatenates a list of BoxList (having the same image size) into a
     single BoxList
 
-    Arguments:
+    Args:
         bboxes (list[BoxList])
     """
     assert isinstance(bboxes, (list, tuple))

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/image_list.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/image_list.py
@@ -14,7 +14,7 @@ class ImageList(object):
 
     def __init__(self, tensors, image_sizes):
         """
-        Arguments:
+        Args:
             tensors (tensor)
             image_sizes (list[tuple[int, int]])
         """

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -37,7 +37,7 @@ class BinaryMaskList(object):
 
     def __init__(self, masks, size):
         """
-            Arguments:
+            Args:
                 masks: Either torch.tensor of [num_instances, H, W]
                     or list of torch.tensors of [H, W] with num_instances elems,
                     or RLE (Run Length Encoding) - interpreted as list of dicts,
@@ -214,7 +214,7 @@ class PolygonInstance(object):
 
     def __init__(self, polygons, size):
         """
-            Arguments:
+            Args:
                 a list of lists of numbers.
                 The first level refers to all the polygons that compose the
                 object, and the second level to the polygon coordinates.
@@ -352,7 +352,7 @@ class PolygonList(object):
 
     def __init__(self, polygons, size):
         """
-        Arguments:
+        Args:
             polygons:
                 a list of list of lists of numbers. The first
                 level of the list correspond to individual instances,
@@ -484,7 +484,7 @@ class SegmentationMask(object):
 
     def __init__(self, instances, size, mode="poly"):
         """
-        Arguments:
+        Args:
             instances: two types
                 (1) polygon
                 (2) binary mask

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -278,7 +278,7 @@ class GANLoss(nn.Module):
 def cal_gradient_penalty(netD, real_data, fake_data, device, type='mixed', constant=1.0, lambda_gp=10.0):
     """Calculate the gradient penalty loss, used in WGAN-GP paper https://arxiv.org/abs/1704.00028
 
-    Arguments:
+    Args:
         netD (network)              -- discriminator network
         real_data (tensor array)    -- real images
         fake_data (tensor array)    -- generated images from the generator

--- a/torchbenchmark/models/tacotron2/distributed.py
+++ b/torchbenchmark/models/tacotron2/distributed.py
@@ -9,7 +9,7 @@ def _flatten_dense_tensors(tensors):
     Since inputs are dense, the resulting tensor will be a concatenated 1D
     buffer. Element-wise operation on this buffer will be equivalent to
     operating individually.
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): dense tensors to flatten.
     Returns:
         A contiguous 1D buffer containing input tensors.
@@ -22,7 +22,7 @@ def _flatten_dense_tensors(tensors):
 def _unflatten_dense_tensors(flat, tensors):
     """View a flat buffer using the sizes of tensors. Assume that tensors are of
     same dense type, and that flat is given by _flatten_dense_tensors.
-    Arguments:
+    Args:
         flat (Tensor): flattened dense tensors to unflatten.
         tensors (Iterable[Tensor]): dense tensors whose sizes will be used to
           unflatten flat.

--- a/torchbenchmark/models/tacotron2/waveglow/distributed.py
+++ b/torchbenchmark/models/tacotron2/waveglow/distributed.py
@@ -58,7 +58,7 @@ def _flatten_dense_tensors(tensors):
     Since inputs are dense, the resulting tensor will be a concatenated 1D
     buffer. Element-wise operation on this buffer will be equivalent to
     operating individually.
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): dense tensors to flatten.
     Returns:
         A contiguous 1D buffer containing input tensors.
@@ -71,7 +71,7 @@ def _flatten_dense_tensors(tensors):
 def _unflatten_dense_tensors(flat, tensors):
     """View a flat buffer using the sizes of tensors. Assume that tensors are of
     same dense type, and that flat is given by _flatten_dense_tensors.
-    Arguments:
+    Args:
         flat (Tensor): flattened dense tensors to unflatten.
         tensors (Iterable[Tensor]): dense tensors whose sizes will be used to
           unflatten flat.

--- a/torchbenchmark/models/tacotron2/waveglow/tacotron2/distributed.py
+++ b/torchbenchmark/models/tacotron2/waveglow/tacotron2/distributed.py
@@ -8,7 +8,7 @@ def _flatten_dense_tensors(tensors):
     Since inputs are dense, the resulting tensor will be a concatenated 1D
     buffer. Element-wise operation on this buffer will be equivalent to
     operating individually.
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): dense tensors to flatten.
     Returns:
         A contiguous 1D buffer containing input tensors.
@@ -21,7 +21,7 @@ def _flatten_dense_tensors(tensors):
 def _unflatten_dense_tensors(flat, tensors):
     """View a flat buffer using the sizes of tensors. Assume that tensors are of
     same dense type, and that flat is given by _flatten_dense_tensors.
-    Arguments:
+    Args:
         flat (Tensor): flattened dense tensors to unflatten.
         tensors (Iterable[Tensor]): dense tensors whose sizes will be used to
           unflatten flat.

--- a/torchbenchmark/models/yolov3/yolo_utils/adabound.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/adabound.py
@@ -7,7 +7,7 @@ from torch.optim.optimizer import Optimizer
 class AdaBound(Optimizer):
     """Implements AdaBound algorithm.
     It has been proposed in `Adaptive Gradient Methods with Dynamic Bound of Learning Rate`_.
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): Adam learning rate (default: 1e-3)
@@ -50,7 +50,7 @@ class AdaBound(Optimizer):
 
     def step(self, closure=None):
         """Performs a single optimization step.
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """
@@ -122,7 +122,7 @@ class AdaBound(Optimizer):
 class AdaBoundW(Optimizer):
     """Implements AdaBound algorithm with Decoupled Weight Decay (arxiv.org/abs/1711.05101)
     It has been proposed in `Adaptive Gradient Methods with Dynamic Bound of Learning Rate`_.
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): Adam learning rate (default: 1e-3)
@@ -165,7 +165,7 @@ class AdaBoundW(Optimizer):
 
     def step(self, closure=None):
         """Performs a single optimization step.
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torchbenchmark/models/yolov3/yolo_utils/utils.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/utils.py
@@ -281,7 +281,7 @@ def box_iou(box1, box2):
     """
     Return intersection-over-union (Jaccard index) of boxes.
     Both sets of boxes are expected to be in (x1, y1, x2, y2) format.
-    Arguments:
+    Args:
         box1 (Tensor[N, 4])
         box2 (Tensor[M, 4])
     Returns:


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736