### PR TITLE
Remove score.yml and generate default spec

### DIFF
--- a/compute_score.py
+++ b/compute_score.py
@@ -9,9 +9,11 @@ import sys
 import os
 import yaml
 
-from torchbenchmark.score.compute_score import compute_score
+from torchbenchmark.score.compute_score import compute_score, generate_spec
 from torchbenchmark.score.generate_score_config import generate_bench_cfg
 from tabulate import tabulate
+
+TARGET_SCORE_DEFAULT = 1000
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
@@ -32,8 +34,8 @@ if __name__ == "__main__":
         if args.benchmark_data_file is None and args.benchmark_data_dir is None:
             parser.print_help(sys.stderr)
             raise ValueError("Invalid command-line arguments. You must specify a config, a data file, or a data dir.")
-        with open(SPEC_FILE_DEFAULT) as spec_file:
-            spec = yaml.full_load(spec_file)
+        # Generate the default spec
+        spec = generate_spec()
 
     if args.benchmark_data_file is not None:
         with open(args.benchmark_data_file) as data_file:

--- a/scripts/dump_bench.py
+++ b/scripts/dump_bench.py
@@ -1,0 +1,43 @@
+"""
+Dump the contents of a pytest benchmark .json file.
+"""
+import argparse
+import json
+from tabulate import tabulate
+
+def print_benchmark_stats(data):
+    print_stats = ['min', 'max', 'mean', 'stddev', 'rounds', 'median']
+    headers = ['name'] + print_stats 
+    rows = []
+    for benchmark in data['benchmarks']:
+        row = [benchmark['name']]
+        row += [benchmark['stats'][k] for k in print_stats]
+        rows.append(row)
+    print(tabulate(rows, headers=headers))
+    print()
+
+def print_kv_table(table_name, data):
+    headers = [table_name, '']
+    rows = [(k, data[k]) for k in data]
+    print(tabulate(rows, headers=headers))
+    print()
+
+def print_other_info(data):
+    print_kv_table('Machine Info',  data['machine_info'])
+    print_kv_table('Commit Info',  data['commit_info'])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_file")
+    parser.add_argument("--table", default="benchmarks",
+                        choices=['benchmarks', 'other'],
+                        help="which section of the json file to tablify")
+    args = parser.parse_args()
+
+    with open(args.json_file) as f:
+        data = json.load(f)
+
+    if args.table == 'benchmarks':
+        print_benchmark_stats(data)
+    elif args.table == 'other':
+        print_other_info(data)

--- a/torchbenchmark/score/compute_score.py
+++ b/torchbenchmark/score/compute_score.py
@@ -9,10 +9,42 @@ import sys
 import os
 import yaml
 
+from collections import defaultdict
 from tabulate import tabulate
+from torchbenchmark import list_models
 
-SPEC_FILE_DEFAULT = "score.yml"
-TARGET_SCORE_DEFAULT = 1000
+def generate_spec():
+    """
+    Helper function which constructs the spec dictionary by iterating
+    over the existing models. This API is used for generating the
+    default spec hierarchy configuration.
+    return type:
+        Returns a dictionary of type collections.defaultdict. Defaultdict
+        handles `None` or missing values and hence, no explicit `None` check
+        is required.
+    Arguments: `None`
+    Note: Only those models available inside the required_models list are
+          used to construct the default spec hierarchy.
+    """
+    spec = {'hierarchy':{'model':defaultdict(dict)}}
+    # These are the models required to generate the default spec.
+    # Please update this list if any new model needs to be a part of
+    # the default spec configuration. Before you update, please consult
+    # with someone in the benchmark team.
+    required_models = ['pytorch_mobilenet_v3', 'yolov3', 'attention_is_all_you_need_pytorch', \
+                       'BERT_pytorch', 'fastNLP', 'dlrm', 'LearningToPaint', 'moco', 'demucs', \
+                       'pytorch_struct']
+
+    for model in list_models():
+        if model.name in required_models and hasattr(model, 'domain'):
+            if not spec['hierarchy']['model'][model.domain]:
+                spec['hierarchy']['model'][model.domain] = defaultdict(dict)
+            if not spec['hierarchy']['model'][model.domain][model.task]:
+                spec['hierarchy']['model'][model.domain][model.task] = defaultdict(dict)
+            spec['hierarchy']['model'][model.domain][model.task][model.name] = None
+
+    assert len(spec) == 0, f"Spec is empty. Make sure to use models only in the required list."
+    return spec
 
 def compute_score(config, data, fake_data=None):
     target = config['target']
@@ -35,4 +67,3 @@ def compute_score(config, data, fake_data=None):
     score = target * math.exp(score)
     assert abs(weight_sum - 1.0) < 1e-6, f"Bad configuration, weights don't sum to 1, but {weight_sum}"
     return score
-

--- a/torchbenchmark/score/compute_score.py
+++ b/torchbenchmark/score/compute_score.py
@@ -13,11 +13,6 @@ from collections import defaultdict
 from tabulate import tabulate
 from torchbenchmark import list_models
 
-<<<<<<< HEAD
-=======
-#SPEC_FILE_DEFAULT = "score.yml"
-
->>>>>>> fa9c3b67367e2cabd3f45ef767b1f10fa8169e93
 def generate_spec():
     """
     Helper function which constructs the spec dictionary by iterating
@@ -28,23 +23,14 @@ def generate_spec():
         handles `None` or missing values and hence, no explicit `None` check
         is required.
     Arguments: `None`
-<<<<<<< HEAD
     Note: Only those models available inside the required_models list are
           used to construct the default spec hierarchy.
-=======
-    Note: Only those models with `domain` and `task` class attributes are
-          used to construct the spec hierarchy.
->>>>>>> fa9c3b67367e2cabd3f45ef767b1f10fa8169e93
     """
     spec = {'hierarchy':{'model':defaultdict(dict)}}
     # These are the models required to generate the default spec.
     # Please update this list if any new model needs to be a part of
-<<<<<<< HEAD
     # the default spec configuration. Before you update, please consult
     # with someone in the benchmark team.
-=======
-    # the default spec configuration.
->>>>>>> fa9c3b67367e2cabd3f45ef767b1f10fa8169e93
     required_models = ['pytorch_mobilenet_v3', 'yolov3', 'attention_is_all_you_need_pytorch', \
                        'BERT_pytorch', 'fastNLP', 'dlrm', 'LearningToPaint', 'moco', 'demucs', \
                        'pytorch_struct']


### PR DESCRIPTION
Fixes issue: #209

This PR depends on #208

Summary:
========
- Creates an explicit list of enabled (required) models which are used for the score and default spec
- Removes score.yml and uses a helper function to generate the default spec