### PR TITLE
Only load the module specified in run.py argument

### DIFF
--- a/run.py
+++ b/run.py
@@ -146,10 +146,8 @@ if __name__ == "__main__":
         exit(-1)
 
     found = False
-    model_name = find_model_by_name(args.model)
-    if model_name:
-        Model = load_model(model_name)
-    else:
+    Model = load_model_by_name(args.model)
+    if not Model:
         print(f"Unable to find model matching {args.model}.")
         exit(-1)
 

--- a/run.py
+++ b/run.py
@@ -12,7 +12,7 @@ import argparse
 import time
 import torch.profiler as profiler
 
-from torchbenchmark import list_models
+from torchbenchmark import find_model_by_name, load_model
 import torch
 
 WARMUP_ROUNDS = 3
@@ -146,15 +146,14 @@ if __name__ == "__main__":
         exit(-1)
 
     found = False
-    for Model in list_models():
-        if args.model.lower() in Model.name.lower():
-            found = True
-            break
-    if found:
-        print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode.")
+    model_name = find_model_by_name(args.model)
+    if model_name:
+        Model = load_model(model_name)
     else:
         print(f"Unable to find model matching {args.model}.")
         exit(-1)
+
+    print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode.")
 
     # build the model and get the chosen test method
     if args.bs:

--- a/run.py
+++ b/run.py
@@ -12,7 +12,7 @@ import argparse
 import time
 import torch.profiler as profiler
 
-from torchbenchmark import find_model_by_name, load_model
+from torchbenchmark import load_model_by_name
 import torch
 
 WARMUP_ROUNDS = 3

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -470,7 +470,7 @@ def load_model_by_name(model):
     models = list(models)
     if not models:
         return None
-    assert len(models) == 1, f"Find more than one models {models} with the exact name: {model}"
+    assert len(models) == 1, f"Found more than one models {models} with the exact name: {model}"
     model_name = models[0]
     try:
         module = importlib.import_module(f'.models.{model_name}', package=__name__)

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -464,22 +464,12 @@ def list_models(model_match=None):
                 models.append(Model)
     return models
 
-def find_model_by_name(model):
-    """Find a model by its exact name"""
+def load_model_by_name(model):
     models = filter(lambda x: model.lower() == x.lower(),
                     map(lambda y: os.path.basename(y), _list_model_paths()))
     models = list(models)
     if not models:
         return None
-    else:
-        assert len(models) == 1, f"Find more than one models {models} with the exact name: {model}"
-        return models[0]
-
-def load_model(model):
-    loaded_models = []
-    models = filter(lambda x: model.lower() == x.lower(),
-                    map(lambda y: os.path.basename(y), _list_model_paths()))
-    models = list(models)
     assert len(models) == 1, f"Find more than one models {models} with the exact name: {model}"
     model_name = models[0]
     try:


### PR DESCRIPTION
When running `run.py`, it tries to read and load every model in the `models` directory even though we only need to run one specific model. In practice this often causes problems such as requiring to install `torchvision`/`torchtext` which are not required by the model we are attempting to run.

`run.py` should only load the specific model we are trying to run, instead of loading all the models.