### PR TITLE
Fix the bug in the V1 score calculation algorithm

### DIFF
--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   run-benchmark:
     env:
-      # Set to "v1-alpha" for testing. Will set it to "v1" in release.
-      TORCHBENCH_VER: "v1-alpha"
+      # Set to "v1-beta" for testing. Will set it to "v1" in release.
+      TORCHBENCH_VER: "v1-beta"
       CONFIG_VER: "v1"
       CONDA_ENV_NAME:  "torchbench-v1-nightly-ci"
       OUTPUT_DIR: ".torchbench/v1-nightly-ci"

--- a/.github/workflows/v1-sweep.yml
+++ b/.github/workflows/v1-sweep.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run-benchmark:
     env:
-      TORCHBENCH_VER: "v1-alpha"
+      TORCHBENCH_VER: "v1-beta"
       CONFIG_VER: "v1"
       SWEEP_DIR: ".torchbench/v1-sweep-ci"
       PYTHON_VER: "3.7"

--- a/torchbenchmark/score/compute_score_v1.py
+++ b/torchbenchmark/score/compute_score_v1.py
@@ -184,7 +184,7 @@ class TorchBenchScoreV1:
         (domain_weights, config_weights) = ref_weights
         for name in data:
             norm = data[name]['norm']
-            benchmark_score = domain_weights[name] * config_weights[name] * math.log(norm / ref[name]['norm'])
+            benchmark_score = domain_weights[name] * config_weights[name] * math.log(ref[name]['norm'] / norm)
             score += benchmark_score
         return math.exp(score)
 
@@ -203,7 +203,7 @@ class TorchBenchScoreV1:
         (domain_weights, _) = ref_weights
         for name in filter(lambda x: self.data_in_list(x, filters), data):
             norm = data[name]['norm']
-            benchmark_score = domain_weights[name] * math.log(norm / ref_norm[name]['norm'])
+            benchmark_score = domain_weights[name] * math.log(ref_norm[name]['norm'] / norm)
             score += benchmark_score
         return math.exp(score)
 


### PR DESCRIPTION
In V1 score, we are using the weighted geometric average of the latency speedups across all tests comparing with the reference execution. When the execution runs faster, we should get a higher perf score.
The `norm` variable is the test latency, and `ref_norm` stores the test latency of reference execution.