### PR TITLE
Check the nightlies are correctly built before running the benchmark

### DIFF
--- a/.github/scripts/run-nightly-nodocker.sh
+++ b/.github/scripts/run-nightly-nodocker.sh
@@ -29,6 +29,14 @@ sudo nvidia-smi -ac ${GPU_FREQUENCY}
 export CUDA_VISIBLE_DEVICES="${GPU_LIST}"
 export GOMP_CPU_AFFINITY="${CORE_LIST}"
 
+# Check if nightly builds are available
+NIGHTLIES=$(python torchbenchmark/util/torch_nightly.py --packages torch torchvision torchtext)
+# If failed, the script will generate empty result
+if [ -z $NIGHTLIES ]; then
+    echo "Torch, torchvision, or torchtext nightly build failed. Cancel the workflow."
+    exit 1
+fi
+
 mkdir -p ${DATA_DIR}
 conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
 . activate ${CONDA_ENV_NAME}

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -1,6 +1,14 @@
+"""
+Return a list of recent PyTorch wheels published on download.pytorch.org.
+Users can specify package name, python version, platform, and the number of days to return.
+If one of the packages specified is missing on one day, the script will skip outputing the results on that day.
+"""
+
 import os
 import re
 import requests
+import argparse
+import urllib.parse
 from datetime import date, timedelta
 from bs4 import BeautifulSoup
 from collections import defaultdict
@@ -26,7 +34,7 @@ def memoize(function):
 def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_index, override_file=torch_nightly_wheel_index_override):
     """
     """
-    if override_file:
+    if os.path.isfile(override_file) and os.stat(override_file).st_size:
         with open(override_file) as f:
             data = f.read()
     else:
@@ -37,6 +45,7 @@ def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_i
     data = defaultdict(dict)
     for link in soup.find_all('a'):
         pkg, version, py, py_m, platform = re.search("([a-z]*)-(.*)-(.*)-(.*)-(.*)\.whl", link.text).groups()
+        version = urllib.parse.unquote(version)
         if py == py_version and platform == platform_version:
             full_url = os.path.join(torch_wheel_nightly_base, link.text)
             data[pkg][version] = full_url
@@ -64,32 +73,40 @@ def get_nightly_wheel_urls(packages:list, date:date,
     return rc
 
 def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
-                                py_version='cp37', platform_version='linux_x86_64'):
+                                py_version='cp37', platform_version='linux_x86_64', reverse=False):
     rc = []
     curr_date = start_date
-    while curr_date < end_date:
+    while curr_date <= end_date:
         curr_wheels = get_nightly_wheel_urls(packages, curr_date,
                                              py_version=py_version,
                                              platform_version=platform_version)
         if curr_wheels is not None:
             rc.append(curr_wheels)
         curr_date += timedelta(days=1)
-
+    if reverse:
+        rc.reverse()
     return rc
 
 def get_n_prior_nightly_wheels(packages:list, n:int,
-                               py_version='cp37', platform_version='linux_x86_64'):
+                               py_version='cp37', platform_version='linux_x86_64', reverse=False):
     end_date = date.today()
     start_date = end_date - timedelta(days=n)
     return get_nightly_wheels_in_range(packages, start_date, end_date,
-                                       py_version=py_version, platform_version=platform_version)
-
+                                       py_version=py_version, platform_version=platform_version, reverse=reverse)
 
 if __name__ == "__main__":
-    from tabulate import tabulate
-    # print(tabulate(get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 200)))
-    wheels = get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 1)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyver", type=str, default="cp37", help="PyTorch Python version")
+    parser.add_argument("--platform", type=str, default="linux_x86_64", help="PyTorch platform")
+    parser.add_argument("--priordays", type=int, default=0, help="Number of days")
+    parser.add_argument("--reverse", action="store_true", help="Return reversed result")
+    parser.add_argument("--packages", required=True, type=str, nargs="+", help="List of package names")
+    args = parser.parse_args()
+    wheels = get_n_prior_nightly_wheels(packages=args.packages,
+                                        n=args.priordays,
+                                        py_version=args.pyver,
+                                        platform_version=args.platform,
+                                        reverse=args.reverse)
     for wheelset in wheels:
         for pkg in wheelset:
-            print(f"{wheelset[pkg]['version']}: {wheelset[pkg]['wheel']}")
-            # print(f"   \"{a} {b} {c}\"  \\")
+            print(f"{pkg}-{wheelset[pkg]['version']}: {wheelset[pkg]['wheel']}")


### PR DESCRIPTION
This PR cherry-picks #333 and adds sanity checks before running the nightly CI.