### PR TITLE
[WIP] Raise RuntimeError when models are missing get_module() implementation

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -337,7 +337,13 @@ class ModelTask(base_task.TaskBase):
     @staticmethod
     def check_example() -> None:
         model = globals()["model"]
-        module, example_inputs = model.get_module()
+
+        try:
+            module, example_inputs = model.get_module()
+        except NotImplementedError:
+            # Raise an error for models without a get_module() implementation.
+            raise RuntimeError('Missing get_module() implementation. Required for all models.')
+
         if isinstance(example_inputs, dict):
             # Huggingface models pass **kwargs as arguments, not *args
             module(**example_inputs)
@@ -354,7 +360,12 @@ class ModelTask(base_task.TaskBase):
         if current_device is None:
             raise RuntimeError('Missing device in BenchmarkModel.')
 
-        model, inputs = instance.get_module()
+        try:
+            model, inputs = instance.get_module()
+        except NotImplementedError:
+            # Raise an error for models without a get_module() implementation.
+            raise RuntimeError('Missing get_module() implementation. Required for all models.')
+
         model_name = getattr(model, 'name', None)
 
         # Check the model tensors are assigned to the expected device.

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -26,7 +26,7 @@ class BenchmarkModel():
     A base class for adding models to torch benchmark.
     See [Adding Models](#../models/ADDING_MODELS.md)
     """
-    def __init__(self, *args, **kwargs): 
+    def __init__(self, *args, **kwargs):
         pass
 
     def train(self):
@@ -45,7 +45,11 @@ class BenchmarkModel():
         return True
 
     def _set_mode(self, train):
-        (model, _) = self.get_module()
+        try:
+            (model, _) = self.get_module()
+        except NotImplementedError:
+            # Raise an error for models without a get_module() implementation.
+            raise RuntimeError('Missing get_module() implementation. Required for all models.')
         model.train(train)
 
     def check_opt_vs_noopt_jit(self):
@@ -89,14 +93,14 @@ class BenchmarkModel():
                 raise RuntimeError("Encountered an supported type.\n" +
                     "Please add the type or override `bench_allclose`")
 
-       
+
         try:
             opt = model(*inputs)
         except Exception as e:
             print(e)
             warnings.warn(UserWarning(f"{model_name}.eval() doesn't support `check_results` yet!"))
             return
-        
+
         # disable optimizations and force a recompilation
         # to a baseline version
         fwd = model._c._get_method("forward")


### PR DESCRIPTION
Since, we call get_module in each of the unit tests: train, eval,
example, and check_device, the unit tests are skipped when get_module()
is Not Implemented. This is because we catch NotImplemented in test.py.
We should throw error when it is missing in any test.