### PR TITLE
Fix mobilenet_v2 GPU utilization.

### DIFF
--- a/torchbenchmark/models/mobilenet_v2/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
 
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.mobilenet_v2().to(self.device)
         self.eval_model = models.mobilenet_v2().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":

--- a/torchbenchmark/models/mobilenet_v2/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
 
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=16):
         super().__init__()
         self.device = device
         self.jit = jit


### PR DESCRIPTION
# mobilenet_v2

### Eval
## batch size analysis
best batch size is 16
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 7.973 | 7.906 | 7.986 | -
2 | 7.578 | 7.515 | 7.587 | -0.04954220494
4 | 7.678 | 7.455 | 7.682 | 0.01319609396
8 | 11.774 | 9.156 | 11.778 | 0.5334722584
16 | 21.273 | 9.116 | 21.288 | 0.8067776457
32 | 40.116 | 7.314 | 40.12 | 0.8857706952
64 | 78.941 | 9.311 | 78.96 | 0.9678183269
128 | 155.825 | 8.057 | 155.838 | 0.9739425647

### non-idleness analysis (bs=16)
![image](https://user-images.githubusercontent.com/502017/140091950-4d21a16f-f176-4cf7-9f2a-e20166056322.png)


## Train
### batch size analysis
best batch size is 32
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 90.233 | 87.626 | 90.235 | -
2 | 105.711 | 104.197 | 105.714 | 0.1715336961
4 | 118.667 | 117.172 | 118.669 | 0.1225605661
8 | 152.167 | 149.58 | 152.168 | 0.2823025778
16 | 238.466 | 237.094 | 238.468 | 0.5671334783
32 | 423.704 | 421.364 | 423.699 | 0.7767899826
64 | 803.82 | 801.466 | 803.808 | 0.8971262957
128 | 1562.212 | 1559.868 | 1562.179 | 0.9434848598

### non-idleness analysis (bs=32)
![image](https://user-images.githubusercontent.com/502017/140091386-425947ee-fcb9-4962-8bec-3a48dadf65b6.png)
