### PR TITLE
Add a ondemand CI to test GPU stability

### DIFF
--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -1,0 +1,64 @@
+import os
+import re
+import tabulate
+import argparse
+
+MAGIC_PREFIX = "STABLE_TEST_MODEL: "
+THRESHOLD = 7
+
+def _parse_pr_body(body):
+    magic_lines = list(filter(lambda x: MAGIC_PREFIX in x, body.splitlines()))
+    if len(magic_lines):
+        return magic_lines[0][len(MAGIC_PREFIX):].strip()
+
+def _parse_repeated_test_log(log, csv):
+    repeated_test_result = []
+    regex_keys = ["gpu", "cpu_dispatch", "cpu_total"]
+    regex_dict = {
+        "gpu": re.compile('GPU Time:\s*([0-9.]+) milliseconds'),
+        "cpu_dispatch": re.compile('CPU Dispatch Time:\s*([0-9.]+) milliseconds'),
+        "cpu_total": re.compile('CPU Total Wall Time:\s*([0-9.]+) milliseconds')
+    }
+    for line in log.splitlines():
+       matches = list(map(lambda x: None if not regex_dict[x].search(line) else regex_dict[x].search(line).groups(), regex_keys))
+       for x in range(len(matches)):
+           if matches[x]:
+               if x == 0:
+                   repeated_test_result.append({})
+               repeated_test_result[-1][regex_keys[x]] = float(matches[x][0])
+    print(_visualize_repeated_test_result(regex_keys, repeated_test_result, csv))
+    cpu_total_times = list(map(lambda x: x["cpu_total"], repeated_test_result))
+    return cpu_total_times
+
+def _visualize_repeated_test_result(keys, result, csv):
+    output = [["Run Number", "GPU Time", "CPU Dispatch Time", "Walltime"]]
+    for index, res in enumerate(result):
+        r = [index]
+        for k in keys:
+            r.append(str(res[k]))
+        output.append(r)
+    if not csv:
+        return tabulate.tabulate(output, headers='firstrow')
+    else:
+        return "\n".join(map(lambda x: ",".join(x), output))
+
+def _is_stable(total_times):
+    return ((max(total_times) - min(total_times)) / min(total_times) * 100) <= THRESHOLD
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pr-body", type=argparse.FileType("r"))
+    parser.add_argument("--log", type=argparse.FileType("r"))
+    parser.add_argument("--csv", action='store_true')
+    args = parser.parse_args()
+    if args.pr_body:
+        body = args.pr_body.read()
+        model = _parse_pr_body(body)
+        print(model)
+        return
+    if args.log:
+        log = args.log.read()
+        cpu_total_times = _parse_repeated_test_log(log, args.csv)
+        if not _is_stable(cpu_total_times):
+            print("GPU stability test failed. Please fix the model code and re-run the test.")
+            exit(1)

--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -55,7 +55,6 @@ if __name__ == "__main__":
         body = args.pr_body.read()
         model = _parse_pr_body(body)
         print(model)
-        return
     if args.log:
         log = args.log.read()
         cpu_total_times = _parse_repeated_test_log(log, args.csv)

--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -31,7 +31,7 @@ def _parse_repeated_test_log(log, csv):
     return cpu_total_times
 
 def _visualize_repeated_test_result(keys, result, csv):
-    output = [["Run Number", "GPU Time", "CPU Dispatch Time", "Walltime"]]
+    output = [["Run Number", "GPU Time", "CPU Dispatch Time", "Wall Time"]]
     for index, res in enumerate(result):
         r = [index]
         for k in keys:

--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -61,4 +61,3 @@ if __name__ == "__main__":
         if not _is_stable(cpu_total_times):
             print("GPU stability test failed. Please fix the model code and re-run the test.")
             exit(1)
-        print("GPU stability test pass!")

--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -61,3 +61,4 @@ if __name__ == "__main__":
         if not _is_stable(cpu_total_times):
             print("GPU stability test failed. Please fix the model code and re-run the test.")
             exit(1)
+        print("GPU stability test pass!")

--- a/.github/scripts/test-repeated-runs.py
+++ b/.github/scripts/test-repeated-runs.py
@@ -7,9 +7,9 @@ MAGIC_PREFIX = "STABLE_TEST_MODEL: "
 THRESHOLD = 7
 
 def _parse_pr_body(body):
-    magic_lines = list(filter(lambda x: MAGIC_PREFIX in x, body.splitlines()))
+    magic_lines = list(filter(lambda x: MAGIC_PREFIX == x[:len(MAGIC_PREFIX)], body.splitlines()))
     if len(magic_lines):
