### PR TITLE
Relax the CPU frequency requirement.

### DIFF
--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -12,7 +12,7 @@ CONFIG_VER=v0
 CONFIG_DIR=${PWD}/torchbenchmark/score/configs/${CONFIG_VER}
 CONFIG_ENV=${CONFIG_DIR}/config-${CONFIG_VER}.env
 DATA_JSON_PREFIX=$(date +"%Y%m%d_%H%M%S")
-if [ -n "$1" ]; then
+if [ -z "$1" ]; then
     echo "You must specify output data dir"
     exit 1
 fi

--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -239,7 +239,7 @@ def set_pstate_frequency(min_freq = 2500, max_freq = 2500):
             write_sys_file(freq_paths[1], str(max_freq * 1000))
 
 def check_pstate_frequency_pin(pin_freq = 2500):
-    FREQ_THRESHOLD = 10  # Allow 10 MHz difference maximum
+    FREQ_THRESHOLD = 15  # Allow 15 MHz difference maximum
     all_freq = get_pstate_frequency()
     for cpuid in all_freq:
         for attr in all_freq[cpuid]:


### PR DESCRIPTION
In practice, the p-state driver often failed to pin the CPU frequency within the 10MHz threshold. We relax the threshold to 15MHz.

For example, I observe the following error message of the failed a few times (with no_turbo set to 1):

Specify frequency 2500 Mhz, find setting cpu30 scaling_cur_freq: 2489.495.
