### PR TITLE
Add PyTorch PR CI support

### DIFF
--- a/.github/scripts/run-bisection.sh
+++ b/.github/scripts/run-bisection.sh
@@ -43,5 +43,4 @@ python bisection.py --work-dir ${BISECT_BASE}/gh${GITHUB_RUN_ID} \
        --pytorch-src ${PYTORCH_SRC_DIR} \
        --torchbench-src ${TORCHBENCH_SRC_DIR} \
        --config ${BISECT_BASE}/config.yaml \
-       --output ${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json \
-       --debug
+       --output ${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json

--- a/bisection.py
+++ b/bisection.py
@@ -147,8 +147,11 @@ class TorchSource:
             assert gitutils.update_git_repo(repo), f"Failed to update master branch of {repo}."
 
     # Get all commits between start and end, save them in self.commits
-    def init_commits(self, start: str, end: str) -> bool:
-        commits = gitutils.get_git_commits(self.srcpath, start, end)
+    def init_commits(self, start: str, end: str, abtest: bool) -> bool:
+        if not abtest:
+            commits = gitutils.get_git_commits(self.srcpath, start, end)
+        else:
+            commits = [start, end]
         if not commits or len(commits) < 2:
             print(f"Failed to retrieve commits from {start} to {end} in {self.srcpath}.")
             return False
@@ -416,7 +419,7 @@ class TorchBenchBisection:
     def prep(self) -> bool:
         if not self.torch_src.prep():
             return False
-        if not self.torch_src.init_commits(self.start, self.end):
+        if not self.torch_src.init_commits(self.start, self.end, self.abtest):
             return False
         if not self.bench.prep():
             return False

--- a/bisection.py
+++ b/bisection.py
@@ -144,7 +144,7 @@ class TorchSource:
         repos.extend(TORCHBENCH_DEPS.values())
         for repo in repos:
             gitutils.clean_git_repo(repo)
-            assert gitutils.update_git_repo(repo, "master"), f"Failed to update master branch of {repo}."
+            assert gitutils.update_git_repo(repo), f"Failed to update master branch of {repo}."
 
     # Get all commits between start and end, save them in self.commits
     def init_commits(self, start: str, end: str) -> bool:

--- a/torchbenchmark/util/gitutils.py
+++ b/torchbenchmark/util/gitutils.py
@@ -8,7 +8,16 @@ import subprocess
 from datetime import datetime
 from typing import Optional, List
 
-def update_git_repo(repo: str, branch: str) -> bool:
+def clean_git_repo(repo: str) -> bool:
+    try:
+        command = f"git clean -xdf"
+        subprocess.check_call(command, cwd=repo, shell=True)
+        return True
+    except subprocess.CalledProcessError:
+        print(f"Failed to cleanup git repo {repo}")
+        return None
+
+def update_git_repo_branch(repo: str, branch: str) -> bool:
     try:
         command = f"git pull origin {branch}"
         out = subprocess.check_output(command, cwd=repo, shell=True).decode().strip()


### PR DESCRIPTION
This PR is to add TorchBench support in PyTorch CI.
It modifies bisection.py so that the bisector is also able to run abtests.
It also allows users to specify model names as test items. So model names like "yolov3" also works, not just "test_eval[yolov3-cpu-eager]".

This PR is the prerequisite of the TorchBench CI PR on PyTorch: https://github.com/pytorch/pytorch/pull/56957.