### PR TITLE
Generate the bisection config and publish to the github actions artifact

### DIFF
--- a/.github/scripts/generate-abtest-config.py
+++ b/.github/scripts/generate-abtest-config.py
@@ -1,0 +1,109 @@
+"""
+This script reads from a PyTorch benchmarking directory and generates a yaml file
+that drives the bisector to run tests on the specified PyTorch commits.
+This only works on V1 benchmark, V0 is not supported.
+"""
+import os
+import json
+import yaml
+import argparse
+import dataclasses
+from pathlib import Path
+
+# We will generate bisection config for tests with performance change > 7%
+PERF_CHANGE_THRESHOLD = 7
+# Timeout of the bisection job in hours
+PERF_TEST_TIMEOUT_THRESHOLD = 120
+
+@dataclasses.dataclass
+class PyTorchVer:
+    version: str
+    commit: str
+
+def exist_dir_path(string):
+    if os.path.isdir(string):
+        return string
+    else:
+        raise NotADirectoryError(string)
+
+def find_latest_nonempty_json(path):
+    json_files = list(filter(lambda x: x.endswith(".json"), os.listdir(result_dir)))
+    json_files.sort(reverse=True)
+    for f in json_files:
+        # Return the first non-empty json file
+        json_path = os.path.join(result_dir, f)
+        if os.path.exists(json_path) and os.stat(json_path).st_size:
+            return json_path
+    print(f"Can't find non-empty json files in path: {result_dir}")
+    return None
+
+def get_pytorch_version(json_path):
+    with open(json_path, "r") as json_obj:
+        bm_result = json.load(json_obj)
+    pytorch_ver = PyTorchVer()
+    pytorch_ver.version = bm_result["machine_info"]["pytorch_version"]
+    pytorch_ver.commit = bm_result["machine_info"]["pytorch_git_version"]
+
+# Compare the tests and generate a list of tests whose perf change larger than threshold
+def generate_bisection_tests(base, tip):
+    def get_test_stats(bm):
+        ret = {}
+        for benchmark in bm["benchmarks"]:
+            name = benchmark["name"]
+            ret[name] = benchmark["stats"]["mean"]
+    base_tests = get_test_stats(base)
+    tip_tests = get_test_stats(tip)
+    result = []
+    for benchmark in tip_tests:
+        tip_latency = tip_tests[benchmark]
+        base_latency = base_tests[benchmark]
+        if abs(tip_latency - base_latency) / base_latency >= PERF_CHANGE_THRESHOLD:
+            result.append(benchmark)
+    return result
+
+def generate_bisection_config(base_file, tip_file):
+    result = {}
+    with open(base_file, "r") as bf:
+        base = json.load(bf)
+    with open(tip_file, "r") as tf:
+        tip = json.load(tf)
+    result["start_version"] = base["machine_info"]["pytorch_version"]
+    result["start"] = base["machine_info"]["pytorch_git_version"]
+    result["end_version"] = base["machine_info"]["pytorch_version"]
+    result["end"] = tip["machine_info"]["pytorch_git_version"]
+    result["threshold"] = PERF_CHANGE_THRESHOLD
+    result["direction"] = "both"
+    result["timeout"] = PERF_TEST_TIMEOUT_THRESHOLD
+    result["tests"] = generate_bisection_tests(base, tip)
+    return result
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark-dir",
+                        required=True,
+                        help="PyTorch benchmark result directory",
+                        type=exist_dir_path)
+    parser.add_argument("--out",
+                        required=True,
+                        help="Result output file")
+    args = parser.parse_args()
+    # input directory
+    input_dir = Path(args.benchmark_dir)
+    tip_json_file = find_latest_nonempty_json(input_dir)
+    assert tip_json_file, "The input benchmark directory must contains non-empty json file"
+    tip_version = get_pytorch_version(input_json_file)
+    parent_dir = input_dir.parent
+    all_benchmark_dirs = [ name for name in os.listdir(parent_dir) if os.path.isdir(os.path.join(parent_dir, name)) ]
+    all_benchmark_dirs.sort(reverse=True)
+    result = {}
+    # Search from the latest to the earliest
+    # Use the latest benchmark result with a different version than tip
+    for bm in all_benchmark_dirs:
+        json_file = find_latest_nonempty_json(bm)
+        if json_file:
+            base_version = get_pytorch_version(json_file)
+            if base_version.commit != tip_version.commit:
+                result = generate_bisection_config(json_file, tip_json_file)
+                break
+    with open(args.out, "w") as fo:
+        yaml.dump(result, fo)

