### PR TITLE
Use `parse_lscpu_cpu_core_list` to get active cpus

### DIFF
--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -213,8 +213,7 @@ def get_pstate_frequency():
 
     if hyper_threading_enabled():
         return None
-    active_cpus = parse_lscpu_cpu_core_list()
-    cpu_dirs = ["cpu" + f for f in active_cpus]
+    cpus_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2])
     output = dict()
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
@@ -234,9 +233,8 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
 
     if hyper_threading_enabled():
         print(f"Must disable hyperthreading before setting CPU frequency.")
-        return None
-    active_cpus = parse_lscpu_cpu_core_list()
-    cpu_dirs = ["cpu" + f for f in active_cpus]
+        return
+    cpus_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2])
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
         freq_paths = [os.path.join(full_path, x) for x in CPU_FREQ_FILES]
@@ -329,6 +327,7 @@ if __name__ == "__main__":
         assert 1 == get_intel_max_cstate(), "Intel max C-State isn't set to 1, which avoids power-saving modes."
         assert len(get_isolated_cpus()) > 0, "No cpus are isolated for benchmarking with isolcpus"
         assert 900 == get_nvidia_gpu_clocks()[0], "Nvidia gpu clock isn't limited, to increase consistency by reducing throttling"
+        assert check_pstate_frequency_pin(), "CPU frequency is not correctly pinned, which is required to minimize noise."
         # doesn't make too much sense to ask the user to run this configure script with the isolated cpu cores
         # that check is more important to be done at runtime of benchmark, and is checked by conftest.py
         #assert is_using_isolated_cpus(), "Not using isolated CPUs for this process"

--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -210,7 +210,11 @@ def get_omp_affinity():
 def get_pstate_frequency():
     CPU_FREQ_BASE_DIR = '/sys/devices/system/cpu'
     CPU_FREQ_FILES = ["scaling_min_freq", "scaling_max_freq", "scaling_cur_freq"]
-    cpu_dirs = [f for f in os.listdir(CPU_FREQ_BASE_DIR) if re.match(r'cpu[0-9]+', f)]
+
+    if hyper_threading_enabled():
+        return None
+    active_cpus = parse_lscpu_cpu_core_list()
+    cpu_dirs = ["cpu" + f for f in active_cpus]
     output = dict()
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
@@ -227,7 +231,12 @@ def get_pstate_frequency():
 def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
     CPU_FREQ_BASE_DIR = '/sys/devices/system/cpu'
     CPU_FREQ_FILES = ["scaling_min_freq", "scaling_max_freq", "scaling_cur_freq"]
-    cpu_dirs = [f for f in os.listdir(CPU_FREQ_BASE_DIR) if re.match(r'cpu[0-9]+', f)]
+
+    if hyper_threading_enabled():
+        print(f"Must disable hyperthreading before setting CPU frequency.")
+        return None
+    active_cpus = parse_lscpu_cpu_core_list()
+    cpu_dirs = ["cpu" + f for f in active_cpus]
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
         freq_paths = [os.path.join(full_path, x) for x in CPU_FREQ_FILES]
@@ -241,6 +250,9 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
 def check_pstate_frequency_pin(pin_freq = 2500):
     FREQ_THRESHOLD = 10  # Allow 10 MHz difference maximum
     all_freq = get_pstate_frequency()
+    if all_freq is None:
+        print(f"Failed to get CPU frequency from pstate driver. Must disable hyper-threading first.")
+        return False
     for cpuid in all_freq:
         for attr in all_freq[cpuid]:
             freq = all_freq[cpuid][attr]
@@ -309,6 +321,7 @@ if __name__ == "__main__":
         set_intel_no_turbo_state(1)
         set_hyper_threading(False)
         set_nvidia_graphics_clock()
+        set_pstate_frequency()
 
     if not args.no_verify:
         assert 1 == check_intel_no_turbo_state(), "Turbo Boost is not disabled"

--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -210,9 +210,6 @@ def get_omp_affinity():
 def get_pstate_frequency():
     CPU_FREQ_BASE_DIR = '/sys/devices/system/cpu'
     CPU_FREQ_FILES = ["scaling_min_freq", "scaling_max_freq", "scaling_cur_freq"]
-
-    if hyper_threading_enabled():
-        return None
     cpu_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2]]
     output = dict()
     for cpu_dir in cpu_dirs:
@@ -230,10 +227,6 @@ def get_pstate_frequency():
 def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
     CPU_FREQ_BASE_DIR = '/sys/devices/system/cpu'
     CPU_FREQ_FILES = ["scaling_min_freq", "scaling_max_freq", "scaling_cur_freq"]
-
-    if hyper_threading_enabled():
-        print(f"Must disable hyperthreading before setting CPU frequency.")
-        return
     cpu_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2]]
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
@@ -248,9 +241,6 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
 def check_pstate_frequency_pin(pin_freq = 2500):
     FREQ_THRESHOLD = 10  # Allow 10 MHz difference maximum
     all_freq = get_pstate_frequency()
-    if all_freq is None:
-        print(f"Failed to get CPU frequency from pstate driver. Must disable hyper-threading first.")
-        return False
     for cpuid in all_freq:
         for attr in all_freq[cpuid]:
             freq = all_freq[cpuid][attr]

--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -263,6 +263,7 @@ def get_machine_config():
         config['isolated_cpus'] = get_isolated_cpus()
         config['process_cpu_affinity'] = get_process_cpu_affinity()
         config['is_using_isolated_cpus'] = is_using_isolated_cpus()
+        config['cpu_pstate_frequency'] = get_pstate_frequency()
     return config
 
 def check_machine_configured(check_process_affinity=True):

--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -213,7 +213,7 @@ def get_pstate_frequency():
 
     if hyper_threading_enabled():
         return None
-    cpus_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2])
+    cpu_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2]]
     output = dict()
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
@@ -234,7 +234,7 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
     if hyper_threading_enabled():
         print(f"Must disable hyperthreading before setting CPU frequency.")
         return
-    cpus_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2])
+    cpu_dirs = ["cpu" + str(cpu[0]) for cpu in parse_lscpu_cpu_core_list() if cpu[2]]
     for cpu_dir in cpu_dirs:
         full_path = os.path.join(CPU_FREQ_BASE_DIR, cpu_dir, "cpufreq")
         freq_paths = [os.path.join(full_path, x) for x in CPU_FREQ_FILES]


### PR DESCRIPTION
Also, check hyper-threading status is disabled before getting/setting pstate frequencies, and enable pstate frequency setup when running with ``--configure`` option.