### PR TITLE
Fix instruction ci failure and improve v0.1 ci scripts

### DIFF
--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -8,7 +8,7 @@ source ${BASEDIR}/config.env
 set +a;
 
 conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
-conda activate ${CONDA_ENV_NAME}
+. activate ${CONDA_ENV_NAME}
 
 # Install PyTorch nightly from pip
 pip install --pre torch \

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -7,7 +7,7 @@ set -a;
 source ${BASEDIR}/config.env
 set +a;
 
-conda activate ${CONDA_ENV_NAME}
+. activate ${CONDA_ENV_NAME}
 PYTORCH_VERSION=$(python -c "import torch; print(torch.__version__)")
 PYTORCH_GIT_VERSION=$(python -c "import torch; print(torch.version.git_version)" | head -c 7)
 echo "Running instruction benchmark for pytorch-${PYTORCH_VERSION}, commit SHA: ${PYTORCH_GIT_VERSION}"

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -1,4 +1,4 @@
-name: Instruction Count Nightly Testing
+name: Instruction count nightly
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 14 * * *' # run at 2 PM UTC
 jobs:
   run-benchmark:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-metal]
     steps:
       - name: Check out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,20 @@
-name: pytorch-nightly-benchmarking-v0.1
+name: TorchBench nightly v0.1
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 13 * * *' # run at 1 PM UTC
 
 jobs:
-  checkout:
-    runs-on: [self-hosted, bm-metal]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: 0.1
   run-benchmark:
-    needs: checkout
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-metal]
     env:
       SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
     steps:
-      - run: bash ./.github/scripts/run-nightly-nodocker.sh
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 0.1
+      - name: Run benchmark
+        run: |
+          bash ./.github/scripts/run-nightly-nodocker.sh

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,17 +1,17 @@
-name: pytorch-sweep-benchmarking-v0.1
+name: TorchBench sweep v0.1
 on:
   workflow_dispatch:
 
 jobs:
-  checkout:
-    runs-on: [self-hosted, bm-metal]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: 0.1
   run-benchmark:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-metal]
     timeout-minutes: 2880 # 48 hours
-    needs: checkout
     steps:
-      - run: bash ./.github/scripts/run-sweep-nodocker.sh
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 0.1
+      - name: Run benchmark
+        run: |
+          bash ./.github/scripts/run-sweep-nodocker.sh


### PR DESCRIPTION
`conda activate` doesn't work in self-hosted runner environment, but `. activate` does.
This PR also disables workflow on forked repositories and unifies the names of ci workflows.