### PR TITLE
Improve usability of torch_nightly.py

### DIFF
--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -1,6 +1,8 @@
 import os
 import re
 import requests
+import argparse
+import urllib.parse
 from datetime import date, timedelta
 from bs4 import BeautifulSoup
 from collections import defaultdict
@@ -26,7 +28,7 @@ def memoize(function):
 def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_index, override_file=torch_nightly_wheel_index_override):
     """
     """
-    if override_file:
+    if os.path.isfile(override_file) and os.stat(override_file).st_size:
         with open(override_file) as f:
             data = f.read()
     else:
@@ -37,6 +39,7 @@ def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_i
     data = defaultdict(dict)
     for link in soup.find_all('a'):
         pkg, version, py, py_m, platform = re.search("([a-z]*)-(.*)-(.*)-(.*)-(.*)\.whl", link.text).groups()
+        version = urllib.parse.unquote(version)
         if py == py_version and platform == platform_version:
             full_url = os.path.join(torch_wheel_nightly_base, link.text)
             data[pkg][version] = full_url
@@ -64,32 +67,40 @@ def get_nightly_wheel_urls(packages:list, date:date,
     return rc
 
 def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
-                                py_version='cp37', platform_version='linux_x86_64'):
+                                py_version='cp37', platform_version='linux_x86_64', reverse=False):
     rc = []
     curr_date = start_date
-    while curr_date < end_date:
+    while curr_date <= end_date:
         curr_wheels = get_nightly_wheel_urls(packages, curr_date,
                                              py_version=py_version,
                                              platform_version=platform_version)
         if curr_wheels is not None:
             rc.append(curr_wheels)
         curr_date += timedelta(days=1)
-
+    if reverse:
+        rc.reverse()
     return rc
 
 def get_n_prior_nightly_wheels(packages:list, n:int,
-                               py_version='cp37', platform_version='linux_x86_64'):
+                               py_version='cp37', platform_version='linux_x86_64', reverse=False):
     end_date = date.today()
     start_date = end_date - timedelta(days=n)
     return get_nightly_wheels_in_range(packages, start_date, end_date,
-                                       py_version=py_version, platform_version=platform_version)
-
+                                       py_version=py_version, platform_version=platform_version, reverse=reverse)
 
 if __name__ == "__main__":
-    from tabulate import tabulate
-    # print(tabulate(get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 200)))
-    wheels = get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 1)
+    parser = argparse.ArgumentParser(description="Find recent pytorch nightly builds")
+    parser.add_argument("--pyver", type=str, default="cp37", help="PyTorch Python version")
+    parser.add_argument("--platform", type=str, default="linux_x86_64", help="PyTorch platform")
+    parser.add_argument("--priordays", type=int, default=0, help="Number of days")
+    parser.add_argument("--reverse", action="store_true", help="Return reversed result")
+    parser.add_argument("--packages", required=True, type=str, nargs="+", help="List of package names")
+    args = parser.parse_args()
+    wheels = get_n_prior_nightly_wheels(packages=['torch', 'torchvision', 'torchtext'],
+                                        n=args.priordays,
+                                        py_version=args.pyver,
+                                        platform_version=args.platform,
+                                        reverse=args.reverse)
     for wheelset in wheels:
         for pkg in wheelset:
-            print(f"{wheelset[pkg]['version']}: {wheelset[pkg]['wheel']}")
-            # print(f"   \"{a} {b} {c}\"  \\")
+            print(f"{pkg}-{wheelset[pkg]['version']}: {wheelset[pkg]['wheel']}")

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser.add_argument("--reverse", action="store_true", help="Return reversed result")
     parser.add_argument("--packages", required=True, type=str, nargs="+", help="List of package names")
     args = parser.parse_args()
-    wheels = get_n_prior_nightly_wheels(packages=['torch', 'torchvision', 'torchtext'],
+    wheels = get_n_prior_nightly_wheels(packages=args.packages,
                                         n=args.priordays,
                                         py_version=args.pyver,
                                         platform_version=args.platform,

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -1,3 +1,9 @@
+"""
+Return a list of recent PyTorch wheels published on download.pytorch.org.
+Users can specify package name, python version, platform, and the number of days to return.
+If one of the packages specified is missing on one day, the script will skip outputing the results on that day.
+"""
+
 import os
 import re
 import requests
@@ -89,7 +95,7 @@ def get_n_prior_nightly_wheels(packages:list, n:int,
                                        py_version=py_version, platform_version=platform_version, reverse=reverse)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Find recent pytorch nightly builds")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pyver", type=str, default="cp37", help="PyTorch Python version")
     parser.add_argument("--platform", type=str, default="linux_x86_64", help="PyTorch platform")
     parser.add_argument("--priordays", type=int, default=0, help="Number of days")


### PR DESCRIPTION
Currently, nightly CI suffers problem when torch/torchtext/torchvision nightly build fails. Installing the failed packages from pip will silently fall back to the recent stable versions. For example, if pytorch nightly build fails, it will install torch stable, torchtext nightly, and torchvision nightly.

Therefore, I would like to add some checks before we actually run the nightly CI. The plan is to first call torch_nightly.py to get a list of latest nightly built packages, and only proceed if all packages have the latest build.