### PR TITLE
Clean up UI for pytest machine config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,8 +26,11 @@ def set_fuser(fuser):
         torch._C._jit_set_texpr_fuser_enabled(True)
 
 def pytest_sessionstart(session):
-    if not session.config.getoption('ignore_machine_config'):
+    try:
         check_machine_configured()
+    except AssertionError as e:
+        if not session.config.getoption('ignore_machine_config'):
+            pytest.exit(f"{e}\nUse --ignore_machine_config arg if not running with recommended tuning settings")
 
 def pytest_configure(config):
     set_fuser(config.getoption("fuser"))

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def set_fuser(fuser):
 def pytest_sessionstart(session):
     try:
         check_machine_configured()
-    except AssertionError as e:
+    except Exception as e:
         if not session.config.getoption('ignore_machine_config'):
             pytest.exit(f"{e}\nUse --ignore_machine_config arg if not running with recommended tuning settings")
 


### PR DESCRIPTION
- when exiting due to assertion, make the message more focused by
  avoiding pytests INTERNALERROR wrapper and whole stacktrace
- also add suggestion of available --ignore_machine_config override