### PR TITLE
Generate plots per config

### DIFF
--- a/plot_sweep.py
+++ b/plot_sweep.py
@@ -5,6 +5,7 @@ import os
 # import sys
 # import re
 import yaml
+import itertools
 
 # from bokeh.layouts import column, row, layout, gridplot
 # from bokeh.plotting import figure, output_file, show
@@ -17,7 +18,7 @@ from bokeh.plotting import figure, output_file, show
 # from bokeh.models import ColumnDataSource, CategoricalTicker, Div
 # from bokeh.models import ColumnDataSource, DataTable, DateFormatter, TableColumn
 # from bokeh.transform import jitter
-# from collections import defaultdict
+from collections import defaultdict
 from datetime import datetime as dt
 from torchbenchmark.util.data import load_data_dir, load_data_files
 from torchbenchmark.score.compute_score import TorchBenchScore, SPEC_FILE_DEFAULT
@@ -33,8 +34,11 @@ if __name__ == "__main__":
     parser.add_argument("--output_html", default='plot.html', help="html file to write")
     parser.add_argument("--score_heirarchy", default=SPEC_FILE_DEFAULT,
                         help="file defining score heirarchy")
+    parser.add_argument("--plot_all", choices=['True', 'False'], default='False',
+                        help="Plots the scores for each configuration")
     parser.add_argument("--reference_json", required=True,
                         help="file defining score norm values, usually first json in first data_dir")
+
     args = parser.parse_args()
     plot_height = 800
     plot_width = 1000
@@ -45,37 +49,57 @@ if __name__ == "__main__":
     with open(args.reference_json) as f:
         ref_data = json.load(f)
     score_heirarchy = args.score_heirarchy
-
+    plot_all = True if args.plot_all == 'True' else False
     score_config = TorchBenchScore(ref_data, score_heirarchy, 1000)
 
     p = figure(plot_width=plot_width, plot_height=plot_height,
                x_axis_type='datetime')
-    p.y_range.start = 0
+
     xs = []
     ys = []
+    zs = []
     for d in compare_datasets:
         scores = []
         dates = []
+        scores_db = defaultdict(list)
         for i in range(len(d._json_raw)):
             data = d._json_raw[i]
             score = score_config.compute_score(data)
             scores.append(score)
+            if plot_all:
+                score_per_config = score_config.get_score_per_config(data, True)
+                for config, score in score_per_config.items():
+                    scores_db[config].append(score)
             pytorch_ver = data['machine_info']['pytorch_version']
             date = dt.strptime(pytorch_ver[pytorch_ver.index("dev") + len("dev"):], "%Y%m%d")
             dates.append(date)
         xs.append(dates)
         ys.append(scores)
+        if plot_all:
+            zs.append(scores_db)
 
-    colors = Category10[10][:len(compare_datasets)]
+    colors = itertools.cycle(Category10[10])
     basenames = map(os.path.basename, args.data_dir)
 
-    for x, y, color in zip(xs, ys, colors):
-        p.line(x, y, color=color, line_width=2, legend_label=next(basenames))
+    if plot_all:
+        for x, y, z in zip(xs, ys, zs):
+            basename = next(basenames)
+            color = next(colors)
+            p.line(x, y, color=color, line_width=2, legend_label=basename + '-total-score')
 
-    for x, y, color in zip(xs, ys, colors):
-        p.circle(x, y, color=color)
+            for config, scores in z.items():
+                test_config = str(config[0] + '-' + config[1] + '-' + config[2])
+                color = next(colors)
+                p.line(x, scores, color=color, line_width=2, legend_label=basename + '-' + test_config)
+
+        p.legend.click_policy = "hide"
+    else:
+        for x, y, color in zip(xs, ys, colors):
+            p.line(x, y, color=color, line_width=2, legend_label=next(basenames))
+
+        for x, y, color in zip(xs, ys, colors):
+            p.circle(x, y, color=color)
 
     p.legend.location = "bottom_right"
-
     output_file(args.output_html)
     show(p)

--- a/torchbenchmark/score/compute_score.py
+++ b/torchbenchmark/score/compute_score.py
@@ -78,7 +78,7 @@ class TorchBenchScore:
         else:
             self.norm = {b['name']: b['stats']['mean'] for b in self.ref_data['benchmarks']}
 
-    def get_score_per_config(self, data):
+    def get_score_per_config(self, data, weighted_score=False):
         """
         This function iterates over found benchmark dictionary
         and calculates the weight_sum and benchmark_score.
@@ -110,6 +110,13 @@ class TorchBenchScore:
                 for mean, config, benchmark in all_configs:
                     benchmark_score = weight * math.log(self.norm[benchmark] / mean)
                     score_db[config] += benchmark_score
+
+        # Get the weights per config and calibrate it to the
+        # target score
+        if weighted_score:
+            for config, score in score_db.items():
+                score_db[config] = score * 0.125
+                score_db[config] = self.target * math.exp(score)
 
         return score_db
 


### PR DESCRIPTION
Summary:
========

This PR generates plots per configuration on which the benchmarks were run. 
 - Adds a command line option to generate all the plots ( 9 plots - 1 for total_score and 8 - score_per_config )
 - Updates the score_per_config API to calibrate the weighted scores for every config to the target score
 
Test:
=====
- Generates all the 9 plots
python plot_sweep.py --reference_json ./new_full_sweep/new_full_sweep_nopstate2500/20210109_203915_.json ./new_full_sweep_nopstate2500 --plot_all True

![image](https://user-images.githubusercontent.com/70345919/109528227-528c1900-7a69-11eb-86a7-4366f6f7b36d.png)

- Generates only one plot
python plot_sweep.py --reference_json ./new_full_sweep/new_full_sweep_nopstate2500/20210109_203915_.json ./new_full_sweep_nopstate2500

![image](https://user-images.githubusercontent.com/70345919/109528365-72234180-7a69-11eb-89af-a3059fea0b0a.png)

 