### PR TITLE
Increase the time limit for bisection job.

### DIFF
--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -14,6 +14,7 @@ jobs:
       BISECT_DIR: ".torchbench/v1-bisection-ci"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
+    timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Recent bisection job fails because of exceeded time limit. Increase the time limit so that those jobs can finish.