### PR TITLE
write_sys_file expects str or write throws

### DIFF
--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -235,8 +235,8 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
         for path in freq_paths:
             all_exist = all_exist and os.path.exists(path)
         if all_exist:
-            write_sys_file(freq_paths[0], min_freq * 1000)
-            write_sys_file(freq_paths[1], max_freq * 1000)
+            write_sys_file(freq_paths[0], str(min_freq * 1000))
+            write_sys_file(freq_paths[1], str(max_freq * 1000))
 
 def check_pstate_frequency_pin(pin_freq = 2500):
     FREQ_THRESHOLD = 10  # Allow 10 MHz difference maximum


### PR DESCRIPTION
It's better to just cast a value to string in `write_sys_file` but this at least fixes the current issue for now while I remember about it.