### PR TITLE
Fix a bbrk due to a left-over call in `conftest.py`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,6 @@ def set_fuser(fuser):
 
 def pytest_sessionstart(session):
     try:
-        check_environment()
         check_machine_configured()
     except Exception as e:
         if not session.config.getoption('ignore_machine_config'):


### PR DESCRIPTION
Remove a call to `check_environment` in `conftest.py`