### PR TITLE
Increase the batch size from mobilenet training

### DIFF
--- a/torchbenchmark/models/mobilenet_v2/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2/__init__.py
@@ -13,7 +13,7 @@ class Model(BenchmarkModel):
         self.model = models.mobilenet_v2().to(self.device)
         if self.jit:
             self.model = torch.jit.script(self.model)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((96, 3, 224, 224)).to(self.device),)
 
     def get_module(self):
         return self.model, self.example_inputs
@@ -41,4 +41,4 @@ if __name__ == "__main__":
     module(*example_inputs)
     m.train(niter=1)
     m.eval(niter=1)
-    
+

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -12,7 +12,7 @@ class Model(BenchmarkModel):
         self.device = device
         self.jit = jit
         self.model = models.mobilenet_v2().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((96, 3, 224, 224)).to(self.device),)
         self.prep_qat_train()  # config+prepare steps are required for both train and eval
 
     def prep_qat_train(self):


### PR DESCRIPTION
Summary: Increase the batch size from 32 to 96 according to the original paper's evaluation setup, [ Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification, Detection and Segmentation](https://arxiv.org/pdf/1801.04381.pdf)

Test Plan:
```
python test.py -k "test_mobilenet_v2_train_cuda"
python test.py -k "test_mobilenet_v2_train_cpu"
python test.py -k "test_mobilenet_v2_quantized_qat_train_cuda"
python test.py -k "test_mobilenet_v2_quantized_qat_train_cpu"
```