### PR TITLE
Set the correct train batch size for squeezenet.

### DIFF
--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -44,12 +44,6 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    # vision models have another model
-    # instance for inference that has
-    # already been optimized for inference
-    def set_eval(self):
-        pass
-
     def train(self, niter=1):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
@@ -66,11 +60,3 @@ class Model(BenchmarkModel):
         example_inputs = self.infer_example_inputs
         for i in range(niter):
             model(*example_inputs)
-
-
-if __name__ == "__main__":
-    m = Model(device="cuda", jit=True)
-    module, example_inputs = m.get_module()
-    module(*example_inputs)
-    m.train(niter=1)
-    m.eval(niter=1)

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -15,7 +15,9 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=16):
+    # Default train batch size is set to 512, which is batch_size (32) * iter_size (16)
+    # Source: https://github.com/forresti/SqueezeNet
+    def __init__(self, device=None, jit=False, train_bs=32, eval_bs=16):
         super().__init__()
         self.device = device
         self.jit = jit
@@ -46,7 +48,7 @@ class Model(BenchmarkModel):
     def set_eval(self):
         pass
 
-    def train(self, niter=3):
+    def train(self, niter=16):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -6,12 +6,6 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-#######################################################
-#
-#       DO NOT MODIFY THESE FILES DIRECTLY!!!
-#       USE `gen_torchvision_benchmarks.py`
-#
-#######################################################
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
@@ -44,7 +38,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
+    # Temporarily disable training because this will cause CUDA OOM in CI
+    # TODO: re-enable this test when better hardware is available
     def train(self, niter=1):
+        raise NotImplementedError("Temporarily disable training test because it causes CUDA OOM on T4")
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):


### PR DESCRIPTION
SqueezeNet uses default batch size of 512 for training. As running a 512 batch will usually cause CUDA OOM on a single GPU, we use a combination of `batch_size` and `iter_size` that multiply to 512 as a workaround.

Source: https://github.com/forresti/SqueezeNet