### PR TITLE
Fix GPU utilization issue of resnext50_32x4d model

### DIFF
--- a/torchbenchmark/models/resnext50_32x4d/__init__.py
+++ b/torchbenchmark/models/resnext50_32x4d/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=8, eval_bs=8):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/resnext50_32x4d/__init__.py
+++ b/torchbenchmark/models/resnext50_32x4d/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.resnext50_32x4d().to(self.device)
         self.eval_model = models.resnext50_32x4d().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Eval

## Batch scaling analysis

<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 20.14 | 20.07 | 20.151 | -
2 | 21.968 | 21.886 | 21.98 | 0.09076464747
4 | 21.776 | 21.706 | 21.796 | -0.008739985433
8 | 39.197 | 24.668 | 39.202 | 0.8000091844
16 | 68.581 | 23.632 | 68.594 | 0.7496492078
32 | 135.644 | 26.935 | 135.663 | 0.9778655896
64 | 254.138 | 22.224 | 254.139 | 0.8735660995

best bs=8

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140841841-d51c448e-d08f-4e3b-9d5b-d5e7ccf43218.png)


# Train

## Batch scaling analysis

<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 198.385 | 190.304 | 198.387 | -
2 | 249.487 | 242.669 | 249.49 | 0.2575900396
4 | 369.653 | 361.657 | 369.65 | 0.4816523506
8 | 597.16 | 589.141 | 597.152 | 0.6154609864
16 | 1227.223 | 1220.652 | 1227.2 | 1.055099136
32 | 2417.154 | 2410.771 | 2417.101 | 0.9696126947
64 | 4719.082 | 4711.292 | 4718.974 | 0.9523298888

best bs=8

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140841927-cd47da6c-7f79-4521-a69b-5eab8ceca30f.png)


STABLE_TEST_MODEL: resnext50_32x4d