### PR TITLE
Fix train batch size for attention model.

### DIFF
--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -61,7 +61,9 @@ class Model(BenchmarkModel):
             preloaded_data.append((src_seq, trg_seq, gold))
         return preloaded_data
 
-    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=32):
+    # Original batch size 256, hardware platform unknown
+    # Source: https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/132907dd272e2cc92e3c10e6c4e783a87ff8893d/README.md?plain=1#L83
+    def __init__(self, device=None, jit=False, train_bs=256, eval_bs=32):
         super().__init__()
         self.device = device
         self.jit = jit


### PR DESCRIPTION
The original paper link: https://arxiv.org/pdf/1706.03762.pdf
Original hardware platform: 8xNvidia P100
Original batch size: 25000 (tokens) per source and target

The reference implementation uses a smaller batch of 256 tokens, source:
- https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/132907dd272e2cc92e3c10e6c4e783a87ff8893d/README.md?plain=1#L83