### PR TITLE
Remove pathlib install command as it is built-in 3.8.

### DIFF
--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -66,7 +66,7 @@ jobs:
           pushd "${HOME}/pytorch"
           git fetch origin
           popd
-          pip install gitpython pyyaml dataclasses argparse pathlib
+          pip install gitpython pyyaml dataclasses argparse
           # Compare the result from yesterday and report any perf signals
           python ./.github/scripts/generate-abtest-config.py \
                  --pytorch-dir "${HOME}/pytorch" \


### PR DESCRIPTION
pathlib is built-in in py38, so we don't need to install it in CI.

Test: V1 CI (https://github.com/pytorch/benchmark/actions/runs/1545941996)