### PR TITLE
Various fixes to instruction count CI

### DIFF
--- a/.github/scripts/instr-count-benchmark/config.env
+++ b/.github/scripts/instr-count-benchmark/config.env
@@ -4,6 +4,7 @@ PYTHON_VERSION=3.7
 CUDA_VERSION=cu102
 CONDA_ENV_NAME="instr_cnt_benchmark"
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
 INSTRUCTION_COUNT_ROOT="$HOME/.torchbench/instruction-count-nightly-ci"
 RESULT_JSON="${INSTRUCTION_COUNT_ROOT}/ubenchmark_results.json"
 REPO_CHECKOUT="${INSTRUCTION_COUNT_ROOT}/pytorch"

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -32,4 +32,7 @@ pip install --pre torch \
 
 pip install numpy
 
+ls -alF ${INSTRUCTION_COUNT_ROOT}
+ls -alF ${REPO_CHECKOUT}
+
 git clone --depth 1 https://github.com/pytorch/pytorch.git ${REPO_CHECKOUT}

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -32,7 +32,5 @@ pip install --pre torch \
 
 pip install numpy
 
-ls -alF ${INSTRUCTION_COUNT_ROOT}
-ls -alF ${REPO_CHECKOUT}
-
+rm -rf ${REPO_CHECKOUT}
 git clone --depth 1 https://github.com/pytorch/pytorch.git ${REPO_CHECKOUT}

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -23,10 +23,10 @@ conda install -y valgrind -c conda-forge
 NIGHTLIES=$(python torchbenchmark/util/torch_nightly.py --packages torch)
 
 # If failed, the script will generate empty result
-if [ -z $NIGHTLIES ]; then
-    echo "Torch nightly build failed. Cancel the workflow."
-    exit 1
-fi
+# if [ -z $NIGHTLIES ]; then
+#     echo "Torch nightly build failed. Cancel the workflow."
+#     exit 1
+# fi
 
 # Install PyTorch nightly from pip
 pip install --pre torch \

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -30,4 +30,6 @@ fi
 pip install --pre torch \
     -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
 
+pip install numpy
+
 git clone --depth 1 https://github.com/pytorch/pytorch.git ${REPO_CHECKOUT}

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -12,6 +12,8 @@ mkdir -p ${INSTRUCTION_COUNT_ROOT}
 conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
 . activate ${CONDA_ENV_NAME}
 
+pip install -r requirements.txt
+
 # We need Valgrind to collect instructions.
 conda install -y valgrind -c conda-forge
 

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -12,8 +12,10 @@ mkdir -p ${INSTRUCTION_COUNT_ROOT}
 conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
 . activate ${CONDA_ENV_NAME}
 
+# For torch_nightly.py
 pip install -r requirements.txt
 
+# For benchmarks. We need CMake and Ninja for JIT-ing C++.
 conda install -y numpy ninja cmake cffi typing_extensions dataclasses
 
 # We need Valgrind to collect instructions.
@@ -23,16 +25,14 @@ conda install -y valgrind -c conda-forge
 NIGHTLIES=$(python torchbenchmark/util/torch_nightly.py --packages torch)
 
 # If failed, the script will generate empty result
-# if [ -z $NIGHTLIES ]; then
-#     echo "Torch nightly build failed. Cancel the workflow."
-#     exit 1
-# fi
+if [ -z $NIGHTLIES ]; then
+    echo "Torch nightly build failed. Cancel the workflow."
+    exit 1
+fi
 
 # Install PyTorch nightly from pip
 pip install --pre torch \
     -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
-
-pip install numpy
 
 rm -rf ${REPO_CHECKOUT}
 git clone --depth 1 https://github.com/pytorch/pytorch.git ${REPO_CHECKOUT}

--- a/.github/scripts/instr-count-benchmark/create-nightly-env.sh
+++ b/.github/scripts/instr-count-benchmark/create-nightly-env.sh
@@ -14,6 +14,8 @@ conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
 
 pip install -r requirements.txt
 
+conda install -y numpy ninja cmake cffi typing_extensions dataclasses
+
 # We need Valgrind to collect instructions.
 conda install -y valgrind -c conda-forge
 

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -16,3 +16,5 @@ echo "Running instruction benchmark for pytorch-${PYTORCH_VERSION}, commit SHA: 
 pushd ${BENCHMARK_ROOT}
 python main.py --mode ci --destination ${RESULT_JSON}
 popd
