### PR TITLE
Fix Circle CI PR correctness check.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Install Conda
           command: ./scripts/install_basics.sh
       - run:
-          name: Install CUDA 11.1
+          name: Install CUDA 11.2
           command: sudo ./scripts/install_cuda.sh
       - run:
           name: Install PyTorch nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   run_benchmarks:
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: gpu.small
+    resource_class: gpu.medium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   run_benchmarks:
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: gpu.small
+    resource_class: gpu.nvidia.medium
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   run_benchmarks:
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: gpu.medium
+    resource_class: gpu.small
     steps:
       - checkout
       - run:

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -3,26 +3,27 @@
 set -ex
 
 echo "Installing nvidia kernel driver"
-DRIVER_FN="NVIDIA-Linux-x86_64-450.51.06.run"
+DRIVER_FN="NVIDIA-Linux-x86_64-460.39.run"
 wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
 sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
 nvidia-smi
 
-echo "Installing CUDA 11.1 and CuDNN"
-rm -rf /usr/local/cuda-11.1 /usr/local/cuda
+echo "Installing CUDA 11.2 and CuDNN"
+rm -rf /usr/local/cuda-11.2 /usr/local/cuda
 # install CUDA 11.1 in the same container
 # CUDA download archive: https://developer.nvidia.com/cuda-toolkit-archive
-wget -q https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run
-chmod +x cuda_11.1.0_455.23.05_linux.run
-./cuda_11.1.0_455.23.05_linux.run --toolkit --silent
-rm -f ./cuda_11.1.0_455.23.05_linux.run
-rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.1 /usr/local/cuda
+CUDA_INSTALLER=cuda_11.2.2_460.32.03_linux.run
+wget -q https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/$CUDA_INSTALLER
+chmod +x $CUDA_INSTALLER
+./$CUDA_INSTALLER --toolkit --silent
+rm -f ${CUDA_INSTALLER}
+rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.2 /usr/local/cuda
 
-# install CUDA 11.1 CuDNN
+# install CUDA 11.2 CuDNN
 # cuDNN download archive: https://developer.nvidia.com/rdp/cudnn-archive
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 mkdir tmp_cudnn && cd tmp_cudnn
-wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-linux-x64-v8.0.5.39.tgz -O cudnn-8.0.tgz
+wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.1.0/cudnn-11.2-linux-x64-v8.1.0.77.tgz -O cudnn-8.0.tgz
 tar xf cudnn-8.0.tgz
 cp -a cuda/include/* /usr/local/cuda/include/
 cp -a cuda/lib64/* /usr/local/cuda/lib64/

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -7,16 +7,5 @@ conda activate base
 # conda install -y pytorch torchvision -c pytorch-nightly
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
 pip install -q numpy
-pip install -q --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
-
-# separating to debug issue where when installing all 3 this error printed
-# 
-# UnsatisfiableError: The following specifications were found
-# to be incompatible with the existing python installation in your environment:
-#
-# Specifications:
-#
-#   - torchtext -> python[version='>=2.7,<2.8.0a0|>=3.5,<3.6.0a0']
-
-# conda install -y torchtext -c pytorch-nightly
-pip install -q --pre torchtext -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
+pip install -q --pre torch torchvision torchtext \
+    -f https://download.pytorch.org/whl/nightly/cu112/torch_nightly.html

--- a/test.py
+++ b/test.py
@@ -49,7 +49,11 @@ def _load_test(model_class, device):
         m = model_object(self)
         try:
             module, example_inputs = m.get_module()
-            module(*example_inputs)
+            if isinstance(example_inputs, dict):
+                # Huggingface models pass **kwargs as arguments, not *args
+                module(**example_inputs)
+            else:
+                module(*example_inputs)
         except NotImplementedError:
             self.skipTest('Method get_module is not implemented, skipping...')
 

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -14,7 +14,6 @@ class Model(BenchmarkModel):
         self.model = models.mobilenet_v2().to(self.device)
         self.example_inputs = (torch.randn((96, 3, 224, 224)).to(self.device),)
         self.prep_qat_train()  # config+prepare steps are required for both train and eval
-        torch.cuda.empty_cache()
 
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -14,6 +14,7 @@ class Model(BenchmarkModel):
         self.model = models.mobilenet_v2().to(self.device)
         self.example_inputs = (torch.randn((96, 3, 224, 224)).to(self.device),)
         self.prep_qat_train()  # config+prepare steps are required for both train and eval
+        torch.cuda.empty_cache()
 
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}


### PR DESCRIPTION
The PR ci meets a bunch of CUDA errors because it uses an incompatible version of Nvidia driver.
I tried to install the correct Nvidia driver, but the problem persists under CUDA 11.1.
After upgrading the version to CUDA 11.2, the problem disappears.

Also added other fixes:
- Use gpu.nvidia.medium runner, which has larger GPU memory
- Fixes the Huggingface model unittests by accepting kwargs in test.py