### PR TITLE
Add bisection script and devbig local abtest scripts

### DIFF
--- a/.github/scripts/bisection-config.sample.yaml
+++ b/.github/scripts/bisection-config.sample.yaml
@@ -1,0 +1,15 @@
+# The sample bisection config that solves GH issue #51380
+
+# Start and end commits
+start: a87a1c1
+end: 0ead9d5
+# 10 percent regression
+threshold: 10
+# Support increase, decrease, or both
+# increase means performance regression, decrease means performance optimization
+direction: increase
+# Test timeout in minutes
+timeout: 60
+# Only the tests specified are executed. If not specified, use the tests in the TorchBench v0 config
+tests:
+ - test_eval[yolov3-cpu-eager]

--- a/.github/scripts/run-bisection.sh
+++ b/.github/scripts/run-bisection.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Script that run the PR bisection
+# Requirements:
+# 1. Conda environment created using the following command:
+#     conda create -y -n bisection python=3.7
+#     # numpy=1.17 is from yolov3 requirements.txt, requests=2.22 is from demucs
+#     conda install numpy=1.17 requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six dataclasses
+# 2. PyTorch git repo (specified by PYTORCH_SRC_DIR) and TorchBench git repo (specified by TORCHBENCH_SRC_DIR)
+#    in clean state with the latest code.
+# 3. Bisection config, in the YAML format.
+#    An example of bisection configuration in YAML can be found in bisection-config.sample.yaml
+
+set -xeo pipefail
+
+SCRIPTPATH=$(realpath $0)
+BASEDIR=$(dirname $SCRIPTPATH)
+
+if [ -z ${PYTORCH_SRC_DIR} ]; then
+    PYTORCH_SRC_DIR=${HOME}/pytorch
+fi
+
+if [ -z ${TORCHBENCH_SRC_DIR} ]; then
+    TORCHBENCH_SRC_DIR=${HOME}/benchmark
+fi
+
+if [ -z ${BISECT_CONDA_ENV} ]; then
+    BISECT_CONDA_ENV=bisection
+fi
+
+# Allows user to specify github issue name
+if [ -z ${BISECT_ISSUE} ]; then
+    BISECT_ISSUE=example-issue
+fi
+
+BISECT_BASE=${HOME}/.torchbench/bisection/${BISECT_ISSUE}
+
+. activate ${BISECT_CONDA_ENV}
+# create the work directory
+mkdir -p ${BISECT_BASE}/gh${GITHUB_RUN_ID}
+
+# specify --debug to allow restart from the last failed point
+python bisection.py --work-dir ${BISECT_BASE}/gh${GITHUB_RUN_ID} \
+       --pytorch-src ${PYTORCH_SRC_DIR} \
+       --torchbench-src ${TORCHBENCH_SRC_DIR} \
+       --config ${BISECT_BASE}/config.yaml \
+       --output ${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json \
+       --debug

--- a/.github/scripts/run-devbig-abtest.sh
+++ b/.github/scripts/run-devbig-abtest.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Script that run the local abtest on devbig
+
+set -eo pipefail
+
+SCRIPTPATH=$(realpath $0)
+BASEDIR=$(dirname $SCRIPTPATH)
+
+if [ -z ${PYTORCH_SRC_DIR} ]; then
+    PYTORCH_SRC_DIR=${HOME}/pytorch
+fi
+
+if [ -z ${TORCHBENCH_SRC_DIR} ]; then
+    TORCHBENCH_SRC_DIR=${HOME}/benchmark
+fi
+
+if [ -z ${CONDA_ENV_NAME} ]; then
+    CONDA_ENV_NAME=abtest
+fi
+
+# Allows user to specify github issue name
+if [ -z ${ABTEST_ISSUE} ]; then
+    ABTEST_ISSUE=example-issue
+fi
+
+ABTEST_BASE=${HOME}/.torchbench/abtest/${ABTEST_ISSUE}
+
+. activate ${CONDA_ENV_NAME}
+# create the work directory
+mkdir -p ${ABTEST_BASE}
+
+# specify --debug to allow restart from the last failed point
+python bisection.py --work-dir ${ABTEST_BASE} \
+       --pytorch-src ${PYTORCH_SRC_DIR} \
+       --torchbench-src ${TORCHBENCH_SRC_DIR} \
+       --config ${ABTEST_BASE}/config.yaml \
+       --output ${ABTEST_BASE}/result.json \
+       --devbig ${CONDA_ENV_NAME} \
+       --debug

--- a/.github/scripts/run-devbig-stub.sh
+++ b/.github/scripts/run-devbig-stub.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This is the stub of run-v0-big.sh
+# Do not directly run it!
+
+set -eu
+
+DATA_DIR=$1
+BENCHMARK_FILTER="$2"
+CONDA_ENV_NAME=$3
+NUM_ROUNDS=20
+DATA_JSON_PREFIX=$(date +"%Y%m%d_%H%M%S")
+
+. ${HOME}/miniconda3/etc/profile.d/conda.sh
+conda activate ${CONDA_ENV_NAME}
+
+echo "Running benchmark with filter: \"${BENCHMARK_FILTER}\""
+
+# Ignore the machine config, because it is on devbig
+pytest test_bench.py -k "${BENCHMARK_FILTER}" \
+       --ignore_machine_config \
+       --benchmark-min-rounds "${NUM_ROUNDS}" \
+       --benchmark-json ${DATA_DIR}/${DATA_JSON_PREFIX}.json

--- a/.github/scripts/run-devbig-stub.sh
+++ b/.github/scripts/run-devbig-stub.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-# This is the stub of run-v0-big.sh
-# Do not directly run it!
-
+# This is the stub of run-devbig.sh
+# DO NOT directly run it!
 set -eu
 
 DATA_DIR=$1

--- a/.github/scripts/run-devbig.sh
+++ b/.github/scripts/run-devbig.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This script runs TorchBench v0 without installing the package
+# It assumes pytorch and its dependencies have been installed correctly
+# Usage:
+# run-v0-devbig.sh RESULT_DIR BENCHMARK_FILTER CONDA_ENV_NAME
+# All three arguments are required
+
+set -eo pipefail
+
+# Big machine config
+DATA_DIR=$1
+BENCHMARK_FILTER="$2"
+CONDA_ENV_NAME=$3
+CURRENT_DIR=$(dirname "$(readlink -f "$0")")
+
+# Install benchmark dependencies
+python install.py
+
+sudo -E systemd-run --slice=workload.slice --same-dir --wait --collect --service-type=exec --pty --uid=$USER \
+     bash $CURRENT_DIR/run-v0-devbig-stub.sh $DATA_DIR "${BENCHMARK_FILTER}" $CONDA_ENV_NAME
+
+echo "Benchmark finished successfully. Output data dir is ${DATA_DIR}."

--- a/.github/scripts/run-devbig.sh
+++ b/.github/scripts/run-devbig.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# This script runs TorchBench v0 without installing the package
+# This script runs TorchBench without installing the package
 # It assumes pytorch and its dependencies have been installed correctly
 # Usage:
-# run-v0-devbig.sh RESULT_DIR BENCHMARK_FILTER CONDA_ENV_NAME
+# run-devbig.sh RESULT_DIR BENCHMARK_FILTER CONDA_ENV_NAME
 # All three arguments are required
 
 set -eo pipefail
@@ -17,6 +17,6 @@ CURRENT_DIR=$(dirname "$(readlink -f "$0")")
 python install.py
 
 sudo -E systemd-run --slice=workload.slice --same-dir --wait --collect --service-type=exec --pty --uid=$USER \
-     bash $CURRENT_DIR/run-v0-devbig-stub.sh $DATA_DIR "${BENCHMARK_FILTER}" $CONDA_ENV_NAME
+     bash $CURRENT_DIR/run-devbig-stub.sh $DATA_DIR "${BENCHMARK_FILTER}" $CONDA_ENV_NAME
 
 echo "Benchmark finished successfully. Output data dir is ${DATA_DIR}."

--- a/bisection.py
+++ b/bisection.py
@@ -256,9 +256,9 @@ class TorchBench:
         bmfilter = targets_to_bmfilter(targets)
         print(f"Running TorchBench for commit: {commit.sha}, filter {bmfilter} ...", end="", flush=True)
         if not self.devbig:
-            command = f"""bash .github/scripts/run-v0.sh "{output_dir}" "{bmfilter}" &> {output_dir}/benchmark.log"""
+            command = f"""bash .github/scripts/run-bench.sh "{output_dir}" "{bmfilter}" &> {output_dir}/benchmark.log"""
         else:
-            command = f"""bash .github/scripts/run-v0-devbig.sh  "{output_dir}" "{bmfilter}" "{self.devbig}" &> {output_dir}/benchmark.log"""
+            command = f"""bash .github/scripts/run-devbig.sh  "{output_dir}" "{bmfilter}" "{self.devbig}" &> {output_dir}/benchmark.log"""
         try:
             subprocess.check_call(command, cwd=self.srcpath, shell=True, timeout=self.timelimit * 60)
         except subprocess.TimeoutExpired:

--- a/bisection.py
+++ b/bisection.py
@@ -1,0 +1,515 @@
+"""bisection.py
+Runs bisection to determine PRs that cause performance change.
+It assumes that the pytorch, torchbench, torchtext, torchvision, and torchaudio repositories provided are all clean with the latest code.
+By default, the torchvision, torchaudio, and torchtext package version will be fixed to the latest commit on the pytorch commit date.
+
+Usage:
+  python bisection.py --work-dir <WORK-DIR> \
+    --pytorch-src <PYTORCH_SRC_DIR> \
+    --torchbench-src <TORCHBENCH_SRC_DIR> \
+    --config <BISECT_CONFIG> --output <OUTPUT_FILE_PATH>
+"""
+
+import os
+import json
+import yaml
+import argparse
+import typing
+from tabulate import tabulate
+import re
+import subprocess
+from datetime import datetime
+from typing import Optional, List, Dict, Tuple
+
+from torchbenchmark.util import gitutils
+
+TORCH_GITREPO="https://github.com/pytorch/pytorch.git"
+TORCHBENCH_GITREPO="https://github.com/pytorch/benchmark.git"
+TORCHBENCH_DEPS = {
+    "torchtext": os.path.expandvars("${HOME}/text"),
+    "torchvision": os.path.expandvars("${HOME}/vision"),
+    "torchaudio": os.path.expandvars("${HOME}/audio"),
+}
+
+def exist_dir_path(string):
+    if os.path.isdir(string):
+        return string
+    else:
+        raise NotADirectoryError(string)
+
+# Translates test name to filter
+# For example, ["test_eval[yolov3-cpu-eager]", "test_train[yolov3-gpu-eager]"]
+#     -> "((eval and yolov3 and cpu and eager) or (train and yolov3 and gpu and eager))"
+# If targets is None, run everything except slomo
+def targets_to_bmfilter(targets: List[str]) -> str:
+    bmfilter_names = []
+    if targets == None or len(targets) == 0:
+        return "(not slomo)"
+    for test in targets:
+        regex = re.compile("test_(train|eval)\[([a-zA-Z0-9_]+)-([a-z]+)-([a-z]+)\]")
+        m = regex.match(test).groups()
+        partial_name = " and ".join(m)
+        bmfilter_names.append(f"({partial_name})")
+    return "(" + " or ".join(bmfilter_names) + ")"
+
+def find_latest_json_file(result_dir: str):
+    json_files = list(filter(lambda x: x.endswith(".json"), os.listdir(result_dir)))
+    assert len(json_files), f"Can't find result json files in directory {result_dir}"
+    return os.path.join(result_dir, sorted(json_files)[-1])
+
+def get_delta_str(reference: float, current: float) -> str:
+    delta_num = ((current - reference) / current * 100)
+    delta_str = "{:+3f}".format(delta_num) + "%"
+    if (abs(delta_num) >= 5):
+        delta_str = delta_str + "*"
+    return delta_str
+
+def get_means(data):
+    rc = dict()
+    for param in data["benchmarks"]:
+        name = param["name"]
+        mean = param["stats"]["mean"]
+        rc[name] = mean
+    return rc
+
+def analyze_abtest_result_dir(result_dir: str):
+    dirs = [ os.path.join(result_dir, name) for name in os.listdir(result_dir) if os.path.isdir(os.path.join(result_dir, name)) ]
+    delta = False
+    # If there are only two directories, we believe it is abtest and print delta of the mean
+    if len(dirs) == 2:
+        delta = True
+    json_files = list(map(find_latest_json_file, dirs))
+    out = [['Benchmark']]
+    assert(len(json_files))
+    with open(json_files[0], "r") as fp:
+        cur_result = json.load(fp)
+        means = get_means(cur_result)
+    for key in means:
+        out.append([])
+        out[-1].append(key)
+    for index, json_file in enumerate(json_files):
+        with open(json_file, "r") as fp:
+            jsonobj = json.load(fp)
+        header = f"Run {os.path.basename(json_file)}"
+        out[0].append(header)
+        means = get_means(jsonobj)
+        if delta and index == 0:
+            reference = means
+        for key_index, key in enumerate(means):
+            out[key_index+1].append(means[key])
+            if delta and index == 1:
+                out[0].append("Delta")
+                out[key_index+1].append(get_delta_str(reference[key], means[key]))
+    out_str = tabulate(out, headers='firstrow')
+    return out_str
+
+class Commit:
+    sha: str
+    ctime: str
+    digest: Dict[str, float]
+    def __init__(self, sha, ctime):
+        self.sha = sha
+        self.ctime = ctime
+        self.digest = None
+    def __str__(self):
+        return self.sha
+
+class TorchSource:
+    srcpath: str
+    commits: List[Commit]
+    # Map from commit SHA to index in commits
+    commit_dict: Dict[str, int]
+    def __init__(self, srcpath: str):
+        self.srcpath = srcpath
+        self.commits = []
+        self.commit_dict = dict()
+
+    def prep(self) -> bool:
+        repo_origin_url = gitutils.get_git_origin(self.srcpath)
+        if not repo_origin_url == TORCH_GITREPO:
+            print(f"WARNING: Unmatched repo origin url: {repo_origin_url} with standard {TORCH_GITREPO}")
+        return True
+    
+    # Get all commits between start and end, save them in self.commits
+    def init_commits(self, start: str, end: str) -> bool:
+        commits = gitutils.get_git_commits(self.srcpath, start, end)
+        if not commits or len(commits) < 2:
+            print(f"Failed to retrieve commits from {start} to {end} in {self.srcpath}.")
+            return False
+        for count, commit in enumerate(commits):
+            ctime = gitutils.get_git_commit_date(self.srcpath, commit)
+            self.commits.append(Commit(sha=commit, ctime=ctime))
+            self.commit_dict[commit] = count
+        return True
+    
+    def get_mid_commit(self, left: Commit, right: Commit) -> Optional[Commit]:
+        left_index = self.commit_dict[left.sha]
+        right_index = self.commit_dict[right.sha]
+        if right_index == left_index + 1:
+            return None
+        else:
+            return self.commits[int((left_index + right_index) / 2)]
+
+    def setup_build_env(self, env):
+        env["USE_CUDA"] = "1"
+        env["BUILD_CAFFE2_OPS"] = "0"
+        env["USE_XNNPACK"] = "0"
+        env["USE_MKLDNN"] = "1"
+        env["USE_MKL"] = "1"
+        env["USE_CUDNN"] = "1"
+        env["CMAKE_PREFIX_PATH"] = env["CONDA_PREFIX"]
+        return env
+
+    # Checkout the last commit of dependencies on date
+    def checkout_deps(self, cdate: datetime):
+        for pkg in TORCHBENCH_DEPS:
+            dep_commit = gitutils.get_git_commit_on_date(TORCHBENCH_DEPS[pkg], cdate)
+            print(f"Checking out {pkg} commit {dep_commit} ...", end="", flush=True)
+            assert dep_commit, "Failed to find the commit on {cdate} of {pkg}"
+            assert gitutils.checkout_git_commit(TORCHBENCH_DEPS[pkg], dep_commit), "Failed to checkout commit {commit} of {pkg}"
+            print("done.")
+    
+    # Install dependencies such as torchaudio, torchtext and torchvision
+    def build_install_deps(self, build_env):
+        # Build torchvision
+        print(f"Building torchvision ...", end="", flush=True)
+        command = "python setup.py install &> /dev/null"
+        subprocess.check_call(command, cwd=TORCHBENCH_DEPS["torchvision"], env=build_env, shell=True)
+        print("done")
+        # Build torchaudio
+        print(f"Building torchaudio ...", end="", flush=True)
+        command = "python setup.py install &> /dev/null"
+        subprocess.check_call(command, cwd=TORCHBENCH_DEPS["torchaudio"], env=build_env, shell=True)
+        print("done")
+        # Build torchtext
+        print(f"Building torchtext ...", end="", flush=True)
+        command = "python setup.py clean install &> /dev/null"
+        subprocess.check_call(command, cwd=TORCHBENCH_DEPS["torchtext"], env=build_env, shell=True)
+        print("done")
+ 
+    def build(self, commit: Commit):
+        # checkout pytorch commit
+        print(f"Checking out pytorch commit {commit.sha} ...", end="", flush=True)
+        gitutils.checkout_git_commit(self.srcpath, commit.sha)
+        print("done.")
+        # checkout pytorch deps commit
+        ctime = datetime.strptime(commit.ctime.split(" ")[0], "%Y-%m-%d")
+        self.checkout_deps(ctime)
+        # setup environment variables
+        build_env = self.setup_build_env(os.environ.copy())
+        # build pytorch
+        print(f"Building pytorch commit {commit.sha} ...", end="", flush=True)
+        # pytorch doesn't update version.py in incremental compile, so generate it manually
+        command = "python tools/generate_torch_version.py --is_debug on"
+        subprocess.check_call(command, cwd=self.srcpath, env=build_env, shell=True)
+        command = "python setup.py install &> /dev/null"
+        subprocess.check_call(command, cwd=self.srcpath, env=build_env, shell=True)
+        print("done")
+        self.build_install_deps(build_env)
+
+    def cleanup(self, commit: Commit):
+        print(f"Cleaning up packages from commit {commit.sha} ...", end="", flush=True)
+        packages = ["torch", "torchtext", "torchvision", "torchaudio"]
+        command = "pip uninstall -y " + " ".join(packages) + " &> /dev/null "
+        subprocess.check_call(command, shell=True)
+        print("done")
+
+class TorchBench:
+    srcpath: str # path to pytorch/benchmark source code
+    branch: str
+    timelimit: int # timeout limit in minutes
+    workdir: str
+    devbig: str
+    torch_src: TorchSource
+
+    def __init__(self, srcpath: str,
+                 torch_src: TorchSource,
+                 timelimit: int,
+                 workdir: str,
+                 devbig: str,
+                 branch: str = "0.1"):
+        self.srcpath = srcpath
+        self.torch_src = torch_src
+        self.timelimit = timelimit
+        self.workdir = workdir
+        self.devbig = devbig
+        self.branch = branch
+
+    def prep(self) -> bool:
+        # Verify the code in srcpath is pytorch/benchmark
+        repo_origin_url = gitutils.get_git_origin(self.srcpath)
+        if not repo_origin_url == TORCHBENCH_GITREPO:
+            print(f"WARNING: Unmatched repo origin url: {repo_origin_url} with standard {TORCHBENCH_GITREPO}")
+        return True
+ 
+    def run_benchmark(self, commit: Commit, targets: List[str]) -> str:
+        # Return the result json file path
+        output_dir = os.path.join(self.workdir, commit.sha)
+        # If the directory already exists, clear its contents
+        if os.path.exists(output_dir):
+            assert os.path.isdir(output_dir), "Must specify output directory: {output_dir}"
+            filelist = [ f for f in os.listdir(output_dir) ]
+            for f in filelist:
+                os.remove(os.path.join(output_dir, f))
+        else:
+            os.mkdir(output_dir)
+        bmfilter = targets_to_bmfilter(targets)
+        print(f"Running TorchBench for commit: {commit.sha}, filter {bmfilter} ...", end="", flush=True)
+        if not self.devbig:
+            command = f"""bash .github/scripts/run-v0.sh "{output_dir}" "{bmfilter}" &> {output_dir}/benchmark.log"""
+        else:
+            command = f"""bash .github/scripts/run-v0-devbig.sh  "{output_dir}" "{bmfilter}" "{self.devbig}" &> {output_dir}/benchmark.log"""
+        try:
+            subprocess.check_call(command, cwd=self.srcpath, shell=True, timeout=self.timelimit * 60)
+        except subprocess.TimeoutExpired:
+            print(f"Benchmark timeout for {commit.sha}. Result will be None.")
+            return output_dir
+        print("done.")
+        return output_dir
+
+    def gen_digest(self, result_dir: str, targets: List[str]) -> Dict[str, float]:
+        filelist = [ f for f in os.listdir(result_dir) if f.endswith(".json") ]
+        out = dict()
+        if not len(filelist):
+            print(f"Empty directory or json file in {result_dir}. Return empty digest.")
+            return out
+        # Use the first json as the benchmark data file
+        data_file = os.path.join(result_dir, filelist[0])
+        if not os.stat(data_file).st_size:
+            print(f"Empty json file {filelist[0]} in {result_dir}. Return empty digest.")
+            return out
+        with open(data_file, "r") as df:
+            data = json.load(df)
+        # Fill in targets if it is None
+        if targets == None:
+            targets = list()
+            for each in data["benchmarks"]:
+                targets.append(each["name"])
+        for each in data["benchmarks"]:
+            if each["name"] in targets:
+                out[each["name"]] = each["stats"]["mean"]
+        # Make sure all target tests are available
+        for target in targets:
+            assert out[target], f"Don't find benchmark result of {target} in {filelist[0]}."
+        return out
+
+    def get_digest(self, commit: Commit, targets: List[str], debug: bool) -> Dict[str, float]:
+        # digest is cached
+        if commit.digest is not None:
+            return commit.digest
+        # if debug mode, skip the build and benchmark run
+        if debug:
+            result_dir = os.path.join(self.workdir, commit.sha)
+            if os.path.isdir(result_dir):
+                filelist = [ f for f in os.listdir(result_dir) if f.endswith(".json") ]
+                if len(filelist):
+                    data_file = os.path.join(result_dir, filelist[0])
+                    if os.stat(data_file).st_size:
+                        commit.digest = self.gen_digest(result_dir, targets)
+                        return commit.digest
+        # Build pytorch and its dependencies
+        self.torch_src.build(commit)
+        # Run benchmark
+        result_dir = self.run_benchmark(commit, targets)
+        commit.digest = self.gen_digest(result_dir, targets)
+        self.torch_src.cleanup(commit)
+        return commit.digest
+        
+class TorchBenchBisection:
+    workdir: str
+    start: str
+    end: str
+    threshold: float
+    direction: str
+    targets: List[str]
+    # left commit, right commit, targets to test
+    bisectq: List[Tuple[Commit, Commit, List[str]]]
+    result: List[Tuple[Commit, Commit]]
+    torch_src: TorchSource
+    bench: TorchBench
+    output_json: str
+    debug: bool
+    abtest: bool
+
+    def __init__(self,
+                 workdir: str,
+                 torch_src: str,
+                 bench_src: str,
+                 start: str,
+                 end: str,
+                 threshold: float,
+                 direction: str,
+                 timeout: int,
+                 targets: List[str],
+                 output_json: str,
+                 devbig: str,
+                 debug: bool = False):
+        self.workdir = workdir
+        self.start = start
+        self.end = end
+        self.threshold = threshold
+        self.direction = direction
+        self.targets = targets
+        self.bisectq = list()
+        self.result = list()
+        self.torch_src = TorchSource(srcpath = torch_src)
+        self.bench = TorchBench(srcpath = bench_src,
+                                torch_src = self.torch_src,
+                                timelimit = timeout,
+                                devbig = devbig,
+                                workdir = self.workdir)
+        self.output_json = output_json
+        self.debug = debug
+        # Special treatment for abtest
+        self.abtest = False
+        if self.threshold == 100.0 and self.direction == "decrease":
+            self.abtest = True
+
+    # Left: older commit; right: newer commit
+    # Return: List of targets that satisfy the regression rule: <threshold, direction>
+    def regression(self, left: Commit, right: Commit, targets: List[str]) -> List[str]:
+        # If uncalculated, commit.digest will be None
+        assert left.digest, "Commit {left.sha} must have a digest"
+        assert right.digest, "Commit {right.sha} must have a digest"
+        out = []
+        for target in targets:
+            # digest could be empty if benchmark timeout
+            left_mean = left.digest[target] if len(left.digest) else 0
+            right_mean = right.digest[target] if len(right.digest) else 0
+            # If either left or right timeout, diff is 100. Otherwise use left_mean to calculate diff.
+            diff = abs(left_mean - right_mean) / left_mean * 100 if min(left_mean, right_mean) else 100
+            # If both timeout, diff is zero percent
+            diff = 0 if not max(left_mean, right_mean) else diff
+            print(f"Target {target}: left commit {left.sha} mean {left_mean} vs. right commit {right.sha} mean {right_mean}. Diff: {diff}.")
+            if diff >= self.threshold:
+                if self.direction == "increase" and left_mean < right_mean:
+                    # Time increase == performance regression
+                    out.append(target)
+                elif self.direction == "decrease" and left_mean > right_mean:
+                    # Time decrease == performance optimization
+                    out.append(target)
+                elif self.direction == "both":
+                    out.append(target)
+        return out
+
+    def prep(self) -> bool:
+        if not self.torch_src.prep():
+            return False
+        if not self.torch_src.init_commits(self.start, self.end):
+            return False
+        if not self.bench.prep():
+            return False
+        left_commit = self.torch_src.commits[0]
+        right_commit = self.torch_src.commits[-1]
+        self.bisectq.append((left_commit, right_commit, self.targets))
+        return True
+        
+    def run(self):
+        while len(self.bisectq):
+            (left, right, targets) = self.bisectq.pop(0)
+            self.bench.get_digest(left, targets, self.debug)
+            self.bench.get_digest(right, targets, self.debug)
+            if targets == None and len(left.digest):
+                targets = left.digest.keys()
+            if targets == None and len(right.digest):
+                targets = right.digest.keys()
+            updated_targets = self.regression(left, right, targets)
+            if len(updated_targets):
+                mid = self.torch_src.get_mid_commit(left, right)
+                if mid == None:
+                    self.result.append((left, right))
+                else:
+                    self.bisectq.append((left, mid, updated_targets))
+                    self.bisectq.append((mid, right, updated_targets))
+ 
+    def output(self):
+        json_obj = dict()
+        json_obj["start"] = self.start
+        json_obj["end"] = self.end
+        json_obj["threshold"] = self.threshold
+        json_obj["timeout"] = self.bench.timelimit
+        json_obj["torchbench_branch"] = self.bench.branch
+        json_obj["result"] = []
+        for res in self.result:
+            r = dict()
+            r["commit1"] = res[0].sha
+            r["commit1_time"] = res[0].ctime
+            r["commit1_digest"] = res[0].digest if len(res[0].digest) else "timeout"
+            r["commit2"] = res[1].sha
+            r["commit2_time"] = res[1].ctime
+            r["commit2_digest"] = res[1].digest if len(res[1].digest) else "timeout"
+            json_obj["result"].append(r)
+        with open(self.output_json, 'w') as outfile:
+            json.dump(json_obj, outfile, indent=2)
+
+    def output_abtest_result(self):
+        abtest_result = analyze_abtest_result_dir(self.workdir)
+        with open(self.output_json, 'w') as outfile:
+            outfile.write(abtest_result)
+        print(abtest_result)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir",
+                        help="bisection working directory",
+                        type=exist_dir_path)
+    parser.add_argument("--pytorch-src",
+                        help="the directory of pytorch source code git repository",
+                        type=exist_dir_path)
+    parser.add_argument("--torchbench-src",
+                        help="the directory of torchbench source code git repository",
+                        type=exist_dir_path)
+    parser.add_argument("--config",
+                        help="the bisection configuration in YAML format")
+    parser.add_argument("--output",
+                        help="the output json file")
+    parser.add_argument("--analyze-result",
+                        help="specify the the output result directory to analyze")
+    # running on devbig
+    parser.add_argument("--devbig",
+                        type=str,
+                        help="if running on devbig, specify the devbig conda env")
+    # by default, debug mode is disabled
+    parser.add_argument("--debug",
+                        help="run in debug mode, if the result json exists, use it directly",
+                        action='store_true')
+    args = parser.parse_args()
+
+    # If this is to print the overview of a test result, don't need to run the actual execution
+    if args.analyze_result:
+        print(analyze_abtest_result_dir(args.analyze_result))
+        exit(0)
+
+    with open(args.config, "r") as f:
+        bisect_config = yaml.full_load(f)
+    # sanity checks
+    valid_directions = ["increase", "decrease", "both"]
+    assert("start" in bisect_config), "Illegal bisection config, must specify start commit SHA."
+    assert("end" in bisect_config), "Illegal bisection config, must specify end commit SHA."
+    assert("threshold" in bisect_config), "Illegal bisection config, must specify threshold."
+    assert("direction" in bisect_config), "Illegal bisection config, must specify direction."
+    assert(bisect_config["direction"] in valid_directions), "We only support increase, decrease, or both directions"
+    assert("timeout" in bisect_config), "Illegal bisection config, must specify timeout."
+    targets = None
+    if "tests" in bisect_config:
+        targets = bisect_config["tests"]
+    
+    bisection = TorchBenchBisection(workdir=args.work_dir,
+                                    torch_src=args.pytorch_src,
+                                    bench_src=args.torchbench_src,
+                                    start=bisect_config["start"],
+                                    end=bisect_config["end"],
+                                    threshold=bisect_config["threshold"],
+                                    direction=bisect_config["direction"],
+                                    timeout=bisect_config["timeout"],
+                                    targets=targets,
+                                    output_json=args.output,
+                                    devbig=args.devbig,
+                                    debug=args.debug)
+    assert bisection.prep(), "The working condition of bisection is not satisfied."
+    print("Preparation steps ok. Commit to bisect: " + " ".join([str(x) for x in bisection.torch_src.commits]))
+    bisection.run()
+    if bisection.abtest:
+        bisection.output_abtest_result()
+    else:
+        bisection.output()

