### PR TITLE
Fix the runner temp interface. (#607)

### DIFF
--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -159,7 +159,7 @@ def get_cpu_temp():
     temps = {}
     if MACHINE.AMAZON_LINUX == get_machine_type():
         thermal_path = Path('/sys/class/thermal/')
-        for zone in os.listdir(thermal_path):
+        for zone in filter(lambda x: "thermal_zone" in x, os.listdir(thermal_path)):
             temps[zone] = int(read_sys_file(thermal_path / zone / "temp")) / 1000.
     return temps
 


### PR DESCRIPTION
Summary:
After updating the infra instances, the thermal file path is changed. This PR updates the new thermal file path so that we can get the CPU temp information.

Pull Request resolved: https://github.com/pytorch/benchmark/pull/607

Reviewed By: erichan1

Differential Revision: D32809371

Pulled By: xuzhao9

fbshipit-source-id: d191800ce7fd67f369da8f69649b8380fa27a457