### PR TITLE
Catch stdout and stderr to provide debug info when installs fail (and fix install)

### DIFF
--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -6,7 +6,12 @@ conda activate base
 
 # conda install -y pytorch torchvision -c pytorch-nightly
 # Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
-pip install -q numpy
+
 pip install --pre torch torchvision torchtext \
     --progress-bar off \
     -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
+
+pip install -q numpy
+
+# Log final configuration
+pip freeze

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -1,9 +1,11 @@
+import io
 import os
 from pathlib import Path
 import subprocess
 import sys
 from urllib import request
 import importlib
+import tempfile
 from typing import Any, List, Tuple
 
 proxy_suggestion = "Unable to verify https connectivity, " \
@@ -31,20 +33,27 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
         'cwd': model_path,
         'check': True,
     }
+
+    output_buffer = None
+    _, stdout_fpath = tempfile.mkstemp()
     try:
+        output_buffer = io.FileIO(stdout_fpath, mode="w")
         if os.path.exists(os.path.join(model_path, install_file)):
             if not verbose:
                 run_kwargs['stderr'] = subprocess.STDOUT
-                run_kwargs['stdout'] = subprocess.PIPE
+                run_kwargs['stdout'] = output_buffer
             subprocess.run(*run_args, **run_kwargs)  # type: ignore
         else:
-            return (False, f"No install.py is found in {model_path}.")
+            return (False, f"No install.py is found in {model_path}.", None)
     except subprocess.CalledProcessError as e:
-        return (False, e.output)
+        return (False, e.output, io.FileIO(stdout_fpath, mode="r").read().decode())
     except Exception as e:
-        return (False, e)
+        return (False, e, io.FileIO(stdout_fpath, mode="r").read().decode())
+    finally:
+        del output_buffer
+        os.remove(stdout_fpath)
 
-    return (True, None)
+    return (True, None, None)
 
 
 def _list_model_paths() -> List[str]:
@@ -60,7 +69,7 @@ def setup(verbose: bool = True, continue_on_fail: bool = False) -> bool:
     failures = {}
     for model_path in _list_model_paths():
         print(f"running setup for {model_path}...", end="", flush=True)
-        success, errmsg = _install_deps(model_path, verbose=verbose)
+        success, errmsg, stdout_stderr = _install_deps(model_path, verbose=verbose)
         if success:
             print("OK")
         else:
@@ -69,16 +78,27 @@ def setup(verbose: bool = True, continue_on_fail: bool = False) -> bool:
                 errmsg = errmsg.decode()
             except Exception:
                 pass
+
+            # If the install was very chatty, we don't want to overwhelm.
+            # This will not affect verbose mode, which does not catch stdout
+            # and stderr.
+            log_lines = (stdout_stderr or "").splitlines(keepends=False)
+            if len(log_lines) > 40:
+                log_lines = log_lines[:20] + ["..."] + log_lines[-20:]
+                stdout_stderr = "\n".join(log_lines)
+
+            if stdout_stderr:
+                errmsg = f"{stdout_stderr}\n\n{errmsg or ''}"
+
             failures[model_path] = errmsg
             if not continue_on_fail:
                 break
-    if verbose and len(failures):
-        for model_path in failures:
-            print(f"Error for {model_path}:")
-            print("---------------------------------------------------------------------------")
-            print(failures[model_path])
-            print("---------------------------------------------------------------------------")
-            print()
+    for model_path in failures:
+        print(f"Error for {model_path}:")
+        print("---------------------------------------------------------------------------")
+        print(failures[model_path])
+        print("---------------------------------------------------------------------------")
+        print()
 
     return len(failures) == 0
 


### PR DESCRIPTION
Right now `attention_is_all_you_need_pytorch` is broken in CI, but we don't know why. This PR makes the install script more helpful by catching output from the subprocess, and displaying it when the install fails for a particular model. Notably, the line
```
OSError: /.../site-packages/torchtext/_torchtext.so: undefined symbol: _ZNK3c104Type14isSubtypeOfExtESt10shared_ptrIS0_EPSo
```
does a lot to narrow down what's going on. (And why the failure is platform specific.) Also let me grep out https://github.com/pytorch/glow/issues/5713.

**EDIT:** Looks like the issue is that we're installing TorchText 0.8, whereas the current version is 0.11

