### PR TITLE
nvidia_deeprecommender: increase gpu utilization

### DIFF
--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -41,12 +41,10 @@ class Model(BenchmarkModel):
       self.infer_obj = DeepRecommenderInferenceBenchmark(device = self.device, jit = jit)
 
   def get_module(self):
-    # FIXME: This is not implemented.
-    raise NotImplementedError("deeprecommender is work in progress")
     if self.eval_mode:
-        return lambda x: self.eval(), [0]
+       return self.infer_obj.rencoder, (self.infer_obj.toyinputs,)
 
-    return lambda x: self.train(), [0]
+    return self.train_obj.rencoder, (self.train_obj.toyinputs,)
 
   def set_eval(self):
     self.eval_mode = True


### PR DESCRIPTION
Existing test is too small to utilize gpu. Increase gpu utilization by increasing corpus and batch sizes.

New benchmark times on 3070 are:
cuda, eval:     5.9493
cuda, train:    33.4809
cpu, eval:   334.9028
cpu, train: 1,214.4854