--- a/.github/workflows/v0-bisection.yml
+++ b/.github/workflows/v0-bisection.yml
@@ -11,7 +11,7 @@ jobs:
   bisection:
     env:
       BISECT_CONDA_ENV: "bisection-ci-v0"
-      BISECT_DIR: ".torchbench/bisection-v0"
+      BISECT_DIR: ".torchbench/v0-bisection-ci"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
     steps:

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -11,7 +11,7 @@ jobs:
   bisection:
     env:
       BISECT_CONDA_ENV: "bisection-ci-v1"
-      BISECT_DIR: ".torchbench/bisection-v1"
+      BISECT_DIR: ".torchbench/v1-bisection-ci"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
     steps:

--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -47,6 +47,12 @@ jobs:
         run: |
           . activate "${CONDA_ENV_NAME}"
           bash ./.github/scripts/run.sh "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}"
+      - name: Generate the bisection config
+        run: |
+          . activate "${CONDA_ENV_NAME}"
+          python ./.github/scripts/generate-abtest-config.py \
+                 --benchmark-dir "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}" \
+                 --out "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}/bisection.yaml"
       - name: Copy artifact and upload to scribe
         run: |
           . activate "${CONDA_ENV_NAME}"
@@ -63,12 +69,14 @@ jobs:
           python compute_score.py --score_version v1 --benchmark_data_file "${LATEST_RESULT}" > "${SCORE_FILE}"
           # Upload result to Scribe
           python scripts/upload_scribe.py --pytest_bench_json "${LATEST_RESULT}" --torchbench_score_file "${SCORE_FILE}"
-          cp "${LATEST_RESULT}" ./benchmark-result-v1-${TODAY}.json
+          mkdir -p benchmark-output
+          cp "${LATEST_RESULT}" ./benchmark-output/benchmark-result-v1-${TODAY}.json
+          cp "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}/bisection.yaml" ./benchmark-output/bisection-v1-%{TODAY}.yaml
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: Benchmark result
-          path: benchmark-result-v1-*.json
+          path: benchmark-output/
       - name: Destroy conda env
         run: |
           conda env remove --name "${CONDA_ENV_NAME}"

--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -71,7 +71,7 @@ jobs:
           python scripts/upload_scribe.py --pytest_bench_json "${LATEST_RESULT}" --torchbench_score_file "${SCORE_FILE}"
           mkdir -p benchmark-output
           cp "${LATEST_RESULT}" ./benchmark-output/benchmark-result-v1-${TODAY}.json
-          cp "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}/bisection.yaml" ./benchmark-output/bisection-v1-%{TODAY}.yaml
+          cp "${HOME}/${OUTPUT_DIR}/gh${GITHUB_RUN_ID}/bisection.yaml" ./benchmark-output/bisection-v1-${TODAY}.yaml
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/bisection.py
+++ b/bisection.py
@@ -409,8 +409,8 @@ class TorchBenchBisection:
             # digest could be empty if benchmark timeout
             left_mean = left.digest[target] if len(left.digest) else 0
             right_mean = right.digest[target] if len(right.digest) else 0
-            # If either left or right timeout, diff is 100. Otherwise use left_mean to calculate diff.
-            diff = abs(left_mean - right_mean) / left_mean * 100 if min(left_mean, right_mean) else 100
+            # If either left or right timeout, diff is 100. Otherwise use the min mean value to calculate diff.
+            diff = abs(left_mean - right_mean) / min(left_mean, right_mean) * 100 if min(left_mean, right_mean) else 100
             # If both timeout, diff is zero percent
             diff = 0 if not max(left_mean, right_mean) else diff
             print(f"Target {target}: left commit {left.sha} mean {left_mean} vs. right commit {right.sha} mean {right_mean}. Diff: {diff}.")


### PR DESCRIPTION
This is the first step of automating the bisection process.
At the end of the nightly job, we will analyze the result with the previous run, find tests whose performance changes over a threshold, and regard it as a performance signal.

The maintainer can use the bisection config generated to start the bisector.