### PR TITLE
change resnet50 benchmark batch size from 1 to 32

### DIFF
--- a/torchbenchmark/models/resnet50/__init__.py
+++ b/torchbenchmark/models/resnet50/__init__.py
@@ -54,7 +54,7 @@ class Model(BenchmarkModel):
     def eval(self, niter=1):
         model = self.eval_model
         example_inputs = self.example_inputs
-        example_inputs = example_inputs[0][0].unsqueeze(0)
+        example_inputs = example_inputs[0]
         for i in range(niter):
             model(example_inputs)
 


### PR DESCRIPTION
Based on analysis of gpu throughput against batch size, change resnet50 benchmark batch size to 32 to better utilize gpu. 

Edit: This was Will's aws node and I forgot to change the git credentials to be mine. Don't think I can change the commit now so will just submit this. 