### PR TITLE
Fix bug where check_device unit tests are skipped when get_module raises NotImplementedError

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -337,7 +337,13 @@ class ModelTask(base_task.TaskBase):
     @staticmethod
     def check_example() -> None:
         model = globals()["model"]
-        module, example_inputs = model.get_module()
+        try:
+            module, example_inputs = model.get_module()
+        except NotImplementedError:
+            # Raise an error for models without a get_module() implementation. Otherwise
+            # all the tests such as train, eval, and example will get skipped in unit testing.
+            raise RuntimeError('Missing get_module() implementation. Required for all models.')
+
         if isinstance(example_inputs, dict):
             # Huggingface models pass **kwargs as arguments, not *args
             module(**example_inputs)
@@ -357,9 +363,9 @@ class ModelTask(base_task.TaskBase):
         try:
             model, inputs = instance.get_module()
         except NotImplementedError:
-            # Skip this check_device for models without get_module() implementation. Otherwise
-            # all the tests such as train, eval, and example will also get skipped in test.py.
-            return
+            # Raise an error for models without a get_module() implementation. Otherwise
+            # all the tests such as train, eval, and example will get skipped in unit testing.
+            raise RuntimeError('Missing get_module() implementation. Required for all models.')
         model_name = getattr(model, 'name', None)
 
         # Check the model tensors are assigned to the expected device.

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -354,7 +354,12 @@ class ModelTask(base_task.TaskBase):
         if current_device is None:
             raise RuntimeError('Missing device in BenchmarkModel.')
 
-        model, inputs = instance.get_module()
+        try:
+            model, inputs = instance.get_module()
+        except NotImplementedError:
+            # Skip this check_device for models without get_module() implementation. Otherwise
+            # all the tests such as train, eval, and example will also get skipped in test.py.
+            return
         model_name = getattr(model, 'name', None)
 
         # Check the model tensors are assigned to the expected device.

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -340,8 +340,7 @@ class ModelTask(base_task.TaskBase):
         try:
             module, example_inputs = model.get_module()
         except NotImplementedError:
-            # Raise an error for models without a get_module() implementation. Otherwise
-            # all the tests such as train, eval, and example will get skipped in unit testing.
+            # Raise an error for models without a get_module() implementation.
             raise RuntimeError('Missing get_module() implementation. Required for all models.')
 
         if isinstance(example_inputs, dict):


### PR DESCRIPTION
Since we added the check_device() to each of the unit tests: example and
check_device, some unit tests are skipped when get_module() is
NotImplemented. This is because we catch NotImplemented in test.py.
We should catch it in check_device, and not skip the rest of the test.