### PR TITLE
Fix the "a view of a leaf Variable that requires grad is being used" error when running yolov3 model.

### DIFF
--- a/torchbenchmark/models/yolov3/yolo_models.py
+++ b/torchbenchmark/models/yolov3/yolo_models.py
@@ -108,8 +108,8 @@ def create_modules(module_defs, img_size, cfg):
                 bias_ = module_list[j][0].bias  # shape(255,)
                 bias = bias_[:modules.no * modules.na].view(modules.na, -1)  # shape(3,85)
                 with torch.no_grad():  # avoids "requires grad is being used in an in-place operation"
-                    bias[:, 4] += -4.5  # obj
-                    bias[:, 5:] += math.log(0.6 / (modules.nc - 0.99))  # cls (sigmoid(p) = 1/nc)
+                    bias.data[:, 4] += -4.5  # obj
+                    bias.data[:, 5:] += math.log(0.6 / (modules.nc - 0.99))  # cls (sigmoid(p) = 1/nc)
                 module_list[j][0].bias = torch.nn.Parameter(bias_, requires_grad=bias_.requires_grad)
             except:
                 print('WARNING: smart bias initialization failure.')


### PR DESCRIPTION
When running yolov3 model on the latest pytorch nightly (20210519), the following error appears:

```
 what():  a view of a leaf Variable that requires grad is being used in an in-place operation.
Exception raised from check_inplace at /pytorch/torch/csrc/autograd/VariableTypeUtils.h:57 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x42 (0x7f44b041b302 in /home/ec2-user/anaconda3/envs/ghtest/lib/python3.7/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, char const*) + 0x5f (0x7f44b0417d6f in /home/ec2-user/anaconda3/envs/ghtest/lib/python3.7/site-packages/torch/lib/libc10.so)
frame #2: <unknown function> + 0x302fb89 (0x7f44f61d8b89 in /home/ec2-user/anaconda3/envs/ghtest/lib/python3.7/site-packages/torch/lib/libtorch_cpu.so)

Fatal Python error: Aborted

Current thread 0x00007f451141f740 (most recent call first):
  File "/home/ec2-user/xz-use/benchmark/torchbenchmark/models/yolov3/yolo_models.py", line 111 in create_modules
  File "/home/ec2-user/xz-use/benchmark/torchbenchmark/models/yolov3/yolo_models.py", line 226 in __init__
  File "/home/ec2-user/xz-use/benchmark/torchbenchmark/models/yolov3/__init__.py", line 54 in get_module
  File "/home/ec2-user/xz-use/benchmark/torchbenchmark/models/yolov3/__init__.py", line 76 in eval
```

This PR applies a fix similar to https://github.com/ultralytics/yolov5/pull/1759/files that fixes this problem.