+
+python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -17,4 +17,4 @@ pushd ${BENCHMARK_ROOT}
 # python main.py --mode ci --destination ${RESULT_JSON}
 popd
 
-python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}
+PYTHONPATH="${GIT_ROOT}:${PYTHONPATH}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -17,4 +17,4 @@ pushd ${BENCHMARK_ROOT}
 # python main.py --mode ci --destination ${RESULT_JSON}
 popd
 
-PYTHONPATH="${GIT_ROOT}:${PYTHONPATH}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}
+PYTHONPATH="${GIT_ROOT}:${PYTHONPATH:''}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -14,7 +14,7 @@ echo "Running instruction benchmark for pytorch-${PYTORCH_VERSION}, commit SHA: 
 
 # Run the instruction count benchmark
 pushd ${BENCHMARK_ROOT}
-# python main.py --mode ci --destination ${RESULT_JSON}
+python main.py --mode ci --destination ${RESULT_JSON}
 popd
 
 PYTHONPATH="${GIT_ROOT}:${PYTHONPATH:-}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -17,4 +17,4 @@ pushd ${BENCHMARK_ROOT}
 # python main.py --mode ci --destination ${RESULT_JSON}
 popd
 
-PYTHONPATH="${GIT_ROOT}:${PYTHONPATH:''}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}
+PYTHONPATH="${GIT_ROOT}:${PYTHONPATH:-}" python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/run-benchmark.sh
+++ b/.github/scripts/instr-count-benchmark/run-benchmark.sh
@@ -14,7 +14,7 @@ echo "Running instruction benchmark for pytorch-${PYTORCH_VERSION}, commit SHA: 
 
 # Run the instruction count benchmark
 pushd ${BENCHMARK_ROOT}
-python main.py --mode ci --destination ${RESULT_JSON}
+# python main.py --mode ci --destination ${RESULT_JSON}
 popd
 
 python ${BASEDIR}/upload.py --result_json ${RESULT_JSON}

--- a/.github/scripts/instr-count-benchmark/upload.py
+++ b/.github/scripts/instr-count-benchmark/upload.py
@@ -11,9 +11,11 @@ import torch
 
 print(os.getcwd())
 print(sys.path)
-os.exit(0)
+
 
 from scripts.upload_scribe import ScribeUploader
+
+sys.exit(0)
 
 
 class PytorchMicrobenchmarkUploader(ScribeUploader):

--- a/.github/scripts/instr-count-benchmark/upload.py
+++ b/.github/scripts/instr-count-benchmark/upload.py
@@ -9,6 +9,10 @@ import time
 import numpy as np
 import torch
 
+print(os.getcwd())
+print(sys.path)
+os.exit(0)
+
 from scripts.upload_scribe import ScribeUploader
 
 

--- a/.github/scripts/instr-count-benchmark/upload.py
+++ b/.github/scripts/instr-count-benchmark/upload.py
@@ -9,13 +9,7 @@ import time
 import numpy as np
 import torch
 
-print(os.getcwd())
-print(sys.path)
-
-
 from scripts.upload_scribe import ScribeUploader
-
-sys.exit(0)
 
 
 class PytorchMicrobenchmarkUploader(ScribeUploader):

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: gh/taylorrobie/callgrind_scribe2
       - name: Create Conda nightly env
         run: |
           bash .github/scripts/instr-count-benchmark/create-nightly-env.sh

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -7,6 +7,8 @@ jobs:
   run-benchmark:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-metal]
+    env:
+      SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
     steps:
       - name: Check out
         uses: actions/checkout@v2


### PR DESCRIPTION
I was missing a bunch of minor things in the first pass:
* Need the top level `requirements.txt` for `torch_nightly.py`
* Need a bunch of extra conda installs for the ubenchmarks
* For some reason there are some files in `REPO_CHECKOUT`. (But not a full checkout.) So clean that up before cloning.
* I wasn't actually calling the Scribe upload script. Oops.
* I am missing `SCRIBE_GRAPHQL_ACCESS_TOKEN`

Right now the benchmark suite runs until it gets to `upload.py` and fails because of the token. So we're close!
