### PR TITLE
Fix GPU utilization issue of mnasnet1_0 model

### DIFF
--- a/torchbenchmark/models/mnasnet1_0/__init__.py
+++ b/torchbenchmark/models/mnasnet1_0/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=1):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.mnasnet1_0().to(self.device)
         self.eval_model = models.mnasnet1_0().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":

--- a/torchbenchmark/models/mnasnet1_0/__init__.py
+++ b/torchbenchmark/models/mnasnet1_0/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=1):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit


### PR DESCRIPTION
# Eval

## Batch size scaling analysis

<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 10.641 | 10.578 | 10.651 | -
2 | 14.103 | 14.029 | 14.125 | 0.3253453623
4 | 12.626 | 12.562 | 12.637 | -0.1047294902
8 | 13.09 | 13.025 | 13.099 | 0.03674956439
16 | 17.455 | 13.184 | 17.46 | 0.333460657
32 | 31.719 | 13.723 | 31.724 | 0.8171870524
64 | 62.722 | 15.37 | 62.729 | 0.9774267789
128 | 124.82 | 13.802 | 124.824 | 0.9900513376

32 is the best bs

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140836088-3fc30e33-32e7-43e3-bcee-86eaf2523a42.png)

# Train

## Batch size scaling analysis

<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 117.221 | 116.833 | 117.224 | -
2 | 128.477 | 126.024 | 128.492 | 0.09602375001
4 | 153.92 | 151.295 | 153.919 | 0.198035446
8 | 192.844 | 190.238 | 192.844 | 0.2528846154
16 | 271.544 | 268.974 | 271.543 | 0.4081018855
32 | 446.159 | 443.637 | 446.152 | 0.6430449577
64 | 790.263 | 788.029 | 790.25 | 0.7712586768
128 | 1497.106 | 1494.919 | 1497.075 | 0.8944402053

32 is the best bs

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140836020-58a8d76c-8a2c-434d-979e-bca507314f85.png)

STABLE_TEST_MODEL: mnasnet1_0