### PR TITLE
Set torchtext version to 0.9 for models that use torchtext.legacy

### DIFF
--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
@@ -2,3 +2,4 @@ dill
 tqdm
 numpy
 spacy==2.3.5
+torchtext==0.9

--- a/torchbenchmark/models/pytorch_struct/requirements.txt
+++ b/torchbenchmark/models/pytorch_struct/requirements.txt
@@ -1,4 +1,4 @@
 torch
-torchtext
+torchtext==0.9
 dgl
 wandb


### PR DESCRIPTION
As we are deprecating `torchtext.legacy`, we would like to freeze the version of torchtext to 0.9 for models that will use `torchtext.legacy` package. 