### PR TITLE
Misc requirements and debuggability fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,15 @@
 */**/*.pyc
 *.out*
 *.swp
+*.swo
 build/
 .ipynb_checkpoints/
+.idea
+old.json
+te.json
+Video_data_train_processed.csv
+labels.json
+results.png
+results.txt
+train_batch0.jpg
+checkpoints

--- a/README.md
+++ b/README.md
@@ -10,14 +10,25 @@ The benchmark suite should be self contained in terms of dependencies,
 except for the torch products which are intended to be installed separately so
 different torch versions can be benchmarked.
 
-Use python 3.7 as currently there are compatibility issues with 3.8+.  Conda is optional but suggested.
-`conda install -y python=3.7`
+Use python 3.7 as currently there are compatibility issues with 3.8+.  Conda is optional but suggested.  To switch to python 3.7 in conda:
+```
+# using your current conda enviroment:
+conda install -y python=3.7
+
+# or, using a new conda environment
+conda create -n torchbenchmark python=3.7
+conda activate torchbenchmark
+```
 
 Install pytorch, torchvision and torchtext
-`conda install -y pytorch torchtext torchvision -c pytorch-nightly`
+```
+conda install -y pytorch torchtext torchvision -c pytorch-nightly
+```
 
 Install the benchmark suite, which will recursively install dependencies for all the models
-`python install.py`
+```
+python install.py
+```
 
 
 ### Notes

--- a/compare.sh
+++ b/compare.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+rm -f old.json te.json
 pytest test_bench.py -k cuda-jit --fuser old --benchmark-json old.json
 pytest test_bench.py -k cuda-jit --fuser te --benchmark-json te.json
 python compare.py old.json te.json

--- a/scripts/recreate_conda_environment.sh
+++ b/scripts/recreate_conda_environment.sh
@@ -6,7 +6,7 @@ PYTHON_VERSION=${PYTHON_VERSION:-3.7}
 source $(conda info --base)/etc/profile.d/conda.sh
 
 # delete the old one if needed
-(conda info --envs | grep -q $NAME) && conda remove --name $NAME --all -y
+conda remove --name $NAME --all -y || true
 
 conda create -y -n $NAME python=$PYTHON_VERSION
 conda activate $NAME

--- a/scripts/recreate_conda_environment.sh
+++ b/scripts/recreate_conda_environment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+NAME=torchbenchmark
+PYTHON_VERSION=${PYTHON_VERSION:-3.7}
+
+source $(conda info --base)/etc/profile.d/conda.sh
+
+# delete the old one if needed
+(conda info --envs | grep -q $NAME) && conda remove --name $NAME --all -y
+
+conda create -y -n $NAME python=$PYTHON_VERSION
+conda activate $NAME
+conda install -y pytorch torchtext torchvision -c pytorch-nightly
+python install.py
+
+echo
+echo "To switch to the new environment, run:"
+echo "    conda activate $NAME"
+echo

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -25,10 +25,15 @@ def _test_https(test_url='https://github.com', timeout=0.5):
 
 def _install_deps(model_path):
     if os.path.exists(os.path.join(model_path, install_file)):
-        subprocess.check_call([sys.executable, install_file], cwd=model_path)
+        try:
+            subprocess.check_call([sys.executable, install_file], cwd=model_path)
+        except subprocess.CalledProcessError:
+            print(f"Error while running {model_path}/{install_file}")
+            sys.exit(-1)
     else:
         print('No install.py is found in {}.'.format(model_path))
         sys.exit(-1)
+
 
 def _list_model_paths():
     p = Path(__file__).parent.joinpath(model_dir)

--- a/torchbenchmark/models/demucs/requirements.txt
+++ b/torchbenchmark/models/demucs/requirements.txt
@@ -1,6 +1,6 @@
 torch
 ffmpeg-python==0.2.0
-scipy==1.3.1
+scipy>=1.3.1
 tqdm>=4.36.1
 lameenc==1.2.2
 musdb==0.3.1

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/utils/imports.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/utils/imports.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
+import six
 
-if torch._six.PY3:
+if six.PY3:
     import importlib
     import importlib.util
     import sys

--- a/torchbenchmark/models/maskrcnn_benchmark/requirements.txt
+++ b/torchbenchmark/models/maskrcnn_benchmark/requirements.txt
@@ -4,3 +4,4 @@ cython
 matplotlib
 tqdm
 opencv-python
+six

--- a/torchbenchmark/models/yolov3/requirements.txt
+++ b/torchbenchmark/models/yolov3/requirements.txt
@@ -1,7 +1,8 @@
 # pip install -U -r requirements.txt
 # pycocotools requires numpy 1.17 https://github.com/cocodataset/cocoapi/issues/356
-numpy == 1.17
-opencv-python >= 4.1
+numpy == 1.17.5
+# opencv-python 4.5 requires numpy 1.8
+opencv-python >= 4.1, < 4.5
 torch >= 1.5
 torchvision
 matplotlib


### PR DESCRIPTION
This is a collection of minor fixes and quality of life improvements I made while making the install script work for python 3.8 (some models still don't run in 3.8, but install now completes).

Tested with:
```
PYTHON_VERSION=3.8 ./scripts/recreate_conda_environment.sh
PYTHON_VERSION=3.7 ./scripts/recreate_conda_environment.sh
conda activate torchbenchmark
pytest test.py
./compare.sh
```