-        return magic_lines[0][len(MAGIC_PREFIX):].strip()
+        return magic_lines[-1][len(MAGIC_PREFIX):].strip()
 
 def _parse_repeated_test_log(log, csv):
     repeated_test_result = []

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -62,9 +62,11 @@ jobs:
             python run.py "${MODEL}" -t train -d cuda | tee -a "${TRAIN_LOG}"
           done
           # Check the stability of GPU tests
-          python ./.github/scripts/test-repeated-runs.py --log "${EVAL_LOG}"
-          python ./.github/scripts/test-repeated-runs.py --log "${TRAIN_LOG}"
+          python ./.github/scripts/test-repeated-runs.py --log "${EVAL_LOG}" && \
+                 echo "GPU stability test pass for inference!"
+          python ./.github/scripts/test-repeated-runs.py --log "${TRAIN_LOG}" && \
+                 echo "GPU stability test pass for train!"
       - name: Remove conda environment
         run: |
-          conda env remove --name "$BISECT_CONDA_ENV"
+          conda env remove --name "${CONDA_ENV}"
 

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -19,7 +19,7 @@ jobs:
       GPU_ID: "1"
       GPU_FREQ: "5001,900"
       REPEAT: "10"
-    if: ${{ github.repository_owner == 'pytorch' && (not pull_request || pull_request has )}}
+    if: ${{ (github.event.inputs.model || contains(github.event.pull_request.body, 'STABLE_TEST_MODEL:')) }}
     runs-on: [self-hosted, bm-runner]
     timeout-minutes: 120 # 2 hours
     steps:

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -1,0 +1,36 @@
+name: TorchBench GPU model stability test
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model Name"
+        required: true
+        default: "fastNLP_Bert"
+  pull_request:
+
+jobs:
+  stability_test:
+    env:
+      CONDA_ENV: "stability-test-ci"
+    if: ${{ github.repository_owner == 'pytorch' && (not pull_request || pull_request has )}}
+    runs-on: [self-hosted, bm-runner]
+    timeout-minutes: 120 # 2 hours
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create conda environment with pytorch nightly
+        run: |
+          conda create -y -n "$BISECT_CONDA_ENV" python=3.7
+          . activate "$BISECT_CONDA_ENV"
+          conda install -y numpy=1.17 requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six dataclasses tabulate gitpython
+          # Install pytorch nightly
+          conda install -y -c pytorch-nightly torchtext torchvision
+          # Install torchbench dependencies
+          python install.py
+      - name: Stability test
+        run: |
+          echo ""
+      - name: Remove conda environment
+        run: |
+          conda env remove --name "$BISECT_CONDA_ENV"
+

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -12,6 +12,13 @@ jobs:
   stability_test:
     env:
       CONDA_ENV: "stability-test-ci"
+      TEST_HOME: "/tmp/tb-stability-ci"
+      CUDA_VERSION: "cu102"
+      PR_BODY: ${{ github.event.pull_request.body }}
+      MODEL: ${{ github.event.inputs.model }}
+      GPU_ID: "1"
+      GPU_FREQ: "5001,900"
+      REPEAT: "10"
     if: ${{ github.repository_owner == 'pytorch' && (not pull_request || pull_request has )}}
     runs-on: [self-hosted, bm-runner]
     timeout-minutes: 120 # 2 hours
@@ -20,16 +27,42 @@ jobs:
         uses: actions/checkout@v2
       - name: Create conda environment with pytorch nightly
         run: |
-          conda create -y -n "$BISECT_CONDA_ENV" python=3.7
-          . activate "$BISECT_CONDA_ENV"
-          conda install -y numpy=1.17 requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six dataclasses tabulate gitpython
+          conda create -y -n "${CONDA_ENV}" python=3.7
+          . activate "${CONDA_ENV}"
+          conda install -y numpy=1.17 requests=2.22 ninja pyyaml mkl mkl-include setuptools \
+                           cmake cffi typing_extensions future six dataclasses tabulate gitpython
           # Install pytorch nightly
-          conda install -y -c pytorch-nightly torchtext torchvision
+          pip install --pre torch torchtext torchvision \
+          -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
           # Install torchbench dependencies
           python install.py
       - name: Stability test
         run: |
