### PR TITLE
Use opacus version < 1.0 to mitigate BC-breaking API change

### DIFF
--- a/torchbenchmark/models/opacus_cifar10/requirements.txt
+++ b/torchbenchmark/models/opacus_cifar10/requirements.txt
@@ -1,1 +1,1 @@
-opacus
+opacus<1.0.0


### PR DESCRIPTION
Opacus 1.0.0 changes its API https://github.com/pytorch/opacus/blob/main/Migration_Guide.md, which breaks this model.
This PR pins opacus to an old version which doesn't introduce this BC-breaking change.