### PR TITLE
Address broken CUDA cases in TorchBench

### DIFF
--- a/torchbenchmark/models/hf_DistilBert/__init__.py
+++ b/torchbenchmark/models/hf_DistilBert/__init__.py
@@ -40,6 +40,11 @@ class Model(BenchmarkModel):
     def train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
+
+        if self.device == "cuda":
+            # TODO: diagnose and re-enable.
+            raise NotImplementedError("This leads to a cudaErrorIllegalAddress from unique_by_key.")
+
         self.model.train()
         for _ in range(niter):
             outputs = self.model(**self.train_inputs)
@@ -73,4 +78,3 @@ if __name__ == "__main__":
     m.eval(niter=1)
     torch.cuda.synchronize()
     print(time.time()-begin)
-    

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -74,12 +74,11 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
         root = str(Path(yolo_train.__file__).parent.absolute())
-        train_args = split(f"--data {root}/data/coco128.data --img 416 --batch 8 --nosave --notest --epochs 1 --device {self.device} --weights ''")
+        train_args = split(f"--data {root}/data/coco128.data --img 416 --batch 8 --nosave --notest --epochs 1 --device {self.device_str} --weights ''")
         print(train_args)
         training_loop = prepare_training_loop(train_args)
 
         return training_loop(niterations)
-
 
     def eval(self, niterations=1):
         model, example_inputs = self.get_module()
@@ -90,6 +89,14 @@ class Model(BenchmarkModel):
             # Apply NMS
             pred = non_max_suppression(pred, 0.3, 0.6,
                                     multi_label=False, classes=None, agnostic=False)
+
+    @property
+    def device_str(self):
+        """YoloV3 uses individual GPU indices."""
+        return str(
+            torch.cuda.current_device() if self.device == "cuda"
+            else self.device
+        )
 
 if __name__ == '__main__':
     m = Model(device='cpu', jit=False)


### PR DESCRIPTION
There are two issues with TorchBench CUDA right now:
1) YoloV3 is misconfigured, and is failing for a simple reason.
2) hf_DistilBert is failing and contaminating the GPU.

(1) is easy to solve, and I do so here. (2) needs to be diagnosed, but this should restore most of the models while we do. (Process isolation will make it moot, but it's still WIP)