### PR TITLE
Bump CUDA version to 11.1 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Install Conda
           command: ./scripts/install_basics.sh
       - run:
-          name: Install CUDA 11.0
+          name: Install CUDA 11.1
           command: sudo ./scripts/install_cuda.sh
       - run:
           name: Install PyTorch nightly

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -8,19 +8,21 @@ wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
 sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
 nvidia-smi
 
-echo "Installing CUDA 11.0 and CuDNN"
-rm -rf /usr/local/cuda-11.0 /usr/local/cuda
-# # install CUDA 11.0 in the same container
-wget -q http://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
-chmod +x cuda_11.0.3_450.51.06_linux.run
-./cuda_11.0.3_450.51.06_linux.run --toolkit --silent
-rm -f cuda_11.0.3_450.51.06_linux.run
-rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.0 /usr/local/cuda
+echo "Installing CUDA 11.1 and CuDNN"
+rm -rf /usr/local/cuda-11.1 /usr/local/cuda
+# install CUDA 11.1 in the same container
+# CUDA download archive: https://developer.nvidia.com/cuda-toolkit-archive
+wget -q https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run
+chmod +x cuda_11.1.0_455.23.05_linux.run
+./cuda_11.1.0_455.23.05_linux.run --toolkit --silent
+rm -f ./cuda_11.1.0_455.23.05_linux.run
+rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.1 /usr/local/cuda
 
-# install CUDA 11.0 CuDNN
+# install CUDA 11.1 CuDNN
+# cuDNN download archive: https://developer.nvidia.com/rdp/cudnn-archive
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 mkdir tmp_cudnn && cd tmp_cudnn
-wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.3/cudnn-11.0-linux-x64-v8.0.3.33.tgz -O cudnn-8.0.tgz
+wget -q https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.0.5/11.1_20201106/cudnn-11.1-linux-x64-v8.0.5.39.tgz -O cudnn-8.0.tgz
 tar xf cudnn-8.0.tgz
 cp -a cuda/include/* /usr/local/cuda/include/
 cp -a cuda/lib64/* /usr/local/cuda/lib64/

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -22,7 +22,7 @@ rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.1 /usr/local/cuda
 # cuDNN download archive: https://developer.nvidia.com/rdp/cudnn-archive
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 mkdir tmp_cudnn && cd tmp_cudnn
-wget -q https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.0.5/11.1_20201106/cudnn-11.1-linux-x64-v8.0.5.39.tgz -O cudnn-8.0.tgz
+wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-linux-x64-v8.0.5.39.tgz -O cudnn-8.0.tgz
 tar xf cudnn-8.0.tgz
 cp -a cuda/include/* /usr/local/cuda/include/
 cp -a cuda/lib64/* /usr/local/cuda/lib64/

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -7,7 +7,7 @@ conda activate base
 # conda install -y pytorch torchvision -c pytorch-nightly
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
 pip install -q numpy
-pip install -q --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
+pip install -q --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
 
 # separating to debug issue where when installing all 3 this error printed
 # 
@@ -19,4 +19,4 @@ pip install -q --pre torch torchvision -f https://download.pytorch.org/whl/night
 #   - torchtext -> python[version='>=2.7,<2.8.0a0|>=3.5,<3.6.0a0']
 
 # conda install -y torchtext -c pytorch-nightly
-pip install -q --pre torchtext -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
+pip install -q --pre torchtext -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html


### PR DESCRIPTION
PyTorch has stopped building against CUDA 11.0: pytorch[#53299](https://github.com/pytorch/pytorch/pull/53299)