### PR TITLE
Fix CI schedule time to benchmark the latest nightly.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: pytorch-nightly-benchmarking-v0.1
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * *' # run at 8 AM UTC
+    - cron: '0 13 * * *' # run at 1 PM UTC
 
 jobs:
   build-benchmark-docker:


### PR DESCRIPTION
Currently the nightly CI schedules before the latest nightly releases.
Moving the testing time from 8 AM to 1 PM UTC should fix this problem.