-          echo ""
+          mkdir -p "${TEST_HOME}"
+          if [ -z "${MODEL}" ] ; then
+             # Load PR to file
+             PR_BODY_FILE="${TEST_HOME}"/pr-body.txt
+             echo "${PR_BODY}" > "${PR_BODY_FILE}"
+             MODEL=`python ./.github/scripts/test-repeated-runs.py --pr-body "${PR_BODY_FILE}"`
+          fi
+          # Setup nvidia gpu frequency
+          sudo nvidia-persistenced --user "${USER}"
+          sudo nvidia-smi -pm  "${GPU_ID}"
+          sudo nvidia-smi -ac "${GPU_FREQ}"
+          # Run the tests
+          EVAL_LOG="${TEST_HOME}/eval-${MODEL}.log"
+          echo -n > "${EVAL_LOG}"
+          for $i in `seq 1 ${REPEAT}`; do
+            python run.py "${MODEL}" -t eval -d cuda >> "${EVAL_LOG}"
+          done
+          TRAIN_LOG="${TEST_HOME}/train-${MODEL}.log"
+          echo -n > "${TRAIN_LOG}"
+          for $i in `seq 1 ${REPEAT}`; do
+            python run.py "${MODEL}" -t train -d cuda >> "${TRAIN_LOG}"
+          done
+          # Check the stability of GPU tests
+          python ./.github/scripts/test-repeated-runs.py "${EVAL_LOG}"
+          python ./.github/scripts/test-repeated-runs.py "${TRAIN_LOG}"
       - name: Remove conda environment
         run: |
           conda env remove --name "$BISECT_CONDA_ENV"

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -38,6 +38,7 @@ jobs:
           python install.py
       - name: Stability test
         run: |
+          . activate "${CONDA_ENV}"
           mkdir -p "${TEST_HOME}"
           if [ -z "${MODEL}" ] ; then
              # Load PR to file

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -52,13 +52,13 @@ jobs:
           # Run the tests
           EVAL_LOG="${TEST_HOME}/eval-${MODEL}.log"
           echo -n > "${EVAL_LOG}"
-          for $i in `seq 1 ${REPEAT}`; do
-            python run.py "${MODEL}" -t eval -d cuda >> "${EVAL_LOG}"
+          for i in `seq 1 ${REPEAT}`; do
+            python run.py "${MODEL}" -t eval -d cuda | tee "${EVAL_LOG}"
           done
           TRAIN_LOG="${TEST_HOME}/train-${MODEL}.log"
           echo -n > "${TRAIN_LOG}"
-          for $i in `seq 1 ${REPEAT}`; do
-            python run.py "${MODEL}" -t train -d cuda >> "${TRAIN_LOG}"
+          for i in `seq 1 ${REPEAT}`; do
+            python run.py "${MODEL}" -t train -d cuda | tee "${TRAIN_LOG}"
           done
           # Check the stability of GPU tests
           python ./.github/scripts/test-repeated-runs.py "${EVAL_LOG}"

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -47,7 +47,7 @@ jobs:
              MODEL=`python ./.github/scripts/test-repeated-runs.py --pr-body "${PR_BODY_FILE}"`
           fi
           # Setup nvidia gpu frequency
-          sudo nvidia-persistenced --user "${USER}"
+          sudo nvidia-persistenced --user "${USER}" || true
           sudo nvidia-smi -pm  "${GPU_ID}"
           sudo nvidia-smi -ac "${GPU_FREQ}"
           # Run the tests

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -53,16 +53,16 @@ jobs:
           EVAL_LOG="${TEST_HOME}/eval-${MODEL}.log"
           echo -n > "${EVAL_LOG}"
           for i in `seq 1 ${REPEAT}`; do
-            python run.py "${MODEL}" -t eval -d cuda | tee "${EVAL_LOG}"
+            python run.py "${MODEL}" -t eval -d cuda | tee -a "${EVAL_LOG}"
           done
           TRAIN_LOG="${TEST_HOME}/train-${MODEL}.log"
           echo -n > "${TRAIN_LOG}"
           for i in `seq 1 ${REPEAT}`; do
-            python run.py "${MODEL}" -t train -d cuda | tee "${TRAIN_LOG}"
+            python run.py "${MODEL}" -t train -d cuda | tee -a "${TRAIN_LOG}"
           done
           # Check the stability of GPU tests
-          python ./.github/scripts/test-repeated-runs.py "${EVAL_LOG}"
-          python ./.github/scripts/test-repeated-runs.py "${TRAIN_LOG}"
+          python ./.github/scripts/test-repeated-runs.py --log "${EVAL_LOG}"
+          python ./.github/scripts/test-repeated-runs.py --log "${TRAIN_LOG}"
       - name: Remove conda environment
         run: |
           conda env remove --name "$BISECT_CONDA_ENV"


### PR DESCRIPTION
This PR adds a new CI workflow that tests the stability of GPU tests.

If you specify a model name with prefix, a torchbench GPU model stability test will run and pass if the model works stably on the CI machine.

STABLE_TEST_MODEL: attention_is_all_you_need_pytorch