### PR TITLE
Support skipping tests on a blacklist in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -24,6 +24,10 @@ from torchbenchmark import _list_model_paths, ModelTask, get_metadata_from_yaml
 # unresponsive for 5 minutes the parent will presume it dead / incapacitated.)
 TIMEOUT = 300  # Seconds
 
+# Skip this list of unit tests. One reason may be that the original batch size
+# used in the paper is too large to fit on the CI's GPU.
+TRAIN_BLACKLIST = {("densenet121", "cuda")}
+
 
 class TestBenchmark(unittest.TestCase):
 
@@ -100,7 +104,8 @@ def _load_test(path, device):
 
     name = os.path.basename(path)
     setattr(TestBenchmark, f'test_{name}_example_{device}', example)
-    setattr(TestBenchmark, f'test_{name}_train_{device}', train)
+    setattr(TestBenchmark, f'test_{name}_train_{device}',
+            (unittest.skipIf((name, device) in TRAIN_BLACKLIST, "This test is on the blacklist")(train)))
     setattr(TestBenchmark, f'test_{name}_eval_{device}', eval_fn)
     setattr(TestBenchmark, f'test_{name}_check_device_{device}', check_device_fn)
 

--- a/test.py
+++ b/test.py
@@ -26,7 +26,7 @@ TIMEOUT = 300  # Seconds
 
 # Skip this list of unit tests. One reason may be that the original batch size
 # used in the paper is too large to fit on the CI's GPU.
-TRAIN_BLACKLIST = {("densenet121", "cuda")}
+TRAIN_EXCLUDELIST = {("densenet121", "cuda")}
 
 
 class TestBenchmark(unittest.TestCase):
@@ -105,7 +105,7 @@ def _load_test(path, device):
     name = os.path.basename(path)
     setattr(TestBenchmark, f'test_{name}_example_{device}', example)
     setattr(TestBenchmark, f'test_{name}_train_{device}',
-            (unittest.skipIf((name, device) in TRAIN_BLACKLIST, "This test is on the blacklist")(train)))
+            (unittest.skipIf((name, device) in TRAIN_EXCLUDELIST, "This test is on the exclude list")(train)))
     setattr(TestBenchmark, f'test_{name}_eval_{device}', eval_fn)
     setattr(TestBenchmark, f'test_{name}_check_device_{device}', check_device_fn)
 


### PR DESCRIPTION
This allows us to control which tests are run on the CI
machines. Ex. we may introduce training batch sizes from
the original papers that are too large to fit on the CI
machine.

Before:
```
$ gpurun python test.py -k densenet --verbose
srun: job 8076 queued and waiting for resources
srun: job 8076 has been allocated resources
test_densenet121_check_device_cpu (__main__.TestBenchmark) ... ok
test_densenet121_check_device_cuda (__main__.TestBenchmark) ... ok
test_densenet121_eval_cpu (__main__.TestBenchmark) ... ok
test_densenet121_eval_cuda (__main__.TestBenchmark) ... ok
test_densenet121_example_cpu (__main__.TestBenchmark) ... ok
test_densenet121_example_cuda (__main__.TestBenchmark) ... ok
test_densenet121_train_cpu (__main__.TestBenchmark) ... ok
test_densenet121_train_cuda (__main__.TestBenchmark) ... ok

----------------------------------------------------------------------
Ran 8 tests in 115.684s

OK
```
After:
```
$ gpurun python test.py -k densenet --verbose
srun: job 8079 queued and waiting for resources
srun: job 8079 has been allocated resources
test_densenet121_check_device_cpu (__main__.TestBenchmark) ... ok
test_densenet121_check_device_cuda (__main__.TestBenchmark) ... ok
test_densenet121_eval_cpu (__main__.TestBenchmark) ... ok
test_densenet121_eval_cuda (__main__.TestBenchmark) ... ok
test_densenet121_example_cpu (__main__.TestBenchmark) ... ok
test_densenet121_example_cuda (__main__.TestBenchmark) ... ok
test_densenet121_train_cpu (__main__.TestBenchmark) ... ok
test_densenet121_train_cuda (__main__.TestBenchmark) ... skipped 'This test is on the blacklist'

----------------------------------------------------------------------
Ran 8 tests in 106.145s

OK (skipped=1)
```
