### PR TITLE
Preload the data to train_data in __init__ for Background_Matting

### DIFF
--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -55,7 +55,7 @@ class Model(BenchmarkModel):
             traindata, batch_size=self.opt.batch_size, shuffle=True, num_workers=self.opt.batch_size, collate_fn=_collate_filter_none)
         self.train_data = []
         for data in train_loader:
-            self.train_data.append(data)
+            self.train_data.append(data.to(device))
 
         netB = ResnetConditionHR(input_nc=(
             3, 3, 1, 4), output_nc=4, n_blocks1=self.opt.n_blocks1, n_blocks2=self.opt.n_blocks2)

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -55,7 +55,9 @@ class Model(BenchmarkModel):
             traindata, batch_size=self.opt.batch_size, shuffle=True, num_workers=self.opt.batch_size, collate_fn=_collate_filter_none)
         self.train_data = []
         for data in train_loader:
-            self.train_data.append(data.to(device))
+            self.train_data.append(data)
+            for key in data:
+                data[key].to(device)
 
         netB = ResnetConditionHR(input_nc=(
             3, 3, 1, 4), output_nc=4, n_blocks1=self.opt.n_blocks1, n_blocks2=self.opt.n_blocks2)

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -145,23 +145,19 @@ class Model(BenchmarkModel):
             bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
 
-            if self.device == 'cuda':
-                bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg.cuda()), Variable(image.cuda()), Variable(
-                    seg.cuda()), Variable(multi_fr.cuda()), Variable(seg_gt.cuda()), Variable(back_rnd.cuda())
-                mask0 = Variable(torch.ones(seg.shape).cuda())
-            else:
-                bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(
-                    image), Variable(seg), Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
-                mask0 = Variable(torch.ones(seg.shape))
+            bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(image), Variable(seg),
+            Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
 
             tr0 = time.time()
 
             # pseudo-supervision
             alpha_pred_sup, fg_pred_sup = self.netB(image, bg, seg, multi_fr)
             if self.device == 'cuda':
+                mask0 = Variable(torch.ones(seg.shape).cuda())
                 mask = (alpha_pred_sup > -0.98).type(torch.cuda.FloatTensor)
                 mask1 = (seg_gt > 0.95).type(torch.cuda.FloatTensor)
             else:
+                mask0 = Variable(torch.ones(seg.shape))
                 mask = (alpha_pred_sup > -0.98).type(torch.FloatTensor)
                 mask1 = (seg_gt > 0.95).type(torch.FloatTensor)
 

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -148,18 +148,23 @@ class Model(BenchmarkModel):
             bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
 
-            bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(image), Variable(seg), Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
+            if self.device == 'cuda':
+                bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg.cuda()), Variable(image.cuda()), Variable(
+                    seg.cuda()), Variable(multi_fr.cuda()), Variable(seg_gt.cuda()), Variable(back_rnd.cuda())
+                mask0 = Variable(torch.ones(seg.shape).cuda())
+            else:
+                bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(
+                    image), Variable(seg), Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
+                mask0 = Variable(torch.ones(seg.shape))
 
             tr0 = time.time()
 
             # pseudo-supervision
             alpha_pred_sup, fg_pred_sup = self.netB(image, bg, seg, multi_fr)
             if self.device == 'cuda':
-                mask0 = Variable(torch.ones(seg.shape).cuda())
                 mask = (alpha_pred_sup > -0.98).type(torch.cuda.FloatTensor)
                 mask1 = (seg_gt > 0.95).type(torch.cuda.FloatTensor)
             else:
-                mask0 = Variable(torch.ones(seg.shape))
                 mask = (alpha_pred_sup > -0.98).type(torch.FloatTensor)
                 mask1 = (seg_gt > 0.95).type(torch.FloatTensor)
 

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -147,8 +147,7 @@ class Model(BenchmarkModel):
             bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
 
-            bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(image), Variable(seg),
-            Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
+            bg, image, seg, multi_fr, seg_gt, back_rnd = Variable(bg), Variable(image), Variable(seg), Variable(multi_fr), Variable(seg_gt), Variable(back_rnd)
 
             tr0 = time.time()
 

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -56,8 +56,9 @@ class Model(BenchmarkModel):
         self.train_data = []
         for data in train_loader:
             self.train_data.append(data)
-            for key in data:
-                data[key].to(device)
+            if device == 'cuda':
+                for key in data:
+                    data[key].cuda()
 
         netB = ResnetConditionHR(input_nc=(
             3, 3, 1, 4), output_nc=4, n_blocks1=self.opt.n_blocks1, n_blocks2=self.opt.n_blocks2)


### PR DESCRIPTION
The idea of torchbenchmark is to measure the computation intensive part of a model. Therefore, we should move the data loading process from `train()` to `__init__` to avoid measuring the data loading speed.

Fixes #388 