### PR TITLE
Check the build of last two days instead of one.

### DIFF
--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pyver", type=str, default="cp37", help="PyTorch Python version")
     parser.add_argument("--platform", type=str, default="linux_x86_64", help="PyTorch platform")
-    parser.add_argument("--priordays", type=int, default=0, help="Number of days")
+    parser.add_argument("--priordays", type=int, default=1, help="Number of days")
     parser.add_argument("--reverse", action="store_true", help="Return reversed result")
     parser.add_argument("--packages", required=True, type=str, nargs="+", help="List of package names")
     args = parser.parse_args()


### PR DESCRIPTION
This is because the CI machine uses UTC, and it may run the workflow when the latest pytorch nightly package is not yet available. In this case, we would still like to run the latest build.