### PR TITLE
Make benchmarks run quietly for inference

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -30,25 +30,20 @@ class Model:
         ]) # Avoid reading sys.argv here
         args.with_cuda = self.device == 'cuda'
         args.script = self.jit
-        print("Loading Vocab", args.vocab_path)
         vocab = WordVocab.load_vocab(args.vocab_path)
-        print("Vocab Size: ", len(vocab))
 
         train_dataset = BERTDataset(args.train_dataset, vocab, seq_len=args.seq_len,
                                     corpus_lines=args.corpus_lines, on_memory=args.on_memory)
         test_dataset = BERTDataset(args.test_dataset, vocab, seq_len=args.seq_len, on_memory=args.on_memory) \
             if args.test_dataset is not None else None
 
-        print("Creating Dataloader")
         train_data_loader = DataLoader(train_dataset, batch_size=args.batch_size, num_workers=args.num_workers)
         test_data_loader = DataLoader(test_dataset, batch_size=args.batch_size, num_workers=args.num_workers) \
             if test_dataset is not None else None
 
-        print("Building BERT model")
         bert = BERT(len(vocab), hidden=args.hidden, n_layers=args.layers, attn_heads=args.attn_heads)
 
         if args.script:
-            print("Scripting BERT model")
             bert = torch.jit.script(bert)
 
         self.trainer = BERTTrainer(bert, len(vocab), train_dataloader=train_data_loader, test_dataloader=test_data_loader,

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
@@ -3,6 +3,8 @@ import tqdm
 import torch
 import random
 
+QUIET = True
+
 
 class BERTDataset(Dataset):
     def __init__(self, corpus_path, vocab, seq_len, encoding="utf-8", corpus_lines=None, on_memory=True):
@@ -16,12 +18,12 @@ class BERTDataset(Dataset):
 
         with open(corpus_path, "r", encoding=encoding) as f:
             if self.corpus_lines is None and not on_memory:
-                for _ in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines):
+                for _ in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines, disable=QUIET):
                     self.corpus_lines += 1
 
             if on_memory:
                 self.lines = [line[:-1].split("\\t")
-                              for line in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines)]
+                              for line in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines, disable=QUIET)]
                 self.corpus_lines = len(self.lines)
 
         if not on_memory:

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/trainer/pretrain.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/trainer/pretrain.py
@@ -47,7 +47,6 @@ class BERTTrainer:
 
         # Distributed GPU training if CUDA can detect more than 1 GPU
         if with_cuda and torch.cuda.device_count() > 1:
-            print("Using %d GPUS for BERT" % torch.cuda.device_count())
             self.model = nn.DataParallel(self.model, device_ids=cuda_devices)
 
         # Setting the train and test data loader
@@ -63,8 +62,6 @@ class BERTTrainer:
 
         self.log_freq = log_freq
         self.debug = debug
-
-        print("Total Parameters:", sum([p.nelement() for p in self.model.parameters()]))
 
     def train(self, epoch):
         self.iteration(epoch, self.train_data)

--- a/torchbenchmark/models/fastNLP/fastNLP/doc_utils.py
+++ b/torchbenchmark/models/fastNLP/fastNLP/doc_utils.py
@@ -2,53 +2,6 @@ r"""undocumented
 用于辅助生成 fastNLP 文档的代码
 """
 
-__all__ = []
-
-import inspect
-import sys
-
 
 def doc_process(m):
