### PR TITLE
Fix GPU utilization issue of alexnet model

### DIFF
--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -15,7 +15,7 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
+    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=16):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -15,13 +15,14 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit
         self.model = models.alexnet().to(self.device)
         self.eval_model = models.alexnet().to(self.device)
-        self.example_inputs = (torch.randn((32, 3, 224, 224)).to(self.device),)
+        self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
+        self.infer_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -57,10 +58,9 @@ class Model(BenchmarkModel):
 
     def eval(self, niter=1):
         model = self.eval_model
-        example_inputs = self.example_inputs
-        example_inputs = example_inputs[0]
+        example_inputs = self.infer_example_inputs
         for i in range(niter):
-            model(example_inputs)
+            model(*example_inputs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Eval
## Batch size analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 2.853 | 1.844 | 2.857 | -
2 | 3.039 | 2.159 | 3.05 | 0.06519453207
4 | 4.43 | 2.173 | 4.434 | 0.4577163541
8 | 6.015 | 2.483 | 6.019 | 0.3577878104
16 | 9.807 | 2.562 | 9.809 | 0.6304239401
32 | 17.844 | 2.646 | 17.849 | 0.8195166718
64 | 29.399 | 2.715 | 29.404 | 0.6475566017
128 | 57.571 | 2.921 | 57.583 | 0.9582638865

best bs=16

## Profiling
![image](https://user-images.githubusercontent.com/502017/141001810-6805ef17-190c-4b76-b610-1ddbe40784ac.png)

# Train
## Batch size analysis
<google-sheets-html-origin>

Batch Size | GPU Time | CPU Dispatch Time | Walltime | GPU Delta
-- | -- | -- | -- | --
1 | 96.571 | 19.375 | 96.619 | -
2 | 106.011 | 24.047 | 106.036 | 0.0977519131
4 | 113.002 | 22.854 | 113.014 | 0.06594598674
8 | 131.276 | 24.553 | 131.301 | 0.161713952
16 | 168.657 | 22.563 | 168.7 | 0.2847512112
32 | 238.722 | 22.459 | 238.748 | 0.4154289475
64 | 372.982 | 24.158 | 373.005 | 0.5624115079
128 | 657.214 | 25.023 | 657.246 | 0.7620528605


best bs=64

## Profiling
![image](https://user-images.githubusercontent.com/502017/141002013-5c32b802-de1c-45c8-b06c-78cb83ec8b6d.png)

 
STABLE_TEST_MODEL: alexnet