### PR TITLE
Fix GPU utilization of squeezenet1_1

### DIFF
--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.squeezenet1_1().to(self.device)
         self.eval_model = models.squeezenet1_1().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=16):
         super().__init__()
         self.device = device
         self.jit = jit


### PR DESCRIPTION
# Eval

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 5.934 | 5.866 | 5.947 | -
2 | 5.197 | 5.137 | 5.21 | -0.1241995281
4 | 6.756 | 6.638 | 6.759 | 0.2999807581
8 | 7.276 | 6.92 | 7.278 | 0.07696862049
16 | 9.105 | 6.532 | 9.11 | 0.2513743815
32 | 16.915 | 6.467 | 16.92 | 0.8577704558
64 | 34.067 | 6.37 | 34.073 | 1.014011233
128 | 63.522 | 6.756 | 63.528 | 0.86461972

best bs = 16

## None-idleness analysis

![image](https://user-images.githubusercontent.com/502017/140850050-49498be8-70dc-4da9-a0d5-a651a7b52071.png)


# Train

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
8 | 96.5 | 66.418 | 96.504 | -
16 | 152.303 | 102.976 | 152.307 | 0.5782694301
32 | 250.614 | 169.743 | 250.627 | 0.6454961491
64 | 432.802 | 289.741 | 432.808 | 0.7269665701
128 | 750.789 | 502.3 | 750.799 | 0.73471703
256 | 1528.627 | 1022.245 | 1528.625 | 1.036027432
512 | 2970.462 | 1980.982 | 2970.422 | 0.9432222511

best bs = 64

## None-idleness analysis

![image](https://user-images.githubusercontent.com/502017/140850112-597c6b9c-38d1-4580-9f27-3e8b244ffea0.png)


STABLE_TEST_MODEL: squeezenet1_1