### PR TITLE
make run.sh log verbose

### DIFF
--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -42,7 +42,8 @@ echo "Running benchmark with filter: \"${BENCHMARK_FILTER}\""
 for c in $(seq 1 $NUM_ITER); do
     taskset -c "${CORE_LIST}" pytest test_bench.py -k "${BENCHMARK_FILTER}" \
             --benchmark-min-rounds "${NUM_ROUNDS}" \
-            --benchmark-json ${DATA_DIR}/${DATA_JSON_PREFIX}_${c}.json
+            --benchmark-json ${DATA_DIR}/${DATA_JSON_PREFIX}_${c}.json \
+            --verbose
     # Fill in circle_build_num and circle_project_reponame
     jq --arg run_id "${GITHUB_RUN_ID}" --arg config_version "githubactions-benchmark-${CONFIG_VER}-metal-fullname" \
        '.machine_info.circle_project_name=$config_version | .machine_info.circle_build_num=$run_id' \


### PR DESCRIPTION
CI is failing with no indication of why. I think it might be as simple as "now that SubprocessWorker" catches stdout and stderr logging info is less frequent and the runner is pulling the plug after a long time of no output. Even if that's not the case, this will at least narrow down where it's failing.