### PR TITLE
Fix pytorch_struct broken by more strict in-place operation restrictions

### DIFF
--- a/torchbenchmark/models/pytorch_struct/torch_struct/helpers.py
+++ b/torchbenchmark/models/pytorch_struct/torch_struct/helpers.py
@@ -15,8 +15,9 @@ class Get(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         (grad_chart,) = ctx.saved_tensors
-        grad_chart[ctx.indices] += grad_output
-        return grad_chart, None, None
+        grad_chart_clone = grad_chart.clone()
+        grad_chart_clone[ctx.indices] += grad_output
+        return grad_chart_clone, None, None
 
 
 class Set(torch.autograd.Function):


### PR DESCRIPTION
Recent CI fails because pytorch restricts the usage of in-place operations. This PR fixes the failure by using copy of data structures instead of in-place operations.