### PR TITLE
Fix the fastNLP model train batch size.

### DIFF
--- a/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
+++ b/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
@@ -8,7 +8,7 @@ import json
 import random
 
 # Use the train batch size from the original CMRC2018 Q&A task
-# The example code is from https://fastnlp.readthedocs.io/zh/latest/tutorials/extend_1_bert_embedding.html
+# Source: https://fastnlp.readthedocs.io/zh/latest/tutorials/extend_1_bert_embedding.html
 TRAIN_BATCH_SIZE = 6
 EVAL_BATCH_SIZE = 1
 

--- a/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
+++ b/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
@@ -7,6 +7,8 @@ import pathlib
 import json
 import random
 
+# Use the train batch size from the original CMRC2018 Q&A task
+# The example code is from https://fastnlp.readthedocs.io/zh/latest/tutorials/extend_1_bert_embedding.html
 TRAIN_BATCH_SIZE = 6
 EVAL_BATCH_SIZE = 1
 

--- a/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
+++ b/torchbenchmark/models/fastNLP_Bert/cmrc2018_simulator.py
@@ -4,12 +4,10 @@ Use random Chinese characters with the same length as the original dataset.
 """
 import os
 import pathlib
-import numpy
 import json
 import random
-import fastNLP
 
-TRAIN_BATCH_SIZE = 1
+TRAIN_BATCH_SIZE = 6
 EVAL_BATCH_SIZE = 1
 
 CMRC2018_TRAIN_SPEC = {


### PR DESCRIPTION
In the documentation, the fastNLP Bert QA task uses batch size=6 for training. This PR fixes the correct train batch size.

Source:
https://fastnlp.readthedocs.io/zh/latest/tutorials/extend_1_bert_embedding.html

Original code:
`
trainer = Trainer(data_bundle.get_dataset('train'), model, loss=loss, optimizer=optimizer,
                  sampler=BucketSampler(seq_len_field_name='context_len'),
                  dev_data=data_bundle.get_dataset('dev'), metrics=metric,
                  callbacks=callbacks, device=device, batch_size=6, num_workers=2, n_epochs=2, print_every=1,
                  test_use_tqdm=False, update_every=10)
`