**EDIT 2:** It seems NumPy was forcing TorchText to an early version. Installing NumPy after torch/torchvision/torchtext allows torchtext nightly to be installed, and fixes the binary incompatibility.

#### Before:
```
running setup for /home/circleci/project/torchbenchmark/models/attention_is_all_you_need_pytorch...FAIL
Traceback (most recent call last):
  File "install.py", line 37, in <module>
    raise RuntimeError("Failed to complete setup")
RuntimeError: Failed to complete setup
```

#### After:
```
running setup for /home/circleci/project/torchbenchmark/models/attention_is_all_you_need_pytorch...FAIL
Error for /home/circleci/project/torchbenchmark/models/attention_is_all_you_need_pytorch:
---------------------------------------------------------------------------
Collecting en_core_web_sm==2.3.1
  Downloading https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz (12.0 MB)
Requirement already satisfied: spacy<2.4.0,>=2.3.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from en_core_web_sm==2.3.1) (2.3.5)
Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (4.61.2)
Requirement already satisfied: requests<3.0.0,>=2.13.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (2.25.1)
Requirement already satisfied: blis<0.8.0,>=0.4.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (0.7.4)
Requirement already satisfied: catalogue<1.1.0,>=0.0.7 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (1.0.0)
Requirement already satisfied: setuptools in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (52.0.0.post20210125)
Requirement already satisfied: plac<1.2.0,>=0.9.6 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (1.1.3)
Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (3.0.5)
Requirement already satisfied: srsly<1.1.0,>=1.0.2 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (1.0.5)
Requirement already satisfied: wasabi<1.1.0,>=0.4.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (0.8.2)
Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (1.0.5)
Requirement already satisfied: thinc<7.5.0,>=7.4.1 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (7.4.5)
Requirement already satisfied: numpy>=1.15.0 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (1.21.1)
Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /home/circleci/miniconda3/lib/python3.7/site-packages (from spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (2.0.5)
Requirement already satisfied: importlib-metadata>=0.20 in /home/circleci/miniconda3/lib/python3.7/site-packages (from catalogue<1.1.0,>=0.0.7->spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (4.6.3)
Requirement already satisfied: zipp>=0.5 in /home/circleci/miniconda3/lib/python3.7/site-packages (from importlib-metadata>=0.20->catalogue<1.1.0,>=0.0.7->spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (3.5.0)
Requirement already satisfied: typing-extensions>=3.6.4 in /home/circleci/miniconda3/lib/python3.7/site-packages (from importlib-metadata>=0.20->catalogue<1.1.0,>=0.0.7->spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (3.10.0.0)
Requirement already satisfied: idna<3,>=2.5 in /home/circleci/miniconda3/lib/python3.7/site-packages (from requests<3.0.0,>=2.13.0->spacy<2.4.0,>=2.3.0->en_core_web_sm==2.3.1) (2.10)
...
Traceback (most recent call last):
  File "preprocess.py", line 13, in <module>
    import torchtext.data
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torchtext/__init__.py", line 40, in <module>
    _init_extension()
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torchtext/__init__.py", line 36, in _init_extension
    torch.ops.load_library(ext_specs.origin)
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torch/_ops.py", line 107, in load_library
    ctypes.CDLL(path)
  File "/home/circleci/miniconda3/lib/python3.7/ctypes/__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /home/circleci/miniconda3/lib/python3.7/site-packages/torchtext/_torchtext.so: undefined symbol: _ZNK3c104Type14isSubtypeOfExtESt10shared_ptrIS0_EPSo
Traceback (most recent call last):
  File "install.py", line 19, in <module>
    preprocess()
  File "install.py", line 12, in preprocess
    subprocess.check_call([sys.executable, 'preprocess.py', '-lang_src', 'de', '-lang_trg', 'en', '-share_vocab', '-save_data', 'm30k_deen_shr.pkl'])
  File "/home/circleci/miniconda3/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/circleci/miniconda3/bin/python', 'preprocess.py', '-lang_src', 'de', '-lang_trg', 'en', '-share_vocab', '-save_data', 'm30k_deen_shr.pkl']' returned non-zero exit status 1.


---------------------------------------------------------------------------

Traceback (most recent call last):
  File "install.py", line 37, in <module>
    raise RuntimeError("Failed to complete setup")
RuntimeError: Failed to complete setup
```