### PR TITLE
Lock spacy version

### DIFF
--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
@@ -1,4 +1,4 @@
 dill
 tqdm
 numpy
-spacy
+spacy==2.3.5


### PR DESCRIPTION
Spacy 3 deprecated short names (e.g. `en`, `de`) for trained embeddings, lock spacy version for now until attention-all-you-need is updated