### PR TITLE
Make test and install scripts handling the failure caused by maskrcnn

### DIFF
--- a/install.py
+++ b/install.py
@@ -31,4 +31,7 @@ if __name__ == '__main__':
             sys.exit(-1)
     success &= setup(verbose=args.verbose, continue_on_fail=args.continue_on_fail)
     if not success:
-        raise RuntimeError("Failed to complete setup")
+        if args.continue_on_fail:
+            print("Warning: some benchmarks were not installed due to failure")
+        else:
+            raise RuntimeError("Failed to complete setup")

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -87,6 +87,9 @@ def list_models():
     for model_path in _list_model_paths():
         model_name = os.path.basename(model_path)
         module = importlib.import_module(f'.models.{model_name}', package=__name__)
+        if not hasattr(module, 'Model'):
+            print(f"Warning: {module} does not define attribute Model, skip it")
+            continue
         Model = getattr(module, 'Model')
         if not hasattr(Model, 'name'):
             Model.name = model_name


### PR DESCRIPTION
Make test and install scripts handling the failure caused by maskrcnn benchmark more gracefully (i.e., not abort the entire test or installation process