### PR TITLE
Allow install.py to only install deps of specified models.

### DIFF
--- a/install.py
+++ b/install.py
@@ -51,6 +51,8 @@ def pip_install_requirements():
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--continue_on_fail", action="store_true")
+    parser.add_argument("--models", nargs='+', default=[],
+                        help="Specify one or more models to install. If not set, install all models.")
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 
@@ -71,7 +73,7 @@ if __name__ == '__main__':
         print(errmsg)
         if not args.continue_on_fail:
             sys.exit(-1)
-    success &= setup(verbose=args.verbose, continue_on_fail=args.continue_on_fail)
+    success &= setup(models=args.models, verbose=args.verbose, continue_on_fail=args.continue_on_fail)
     if not success:
         if args.continue_on_fail:
             print("Warning: some benchmarks were not installed due to failure")


### PR DESCRIPTION
This PR fixes the following problems of the main `install.py`:
- Crash if the model directory doesn't have `install.py` script (should skip instead, because when switching between branches, such as v1.0 and main, some directories will be remained there by git, such as fastNLP in v1.0 will stay as an empty folder after switching to main)
- Doesn't support installing a specific model