### PR TITLE
Fix GPU utilization issue for resnet18

### DIFF
--- a/torchbenchmark/models/resnet18/__init__.py
+++ b/torchbenchmark/models/resnet18/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.resnet18().to(self.device)
         self.eval_model = models.resnet18().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":

--- a/torchbenchmark/models/resnet18/__init__.py
+++ b/torchbenchmark/models/resnet18/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=16, eval_bs=8):
         super().__init__()
         self.device = device
         self.jit = jit


### PR DESCRIPTION
# Eval

## Batch size analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 6.831 | 6.234 | 6.836 | -
2 | 8.134 | 7.741 | 8.138 | 0.1907480603
4 | 7.701 | 7.086 | 7.704 | -0.05323334153
8 | 12.355 | 9.24 | 12.362 | 0.6043370991
16 | 23.613 | 7.167 | 23.618 | 0.9112100364
32 | 43.685 | 7.124 | 43.698 | 0.8500402321
64 | 81.349 | 8.187 | 81.362 | 0.8621723704
128 | 157.381 | 8.117 | 157.389 | 0.9346396391

best bs = 8

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140838232-2ad04496-7211-4c61-8829-6763fd31f319.png)


# Train

## Batch size analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 63.873 | 59.249 | 63.877 | -
2 | 83.961 | 69.599 | 83.974 | 0.3144990841
4 | 116.895 | 77.58 | 116.897 | 0.3922535463
8 | 171.702 | 115.767 | 171.714 | 0.4688566662
16 | 289.856 | 192.566 | 289.855 | 0.6881340928
32 | 492.707 | 327.83 | 492.707 | 0.6998337105
64 | 974.338 | 648.937 | 974.34 | 0.9775201083
128 | 1879.526 | 1254.384 | 1879.521 | 0.9290287354

best bs=16

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140838274-deb937e7-9816-49ce-a81c-241382327f5e.png)



STABLE_TEST_MODEL: resnet18