### PR TITLE
Rewrite DLRM to be TorchScript-able

### DIFF
--- a/torchbenchmark/models/dlrm/tricks/md_embedding_bag.py
+++ b/torchbenchmark/models/dlrm/tricks/md_embedding_bag.py
@@ -61,7 +61,7 @@ def pow_2_round(dims):
 
 
 class PrEmbeddingBag(nn.Module):
-    def __init__(self, num_embeddings, embedding_dim, base_dim):
+    def __init__(self, num_embeddings: int, embedding_dim, base_dim):
         super(PrEmbeddingBag, self).__init__()
         self.embs = nn.EmbeddingBag(
             num_embeddings, embedding_dim, mode="sum", sparse=True)


### PR DESCRIPTION
* The only portion not scriptable is `parallel_forward` calling into `nn.parallel`, but it is only needed for distributed execution, which as far as I know isn't part of plan for benchmarking.