### PR TITLE
Unify the label name with pytorch/pytorch.

### DIFF
--- a/.github/workflows/bisection.yml
+++ b/.github/workflows/bisection.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   bisection:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, bm-metal]
+    runs-on: [self-hosted, bm-runner]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/instruction-count.yml
+++ b/.github/workflows/instruction-count.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   run-benchmark:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, bm-metal]
+    runs-on: [self-hosted, bm-runner]
     env:
       SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run-benchmark:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, bm-metal]
+    runs-on: [self-hosted, bm-runner]
     env:
       SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   run-benchmark:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, bm-metal]
+    runs-on: [self-hosted, bm-runner]
     timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout


### PR DESCRIPTION
In pytorch/pytorch, we use the self-hosted runner with tag "bm-runner" (https://github.com/pytorch/pytorch/blob/master/.github/workflows/run_torchbench.yml#L16). This PR is to unify the runner label with pytorch/pytorch.

The runner is now shared on the pytorch organization level, so that jobs in both repostories (pytorch/benchmark and pytorch/pytorch) won't conflict and will run sequentially.