### PR TITLE
Use the correct batch size for vgg16 training

### DIFF
--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -14,8 +14,8 @@ from torchbenchmark.tasks import COMPUTER_VISION
 #######################################################
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
-    optimized_for_inference = True
-    def __init__(self, device=None, jit=False, train_bs=8, eval_bs=4):
+
+    def __init__(self, device=None, jit=False, train_bs=256, eval_bs=4):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -15,9 +15,10 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
 
-    # Train batch size 256
+    # Original train batch size 256 on 4-GPU system
+    # Downscale to 64 to run on single GPU
     # Source: https://arxiv.org/pdf/1409.1556.pdf
-    def __init__(self, device=None, jit=False, train_bs=256, eval_bs=4):
+    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=4):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -15,11 +15,8 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
 
-<<<<<<< HEAD
-=======
     # Train batch size 256
     # Source: https://arxiv.org/pdf/1409.1556.pdf
->>>>>>> 7816c91 (Use batch size 256 in the paper for vgg16)
     def __init__(self, device=None, jit=False, train_bs=256, eval_bs=4):
         super().__init__()
         self.device = device

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -15,6 +15,11 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
 
+<<<<<<< HEAD
+=======
+    # Train batch size 256
+    # Source: https://arxiv.org/pdf/1409.1556.pdf
+>>>>>>> 7816c91 (Use batch size 256 in the paper for vgg16)
     def __init__(self, device=None, jit=False, train_bs=256, eval_bs=4):
         super().__init__()
         self.device = device


### PR DESCRIPTION
The batch size for train was set to 256. 
Source: https://arxiv.org/pdf/1409.1556.pdf