### PR TITLE
Setting eval mode in mobilenetv3

### DIFF
--- a/torchbenchmark/models/pytorch_mobilenet_v3/__init__.py
+++ b/torchbenchmark/models/pytorch_mobilenet_v3/__init__.py
@@ -29,6 +29,7 @@ class Model:
 
     def eval(self, niter=1):
         model, example_inputs = self.get_module()
+        model.eval()
         for i in range(niter):
             model(*example_inputs)
 


### PR DESCRIPTION
MobilenetV3 model eval was being done without setting the eval mode in the module. This resulted in `batch_norm` ops taking the slow path. 

Setting eval mode appropriately results in `batch_norm` ops taking the fast path and improves the cpu eval performance of this model by ~45% (39.92ms to 22ms).

Before:
Name (time in ms)                               Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
test_eval[pytorch_mobilenet_v3-cpu-jit]     38.7610  42.3089  **39.9172**  0.8119  39.7518  0.9908       6;1  25.0519      25           1

After:
Name (time in ms)                               Min      Max     Mean  StdDev   Median     IQR  Outliers      OPS  Rounds  Iterations
test_eval[pytorch_mobilenet_v3-cpu-jit]     21.5358  22.4913  **22.0004**  0.2120  21.9547  0.3226      15;0  45.4537      43           1

Profile data:
Before this change, `batch_norm` op was taking **40.12%** of the total CPU time.
After this change, `batch_norm` op only takes **7.38%** of the total CPU time.