-    for name, obj in inspect.getmembers(m):
-        if inspect.isclass(obj) or inspect.isfunction(obj):
-            if obj.__module__ != m.__name__:
-                if obj.__doc__ is None:
-                    # print(name, obj.__doc__)
-                    pass
-                else:
-                    module_name = obj.__module__
-                    
-                    # 识别并标注类和函数在不同层次中的位置
-                    
-                    while 1:
-                        defined_m = sys.modules[module_name]
-                        try:
-                            if "undocumented" not in defined_m.__doc__ and name in defined_m.__all__:
-                                obj.__doc__ = r"别名 :class:`" + m.__name__ + "." + name + "`" \
-                                              + " :class:`" + module_name + "." + name + "`\n" + obj.__doc__
-                                break
-                            module_name = ".".join(module_name.split('.')[:-1])
-                            if module_name == m.__name__:
-                                # print(name, ": not found defined doc.")
-                                break
-                        except:
-                            print("Warning: Module {} lacks `__doc__`".format(module_name))
-                            break
-
-                    # 识别并标注基类，只有基类也在 fastNLP 中定义才显示
-                    
-                    if inspect.isclass(obj):
-                        for base in obj.__bases__:
-                            if base.__module__.startswith("fastNLP"):
-                                parts = base.__module__.split(".") + []
-                                module_name, i = "fastNLP", 1
-                                for i in range(len(parts) - 1):
-                                    defined_m = sys.modules[module_name]
-                                    try:
-                                        if "undocumented" not in defined_m.__doc__ and name in defined_m.__all__:
-                                            obj.__doc__ = r"基类 :class:`" + defined_m.__name__ + "." + base.__name__ + "` \n\n" + obj.__doc__
-                                            break
-                                        module_name += "." + parts[i + 1]
-                                    except:
-                                        print("Warning: Module {} lacks `__doc__`".format(module_name))
-                                        break
+    return  # no need to check docs for a benchmark

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -1,11 +1,5 @@
 from argparse import Namespace
-import math
-import time
-from tqdm import tqdm
-
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 from .meta import Meta
 
 

--- a/torchbenchmark/models/maskrcnn_benchmark/__init__.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/__init__.py
@@ -14,6 +14,7 @@ from .maskrcnn_benchmark.data import make_data_loader
 from .maskrcnn_benchmark.solver import make_lr_scheduler
 from .maskrcnn_benchmark.solver import make_optimizer
 from .maskrcnn_benchmark.utils.miscellaneous import mkdir, save_config
+import pycocotools.coco
 
 # See if we can use apex.DistributedDataParallel instead of the torch default,
 # and enable mixed-precision via apex.amp
@@ -37,6 +38,9 @@ torch.backends.cudnn.benchmark = False
 dirname = os.path.dirname(__file__)
 config_filename = os.path.join(dirname, 'configs/e2e_mask_rcnn_R_50_FPN_1x.yaml')
 
+# COCO is spammy
+pycocotools.coco.print = lambda *args: None
+
 
 class Model:
     def __init__(self, device='cpu', jit=False):
@@ -55,7 +59,8 @@ class Model:
                              'SOLVER.MAX_ITER', '720000', 
                              'SOLVER.STEPS', '(480000, 640000)', 
                              'TEST.IMS_PER_BATCH', '1', 
