### PR TITLE
BERT_pytorch: Increase corpus and batch for adequate gpu utilization

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -157,7 +157,7 @@ class Model(BenchmarkModel):
         self.is_next = example_batch['is_next'].to(self.device)[:INFERENCE_BATCH_SIZE]
         self.bert_label = example_batch['bert_label'].to(self.device)[:INFERENCE_BATCH_SIZE]
         if args.script:
-            bert = torch.jit.script(bert, example_inputs=[self.example_inputs, ])
+            bert = torch.jit.script(bert, [self.example_inputs, ])
 
     def get_module(self):
         return self.trainer.model, self.example_inputs

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
@@ -7,6 +7,7 @@ QUIET = True
 
 
 class BERTDataset(Dataset):
+
     def __init__(self, corpus_path, vocab, seq_len, encoding="utf-8", corpus_lines=None, on_memory=True, generator = None):
         self.vocab = vocab
         self.seq_len = seq_len
@@ -16,8 +17,12 @@ class BERTDataset(Dataset):
         self.corpus_path = corpus_path
         self.encoding = encoding
 
-        with generator as f:
+        # For use as benchmark we only accept data from generator
         #with open(corpus_path, "r", encoding=encoding) as f:
+
+        assert generator != None
+        with generator as f:
+
             if self.corpus_lines is None and not on_memory:
                 for _ in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines, disable=QUIET):
                     self.corpus_lines += 1

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/dataset/dataset.py
@@ -7,7 +7,7 @@ QUIET = True
 
 
 class BERTDataset(Dataset):
-    def __init__(self, corpus_path, vocab, seq_len, encoding="utf-8", corpus_lines=None, on_memory=True):
+    def __init__(self, corpus_path, vocab, seq_len, encoding="utf-8", corpus_lines=None, on_memory=True, generator = None):
         self.vocab = vocab
         self.seq_len = seq_len
 
@@ -16,7 +16,8 @@ class BERTDataset(Dataset):
         self.corpus_path = corpus_path
         self.encoding = encoding
 
-        with open(corpus_path, "r", encoding=encoding) as f:
+        with generator as f:
+        #with open(corpus_path, "r", encoding=encoding) as f:
             if self.corpus_lines is None and not on_memory:
                 for _ in tqdm.tqdm(f, desc="Loading Dataset", total=corpus_lines, disable=QUIET):
                     self.corpus_lines += 1
@@ -101,6 +102,7 @@ class BERTDataset(Dataset):
             return t1, self.get_random_line(), 0
 
     def get_corpus_line(self, item):
+
         if self.on_memory:
             return self.lines[item][0], self.lines[item][1]
         else:


### PR DESCRIPTION
Uses parameterized generated random corpus instead of giant file. Profile corresponds with running actual 620mb trained model.

<eval, train>
On gpu: <30ms, 150ms>
On cpu: <4.1s, 8.3s>