### PR TITLE
Fix GPU utilization issue for shufflenet_v2

### DIFF
--- a/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=128, eval_bs=64):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.shufflenet_v2_x1_0().to(self.device)
         self.eval_model = models.shufflenet_v2_x1_0().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Eval

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 12.282 | 12.219 | 12.293 | -
2 | 15.328 | 15.242 | 15.341 | 0.2480052109
4 | 15.686 | 15.614 | 15.7 | 0.0233559499
8 | 15.836 | 15.764 | 15.847 | 0.009562667347
16 | 15.36 | 15.275 | 15.371 | -0.03005809548
32 | 15.515 | 15.297 | 15.519 | 0.01009114583
64 | 25.573 | 15.644 | 25.596 | 0.6482758621
128 | 50.018 | 15.881 | 50.021 | 0.9558909788

best bs=64

## None-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140845002-393ddff1-82b7-466c-8849-34c19ee8c693.png)


# Train

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 123.335 | 123.266 | 123.347 | -
2 | 163.121 | 163.031 | 163.136 | 0.3225848299
4 | 130.795 | 130.185 | 130.797 | -0.1981719092
8 | 141.061 | 139.277 | 141.062 | 0.07848923889
16 | 201.191 | 199.659 | 201.19 | 0.4262694863
32 | 242.508 | 240.703 | 242.507 | 0.2053620689
64 | 345.422 | 343.727 | 345.419 | 0.4243736289
128 | 582.909 | 582.8 | 582.916 | 0.6875271407
256 | 1057.891 | 1056.498 | 1057.869 | 0.8148476006
512 | 2046.851 | 2046.696 | 2046.82 | 0.9348411131

best bs = 128

## None-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140845056-6a037377-0136-411d-b475-cebd186bcb7a.png)



STABLE_TEST_MODEL: shufflenet_v2_x1_0