-                             'MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN', '2000'])
+                             'MODEL.RPN.FPN_POST_NMS_TOP_N_TRAIN', '2000',
+                             'OUTPUT_DIR', dirname])
 
         cfg.freeze()
         self.module = build_detection_model(cfg)

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
@@ -127,7 +127,7 @@ def make_data_loader(cfg, is_train=True, is_distributed=False, start_iter=0, is_
         num_iters = None
         start_iter = 0
 
-    if images_per_gpu > 1:
+    if images_per_gpu > 2:
         logger = logging.getLogger(__name__)
         logger.warning(
             "When using more than one image per GPU you may encounter "

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/data/build.py
@@ -127,19 +127,6 @@ def make_data_loader(cfg, is_train=True, is_distributed=False, start_iter=0, is_
         num_iters = None
         start_iter = 0
 
-    if images_per_gpu > 2:
-        logger = logging.getLogger(__name__)
-        logger.warning(
-            "When using more than one image per GPU you may encounter "
-            "an out-of-memory (OOM) error if your GPU does not have "
-            "sufficient memory. If this happens, you can reduce "
-            "SOLVER.IMS_PER_BATCH (for training) or "
-            "TEST.IMS_PER_BATCH (for inference). For training, you must "
-            "also adjust the learning rate and schedule length according "
-            "to the linear scaling rule. See for example: "
-            "https://github.com/facebookresearch/Detectron/blob/master/configs/getting_started/tutorial_1gpu_e2e_faster_rcnn_R-50-FPN.yaml#L14"
-        )
-
     # group images which have similar aspect ratio. In this case, we only
     # group in two cases: those with width / height > 1, and the other way around,
     # but the code supports more general grouping strategy

--- a/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/utils/miscellaneous.py
+++ b/torchbenchmark/models/maskrcnn_benchmark/maskrcnn_benchmark/utils/miscellaneous.py
@@ -28,7 +28,6 @@ def save_labels(dataset_list, output_dir):
 
         if ids_to_labels:
             labels_file = os.path.join(output_dir, 'labels.json')
-            logger.info("Saving labels mapping into {}".format(labels_file))
             with open(labels_file, 'w') as f:
                 json.dump(ids_to_labels, f, indent=2)
 

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from argparse import Namespace
-import builtins
-import math
-import os
 import random
-import shutil
-import time
-import warnings
 
 import torch
 import torch.nn as nn
@@ -15,11 +9,8 @@ import torch.nn.parallel
 import torch.backends.cudnn as cudnn
 import torch.distributed as dist
 import torch.optim
-import torch.multiprocessing as mp
 import torch.utils.data
 import torch.utils.data.distributed
-import torchvision.transforms as transforms
-import torchvision.datasets as datasets
 import torchvision.models as models
 
 from .moco.builder import MoCo

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/data/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/data/__init__.py
@@ -71,7 +71,6 @@ class CustomDatasetDataLoader():
         self.opt = opt
         dataset_class = find_dataset_using_name(opt.dataset_mode)
         self.dataset = dataset_class(opt)
-        print("dataset [%s] was created" % type(self.dataset).__name__)
         self.dataloader = torch.utils.data.DataLoader(
             self.dataset,
             batch_size=opt.batch_size,

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/__init__.py
@@ -62,7 +62,5 @@ def create_model(opt):
         >>> model = create_model(opt)
     """
     model = find_model_using_name(opt.model)
-    print(model)
     instance = model(opt)
-    print("model [%s] was created" % type(instance).__name__)
     return instance

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -86,7 +86,6 @@ class BaseModel(ABC):
         if not self.isTrain or opt.continue_train:
             load_suffix = 'iter_%d' % opt.load_iter if opt.load_iter > 0 else opt.epoch
             self.load_networks(load_suffix)
-        self.print_networks(opt.verbose)
 
     def eval(self):
         """Make models eval mode during test time"""
@@ -122,7 +121,6 @@ class BaseModel(ABC):
                 scheduler.step()
 
         lr = self.optimizers[0].param_groups[0]['lr']
-        print('learning rate = %.7f' % lr)
 
     def get_current_visuals(self):
         """Return visualization images. train.py will display these images with visdom, and save the images to a HTML"""
@@ -177,14 +175,12 @@ class BaseModel(ABC):
             epoch (int) -- current epoch; used in the file name '%s_net_%s.pth' % (epoch, name)
         """
         for name in self.model_names:
-            print("NNNNN", name)
             if isinstance(name, str):
                 load_filename = '%s_net_%s.pth' % (epoch, name)
                 load_path = os.path.join(self.save_dir, load_filename)
                 net = getattr(self, 'net' + name)
                 if isinstance(net, torch.nn.DataParallel):
                     net = net.module
-                print('loading the model from %s' % load_path)
                 # if you are using PyTorch newer than 0.4 (e.g., built from
                 # GitHub source), you can remove str() on self.device
                 state_dict = torch.load(load_path, map_location=str(self.device))

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -94,7 +94,6 @@ def init_weights(net, init_type='normal', init_gain=0.02):
             init.normal_(m.weight.data, 1.0, init_gain)
             init.constant_(m.bias.data, 0.0)
 
-    print('initialize network with %s' % init_type)
     net.apply(init_func)  # apply the initialization function <init_func>
 
 

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -120,8 +120,6 @@ class BaseOptions():
             suffix = ('_' + opt.suffix.format(**vars(opt))) if opt.suffix != '' else ''
             opt.name = opt.name + suffix
 
-        self.print_options(opt)
-
         # set gpu ids
         str_ids = opt.gpu_ids.split(',')
         opt.gpu_ids = []

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/train_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/train_cyclegan.py
@@ -28,7 +28,6 @@ def prepare_training_loop(args):
     opt = TrainOptions().parse(args)   # get training options
     dataset = create_dataset(opt)  # create a dataset given opt.dataset_mode and other options
     dataset_size = len(dataset)    # get the number of images in the dataset.
-    print('The number of training images = %d' % dataset_size)
 
     model = create_model(opt)      # create a model given opt.model and other options
     model.setup(opt)               # regular setup: load and print networks; create schedulers
@@ -67,12 +66,10 @@ def prepare_training_loop(args):
                         visualizer.plot_current_losses(epoch, float(epoch_iter) / dataset_size, losses)
 
                 if total_iters % opt.save_latest_freq == 0:   # cache our latest model every <save_latest_freq> iterations
-                    print('saving the latest model (epoch %d, total_iters %d)' % (epoch, total_iters))
                     save_suffix = 'iter_%d' % total_iters if opt.save_by_iter else 'latest'
                     model.save_networks(save_suffix)
 
                 iter_data_time = time.time()
             
-            print('End of epoch %d / %d \t Time Taken: %d sec' % (epoch, opt.n_epochs + opt.n_epochs_decay, time.time() - epoch_start_time))
             model.update_learning_rate()                     # update learning rates at the end of every epoch.
     return training_loop

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/util/visualizer.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/util/visualizer.py
@@ -76,7 +76,6 @@ class Visualizer():
         if self.use_html:  # create an HTML object at <checkpoints_dir>/web/; images will be saved under <checkpoints_dir>/web/images/
             self.web_dir = os.path.join(opt.checkpoints_dir, opt.name, 'web')
             self.img_dir = os.path.join(self.web_dir, 'images')
-            print('create web directory %s...' % self.web_dir)
             util.mkdirs([self.web_dir, self.img_dir])
         # create a logging file to store training losses
         self.log_name = os.path.join(opt.checkpoints_dir, opt.name, 'loss_log.txt')

--- a/torchbenchmark/models/pytorch_stargan/data_loader.py
+++ b/torchbenchmark/models/pytorch_stargan/data_loader.py
@@ -54,8 +54,6 @@ class CelebA(data.Dataset):
             else:
                 self.train_dataset.append([filename, label])
 
-        print('Finished preprocessing the CelebA dataset...')
-
     def __getitem__(self, index):
         """Return one image and its corresponding attribute label."""
         dataset = self.train_dataset if self.mode == 'train' else self.test_dataset

--- a/torchbenchmark/models/pytorch_stargan/solver.py
+++ b/torchbenchmark/models/pytorch_stargan/solver.py
@@ -84,8 +84,6 @@ class Solver(object):
 
         self.g_optimizer = torch.optim.Adam(self.G.parameters(), self.g_lr, [self.beta1, self.beta2])
         self.d_optimizer = torch.optim.Adam(self.D.parameters(), self.d_lr, [self.beta1, self.beta2])
-        self.print_network(self.G, 'G')
-        self.print_network(self.D, 'D')
 
         self.G.to(self.device)
         self.D.to(self.device)

--- a/torchbenchmark/models/pytorch_struct/torch_struct/networks/TreeLSTM.py
+++ b/torchbenchmark/models/pytorch_struct/torch_struct/networks/TreeLSTM.py
@@ -2,8 +2,13 @@
 import torch
 import torch as th
 import torch.nn as nn
-import dgl
 from torch_struct import CKY
+from unittest.mock import patch
+from io import StringIO
+
+with patch("sys.stderr", StringIO()):
+    # importing dgl is spammy
+    import dgl
 
 
 class TreeLSTMCell(nn.Module):


### PR DESCRIPTION
I was running some tests on benchmarks and was bombarded by pages and pages of printouts which made it hard to see the data I wanted.   This PR removes all those printouts (at least for inference). 

The following now prints nothing:
```
for benchmark_cls in list_models():
    for device in ("cpu", "cuda"):
        try:
            benchmark = benchmark_cls(device=device)
            model, example_inputs = benchmark.get_module()
            model(*example_inputs)
        except NotImplementedError:
            pass
```