### PR TITLE
Switch BERT, pytorch_struct, and fastNLP to develop mode

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/install.py
+++ b/torchbenchmark/models/BERT_pytorch/install.py
@@ -3,7 +3,7 @@ import sys
 
 
 def setup_install():
-    subprocess.check_call([sys.executable, 'setup.py', 'install'])
+    subprocess.check_call([sys.executable, 'setup.py', 'develop'])
 
 if __name__ == '__main__':
     setup_install()

--- a/torchbenchmark/models/fastNLP/install.py
+++ b/torchbenchmark/models/fastNLP/install.py
@@ -10,7 +10,7 @@ def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'])
 
 def setup_install():
-    subprocess.check_call([sys.executable, 'setup.py', 'install'])
+    subprocess.check_call([sys.executable, 'setup.py', 'develop'])
 
 def generate_batch(batch):
     label = torch.tensor([entry[0] for entry in batch])

--- a/torchbenchmark/models/pytorch_struct/install.py
+++ b/torchbenchmark/models/pytorch_struct/install.py
@@ -3,7 +3,7 @@ import sys
 
 def setup_install():
   subprocess.check_call('pip install dgl wandb'.split(' '))
-  subprocess.check_call([sys.executable, 'setup.py', 'install'])
+  subprocess.check_call([sys.executable, 'setup.py', 'develop'])
 
 if __name__ == '__main__':
   setup_install()


### PR DESCRIPTION
I got hit by the "gotcha" where I was editing benchmark files and nothing was changing.  Turns out you need to re-run `install.py`to make changes visibile for these benchmarks because we install them into the conda environment.  Hopefully this fix saves someone else a headache.