### PR TITLE
Fix the conda deactivation bug in instruction count ci script and enable conda in run-benchmark.sh

### DIFF
--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -8,8 +8,7 @@ source ${BASEDIR}/config.env
 set +a;
 
 conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
-. activate ${CONDA_ENV_NAME}
-conda init bash; conda run /bin/bash
+conda activate ${CONDA_ENV_NAME}
 
 # Install PyTorch nightly from pip
 pip install --pre torch \

--- a/.github/scripts/instr-count-benchmark/remove-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/remove-nightly-env.sh
@@ -7,5 +7,4 @@ set -a;
 source ${BASEDIR}/config.env
 set +a;
 
-conda deactivate
 conda env remove --name ${CONDA_ENV_NAME}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -1,1 +1,15 @@
 #!/bin/sh
+
+set -xueo pipefail
+
+BASEDIR=$(dirname $0)
+set -a;
+source ${BASEDIR}/config.env
+set +a;
+
+conda activate ${CONDA_ENV_NAME}
+PYTORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
+PYTORCH_GIT_VERSION=$(python -c "import torch; print(torch.version.git_version)" | head -c 7)
+echo "Running instruction benchmark for pytorch-${PYTORCH_VERSION}, commit SHA: ${PYTORCH_GIT_VERSION}"
+
+# Run the instruction count benchmark

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -4,27 +4,19 @@ on:
   schedule:
     - cron: '0 14 * * *' # run at 2 PM UTC
 jobs:
-  checkout:
+  run-benchmark:
     runs-on: [self-hosted, bm-metal]
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out
+        uses: actions/checkout@v2
         with:
           ref: master
-  create-nightly-env:
-    needs: checkout
-    runs-on: [self-hosted, bm-metal]
-    steps:
-      - run: |
+      - name: Create Conda nightly env
+        run: |
           bash .github/scripts/instr-count-benchmark/create-nightly-env.sh
-  run-benchmark:
-    needs: create-nightly-env
-    runs-on: [self-hosted, bm-metal]
-    steps:
-      - run: |
+      - name: Run benchmark
+        run: |
           bash .github/scripts/instr-count-benchmark/run-benchmark.sh
-  remove-nightly-env:
-    needs: run-benchmark
-    runs-on: [self-hosted, bm-metal]
-    steps:
-      - run: |
+      - name: Clean up environment
+        run: |
           bash .github/scripts/instr-count-benchmark/remove-nightly-env.sh


### PR DESCRIPTION
- Improves the instruction benchmark CI to use steps not jobs
- Fix a bug of `conda deactivate` in environment cleanup.