### PR TITLE
Fix GPU utilization issue of vgg16

### DIFF
--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=8, eval_bs=4):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.vgg16().to(self.device)
         self.eval_model = models.vgg16().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Eval

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 13.322 | 4.303 | 13.326 | -
2 | 21.55 | 3.821 | 21.553 | 0.6176249812
4 | 37.348 | 3.841 | 37.352 | 0.7330858469
8 | 71.241 | 4.125 | 71.254 | 0.9074916997
16 | 153.317 | 3.934 | 153.325 | 1.152089387
32 | 291.51 | 4.678 | 291.51 | 0.9013547095
64 | 631.886 | 5.115 | 631.904 | 1.167630613
128 | 1138.609 | 4.618 | 1138.614 | 0.8019215491

best bs=4

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140856496-a9ef0c7e-e886-4d45-9983-8fd9242f13ea.png)


# Train

## Batch scaling analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 328.723 | 133.978 | 328.722 | -
2 | 422.562 | 168.257 | 422.571 | 0.2854652702
4 | 609.029 | 261.781 | 609.038 | 0.4412772564
8 | 995.391 | 409.359 | 995.402 | 0.6343901522
16 | 1820.458 | 792.342 | 1820.451 | 0.8288873418
32 | 3368.939 | 1438.867 | 3368.897 | 0.8505996843
64 | 6409.849 | 2821.981 | 6409.767 | 0.9026313626
128 | 12717.985 | 5453.158 | 12717.686 | 0.9841317635

best bs=8

## Non-idleness analysis
![image](https://user-images.githubusercontent.com/502017/140856536-87056110-b168-46e7-80cd-e0c15d48d3ae.png)



STABLE_TEST_MODEL: vgg16