### PR TITLE
Revert to use CUDA 11.1 supported by pytorch nightly.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Install Conda
           command: ./scripts/install_basics.sh
       - run:
-          name: Install CUDA 11.2
+          name: Install CUDA 11.1
           command: sudo ./scripts/install_cuda.sh
       - run:
           name: Install PyTorch nightly

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -8,22 +8,22 @@ wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
 sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
 nvidia-smi
 
-echo "Installing CUDA 11.2 and CuDNN"
-rm -rf /usr/local/cuda-11.2 /usr/local/cuda
+echo "Installing CUDA 11.1 and CuDNN"
+rm -rf /usr/local/cuda-11.1 /usr/local/cuda
 # install CUDA 11.1 in the same container
 # CUDA download archive: https://developer.nvidia.com/cuda-toolkit-archive
-CUDA_INSTALLER=cuda_11.2.2_460.32.03_linux.run
-wget -q https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/$CUDA_INSTALLER
+CUDA_INSTALLER=cuda_11.1.1_455.32.00_linux.run
+wget -q https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/$CUDA_INSTALLER
 chmod +x $CUDA_INSTALLER
 ./$CUDA_INSTALLER --toolkit --silent
 rm -f ${CUDA_INSTALLER}
-rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.2 /usr/local/cuda
+rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.1 /usr/local/cuda
 
-# install CUDA 11.2 CuDNN
+# install CUDA 11.1 CuDNN 8.0.4
 # cuDNN download archive: https://developer.nvidia.com/rdp/cudnn-archive
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 mkdir tmp_cudnn && cd tmp_cudnn
-wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.1.0/cudnn-11.2-linux-x64-v8.1.0.77.tgz -O cudnn-8.0.tgz
+wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.4/cudnn-11.1-linux-x64-v8.0.4.30.tgz -O cudnn-8.0.tgz
 tar xf cudnn-8.0.tgz
 cp -a cuda/include/* /usr/local/cuda/include/
 cp -a cuda/lib64/* /usr/local/cuda/lib64/

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -8,4 +8,5 @@ conda activate base
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
 pip install -q numpy
 pip install --pre torch torchvision torchtext \
+    --progress-bar off \
     -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -7,5 +7,5 @@ conda activate base
 # conda install -y pytorch torchvision -c pytorch-nightly
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
 pip install -q numpy
-pip install -q --pre torch torchvision torchtext \
+pip install --pre torch torchvision torchtext \
     -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -8,4 +8,4 @@ conda activate base
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
 pip install -q numpy
 pip install -q --pre torch torchvision torchtext \
-    -f https://download.pytorch.org/whl/nightly/cu112/torch_nightly.html
+    -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html


### PR DESCRIPTION
Revert to use CUDA 11.1 because of the official pytorch nightly build target only supports CUDA 11.1.