### PR TITLE
Add test to verify models and inputs are using the expected device

### DIFF
--- a/test.py
+++ b/test.py
@@ -83,10 +83,21 @@ def _load_test(path, device):
             except NotImplementedError:
                 self.skipTest('Method eval is not implemented, skipping...')
 
+    def check_device_fn(self):
+        task = ModelTask(path, timeout=TIMEOUT)
+        with task.watch_cuda_memory(skip=(device != "cuda"), assert_equal=self.assertEqual):
+            try:
+                task.make_model_instance(device=device, jit=False)
+                task.check_device()
+                task.del_model_instance()
+            except NotImplementedError:
+                self.skipTest('Method check_device is not implemented, skipping...')
+
     name = os.path.basename(path)
     setattr(TestBenchmark, f'test_{name}_example_{device}', example)
     setattr(TestBenchmark, f'test_{name}_train_{device}', train)
     setattr(TestBenchmark, f'test_{name}_eval_{device}', eval_fn)
+    setattr(TestBenchmark, f'test_{name}_check_device_{device}', check_device_fn)
 
 
 def _load_tests():

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -340,7 +340,7 @@ class ModelTask(base_task.TaskBase):
                     # kernels and need not match device.
                     return
 
-                inputs_device = inputs[0].device.type
+                inputs_device = inputs.device.type
                 if inputs_device != current_device:
                     raise RuntimeError(f'Model {model_name} inputs were' \
                                        f' not set to the expected device' \

--- a/torchbenchmark/models/Super_SloMo/__init__.py
+++ b/torchbenchmark/models/Super_SloMo/__init__.py
@@ -55,7 +55,7 @@ class Model(BenchmarkModel):
         trainData = (frame0.to(device),
                      frameT.to(device),
                      frame1.to(device))
-        self.example_inputs = trainFrameIndex, *trainData
+        self.example_inputs = trainFrameIndex.to(self.device), *trainData
 
         if jit:
             self.module = torch.jit.script(self.module, example_inputs=[self.example_inputs, ])

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -82,7 +82,7 @@ class Model(BenchmarkModel):
         batches = []
 
         for i in range(4):
-          batches.append(torch.randn(self.opt.batch_size, 3, 224, 224))
+          batches.append(torch.randn(self.opt.batch_size, 3, 224, 224).to(self.device))
 
         def collate_fn(data):
             ind = data[0]

--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -18,29 +18,31 @@ from .nvtrain import DeepRecommenderTrainBenchmark
 from .nvinfer import DeepRecommenderInferenceBenchmark
 
 class Model(BenchmarkModel):
-  
+
   task = RECOMMENDATION.RECOMMENDATION
-  
+
   def __init__(self, device="cpu", jit=False):
     super().__init__()
-    self.device_name = device
+    self.device = device
     self.not_implemented_reason = "Implemented"
     self.eval_mode = True #default to inference
 
     if jit:
       self.not_implemented_reason = "Jit Not Supported"
 
-    elif self.device_name != "cpu" and self.device_name != "cuda":
+    elif self.device != "cpu" and self.device != "cuda":
       self.not_implemented_reason = "device type not supported"
 
-    elif self.device_name == "cuda" and torch.cuda.is_available() == False:
+    elif self.device == "cuda" and torch.cuda.is_available() == False:
       self.not_implemented_reason = "cuda not available on this device"
 
     else:
-      self.train_obj = DeepRecommenderTrainBenchmark(device = device, jit = jit)
-      self.infer_obj = DeepRecommenderInferenceBenchmark(device = device, jit = jit)
+      self.train_obj = DeepRecommenderTrainBenchmark(device = self.device, jit = jit)
+      self.infer_obj = DeepRecommenderInferenceBenchmark(device = self.device, jit = jit)
 
   def get_module(self):
+    # FIXME: This is not implemented.
+    raise NotImplementedError("deeprecommender is work in progress")
     if self.eval_mode:
         return lambda x: self.eval(), [0]
 
@@ -48,7 +50,7 @@ class Model(BenchmarkModel):
 
   def set_eval(self):
     self.eval_mode = True
-    
+
   def set_train(self):
     self.eval_mode = False
 
@@ -57,13 +59,13 @@ class Model(BenchmarkModel):
 
     for i in range(niter):
       self.train_obj.train(niter)
-  
+
   def eval(self, niter=1):
     self.check_implemented()
 
     for i in range(niter):
       self.infer_obj.eval(niter)
-    
+
   def check_implemented(self):
     if self.not_implemented_reason != "Implemented":
       raise NotImplementedError(self.not_implemented_reason)

--- a/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
-        self.model = EquationOfState().to(self.device)
+        self.model = EquationOfState().to(device=self.device)
         self.example_inputs = tuple(
             torch.from_numpy(x).to(self.device)
             for x in _generate_inputs(2 ** 22)

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -129,7 +129,7 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
-        self.model = IsoneutralMixing(self.device).to(self.device)
+        self.model = IsoneutralMixing(self.device).to(device=self.device)
         self.example_inputs = tuple(
             torch.from_numpy(x).to(self.device) for x in _generate_inputs(2 ** 22)
         )
@@ -146,7 +146,6 @@ class Model(BenchmarkModel):
         model, example_inputs = self.get_module()
         for i in range(niter):
             model(*example_inputs)
-
 
 if __name__ == "__main__":
     m = Model(device="cuda", jit=True)

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -147,7 +147,6 @@ class Model(BenchmarkModel):
 
 if __name__ == '__main__':
     m = Model(device='cuda', jit=False)
-    model = m.get_module()
     model, example_inputs = m.get_module()
     model(*example_inputs)
     m.train()

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -14,7 +14,7 @@ class Model(BenchmarkModel):
         self.model.model.to(self.device)
 
     def get_module(self):
-        return self.model.model, [SYNTHETIC_DATA[0].to(self.device), ]
+        return self.model.model, [SYNTHETIC_DATA[0], ]
 
     def set_train(self):
         # another model instance is used for training

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -11,9 +11,10 @@ class Model(BenchmarkModel):
         self.device = device
         self.jit = jit
         self.model = TTSModel(device=self.device)
+        self.model.model.to(self.device)
 
     def get_module(self):
-        return self.model.model, [SYNTHETIC_DATA[0], ]
+        return self.model.model, [SYNTHETIC_DATA[0].to(self.device), ]
 
     def set_train(self):
         # another model instance is used for training


### PR DESCRIPTION
The device attribute needs to be set in three locations: the BenchmarkModel,
the nn.Module model, and the model inputs. This test will verify that
the tensors and inputs are on the expected device set in BenchmarkModel.
Also, fix a few benchmark bugs where the device is incorrectly set.