--- a/bisection.py
+++ b/bisection.py
@@ -90,7 +90,7 @@ def analyze_abtest_result_dir(result_dir: str):
     for index, json_file in enumerate(json_files):
         with open(json_file, "r") as fp:
             jsonobj = json.load(fp)
-        header = f"Run {os.path.basename(json_file)}"
+        header = f"Run {os.path.basename(os.path.dirname(json_file))}"
         out[0].append(header)
         means = get_means(jsonobj)
         if delta and index == 0:

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import torch
 from urllib import request
 import importlib
 

--- a/torchbenchmark/util/gitutils.py
+++ b/torchbenchmark/util/gitutils.py
@@ -1,0 +1,114 @@
+"""gitutils.py
+
+Utils for getting git-related information.
+"""
+
+import os
+import subprocess
+from datetime import datetime
+from typing import Optional, List
+
+def update_git_repo(repo: str, branch: str) -> bool:
+    try:
+        command = f"git pull origin {branch}"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except subprocess.CalledProcessError:
+        print(f"Failed to update git repo {repo}, branch {branch}")
+        return None
+
+def get_git_commit_on_date(repo: str, date: datetime) -> Optional[str]:
+    try:
+        # Get the first commit since date
+        formatted_date = date.strftime("%Y-%m-%d")
+        command = f"git log --until={formatted_date} -1 --oneline | cut -d ' ' -f 1"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except subprocess.CalledProcessError:
+        print(f"Failed to get the last commit on date {formatted_date} in repo {repo}")
+        return None
+ 
+def check_git_exist_local_branch(repo: str, branch: str) -> bool:
+    command = f"git rev-parse --verify {branch} &> /dev/null "
+    retcode = subprocess.call(command, cwd=repo, shell=True)
+    return (retcode == 0)
+
+def get_git_commit_date(repo: str, commit: str) -> str:
+    try:
+        command = f"git show -s --format=%ci {commit}"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except subprocess.CalledProcessError:
+        print(f"Failed to get date of commit {commit} in repo {repo}")
+        return None
+    
+def checkout_git_branch(repo: str, branch: str) -> bool:
+    try:
+        if check_git_exist_local_branch(repo, branch):
+            command = f"git checkout {branch} &> /dev/null "
+        else:
+            command = f"git checkout --track origin/{branch} &> /dev/null"
+        retcode = subprocess.call(command, cwd=repo, shell=True)
+        return (retcode == 0)
+    except subprocess.CalledProcessError:
+        print(f"Failed to checkout git repo {repo}, branch {branch}")
+        return None
+
+def get_current_branch(repo: str) -> Optional[str]:
+    try:
+        command = "git branch --show-current"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except subprocess.CalledProcessError:
+        print(f"Failed to get current branch name for repo {repo}")
+        return None
+
+def get_git_origin(repo: str) -> Optional[str]:
+    try:
+        command = "git remote get-url origin"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except:
+        print(f"git command {command} returns non-zero status in repo {repo}")
+        return None
+
+def get_git_commits(repo: str, start: str, end: str) -> Optional[List[str]]:
+    try:
+        command = f"git log --reverse --oneline --ancestry-path {start}^..{end} | cut -d \" \" -f 1"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip().split("\n")
+        return out
+    except subprocess.CalledProcessError:
+        print(f"git command {command} returns non-zero status in repo {repo}")
+        return None
+
+def get_current_commit(repo: str) -> Optional[str]:
+    try:
+        command = f"git log --reverse --oneline -1 | cut -d \" \" -f 1"
+        out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()
+        return out
+    except subprocess.CalledProcessError:
+        print(f"Failed to get the current commit in repo {repo}")
+        return None
+
+def checkout_git_commit(repo: str, commit: str) -> bool:
+    try:
+        assert len(commit) != 0
+        command = f"git checkout {commit} &> /dev/null"
+        subprocess.run(command, cwd=repo, shell=True)
+        command = f"git submodule sync &> /dev/null && git submodule update --init --recursive &> /dev/null"
+        subprocess.run(command, cwd=repo, shell=True)
+        return True
+    except subprocess.CalledProcessError:
+        print(f"Failed to checkout commit f{commit} in repo {repo}")
+        return False
+
+def update_git_repo(repo: str) -> bool:
+    try:
+        command = "git checkout master && git pull origin master"
+        subprocess.run(command, cwd=repo, shell=True)
+        command = f"git submodule sync &> /dev/null && git submodule update --init --recursive &> /dev/null"
+        subprocess.run(command, cwd=repo, shell=True)
+        return True
+    except subprocess.CalledProcessError:
+        print(f"Failed to update git repo {repo}")
+        return False


### PR DESCRIPTION
This PR cherry-picks the bisector and devbig local abtest scripts from the 0.1 branch. So that people can local test models in the master branch.

Need to remove `import torch` from `__init__.py` because when running the bisector, pytorch is not compiled and installed yet.