### PR TITLE
Fix train batch size for pytorch_struct.

### DIFF
--- a/torchbenchmark/models/pytorch_struct/__init__.py
+++ b/torchbenchmark/models/pytorch_struct/__init__.py
@@ -55,7 +55,9 @@ def TokenBucket(
 class Model(BenchmarkModel):
   task = OTHER.OTHER_TASKS
 
-  def __init__(self, device=None, jit=False, train_bs=128):
+  # Original train batch size: 200
+  # Source: https://github.com/harvardnlp/pytorch-struct/blob/f4e374e894b94a9411fb3d2dfb44201a18e37b26/notebooks/Unsupervised_CFG.ipynb
+  def __init__(self, device=None, jit=False, train_bs=200):
     super().__init__()
     self.device = device
     self.jit = jit


### PR DESCRIPTION
Use the original batch size 200 for train.
Source: https://github.com/harvardnlp/pytorch-struct/blob/f4e374e894b94a9411fb3d2dfb44201a18e37b26/notebooks/Unsupervised_CFG.ipynb