### PR TITLE
Normalize demucs/maml behavior when using get_module

### DIFF
--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -55,7 +55,7 @@ class Model:
             sources = streams[:, 1:]
             sources = self.augment(sources)
             mix = sources.sum(dim=1)
-            estimates = self.model(mix)
+            return self.model(mix)
         return helper, self.example_inputs
 
     def eval(self, niter=1):

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -1,10 +1,9 @@
-from argparse import Namespace
-import torch
-from .meta import Meta
-
-
-import random
 import numpy as np
+import random
+import time
+import torch
+from argparse import Namespace
+from .meta import Meta
 from pathlib import Path
 
 torch.manual_seed(1337)
@@ -12,6 +11,7 @@ random.seed(1337)
 np.random.seed(1337)
 torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
+
 
 class Model:
     def __init__(self, device='cpu', jit=False):
@@ -50,10 +50,10 @@ class Model:
         self.example_inputs = torch.load(f'{root}/batch.pt')
         self.example_inputs = tuple([torch.from_numpy(i).to(self.device) for i in self.example_inputs])
 
-        
     def get_module(self):
         if self.jit:
             raise NotImplementedError()
+        self.module.eval()
         return self.module, self.example_inputs
 
     def eval(self, niter=1):
@@ -61,7 +61,7 @@ class Model:
             raise NotImplementedError()
         self.module.eval()
         for _ in range(niter):
-            self.module.finetunning(*[i[0] for i in self.example_inputs])
+            self.module(*self.example_inputs)
 
     def train(self, niter=1):
         if self.jit:
@@ -69,13 +69,12 @@ class Model:
         self.module.train()
         for _ in range(niter):
             self.module(*self.example_inputs)
-        
+
 
 if __name__ == '__main__':
     m = Model(device='cpu', jit=False)
     module, example_inputs = m.get_module()
     module(*example_inputs)
-    import time
     begin = time.time()
     m.train(niter=1)
     print(time.time() - begin)

--- a/torchbenchmark/models/maml/meta.py
+++ b/torchbenchmark/models/maml/meta.py
@@ -61,8 +61,13 @@ class Meta(nn.Module):
 
         return total_norm/counter
 
-
     def forward(self, x_spt, y_spt, x_qry, y_qry):
+        if self.training:
+            return self.forward_train(x_spt, y_spt, x_qry, y_qry)
+        else:
+            return self.finetunning(x_spt[0], y_spt[0], x_qry[0], y_qry[0])
+
+    def forward_train(self, x_spt, y_spt, x_qry, y_qry):
         """
 
         :param x_spt:   [b, setsz, c_, h, w]
@@ -142,7 +147,7 @@ class Meta(nn.Module):
         self.meta_optim.step()
 
 
-        accs = np.array(corrects) / (querysz * task_num)
+        accs = torch.tensor(corrects) / (querysz * task_num)
 
         return accs
 
@@ -213,7 +218,7 @@ class Meta(nn.Module):
 
         del net
 
-        accs = np.array(corrects) / querysz
+        accs = torch.tensor(corrects) / querysz
 
         return accs
 


### PR DESCRIPTION
I am doing some tests where I iterate over benchmarks and do some automated changes and output correctness checking.  This is a minor change to normalize the behavior of these two benchmarks.

First I make them return a `Tensor()` (to make checking outputs easier).  Before they returned `None`/`np.ndarray`.

Second I make the following do inference (for maml it actually did training):
```
module, example_inputs = benchmark.get_module()
module.eval()(*example_inputs)
```
