### PR TITLE
Remove two wav files in tacotron2.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -481,8 +481,6 @@ torchbenchmark/models/Super_SloMo/misc/slomo.gif filter=lfs diff=lfs merge=lfs -
 torchbenchmark/models/pytorch_struct/docs/source/model.ipynb filter=lfs diff=lfs merge=lfs -text
 torchbenchmark/models/pytorch_struct/docs/source/semiring.ipynb filter=lfs diff=lfs merge=lfs -text
 torchbenchmark/models/yolov3/tutorial.ipynb filter=lfs diff=lfs merge=lfs -text
-torchbenchmark/models/tacotron2/waveglow/tacotron2/inference.ipynb filter=lfs diff=lfs merge=lfs -text
-torchbenchmark/models/tacotron2/waveglow/tacotron2/filelists/ljs_audio_text_train_filelist.txt filter=lfs diff=lfs merge=lfs -text
 torchbenchmark/models/BERT_pytorch/data/corpus.small filter=lfs diff=lfs merge=lfs -text
 torchbenchmark/models/BERT_pytorch/data/vocab.small filter=lfs diff=lfs merge=lfs -text
 torchbenchmark/models/Super_SloMo/.github/ISSUE_TEMPLATE/bug_report.md filter=lfs diff=lfs merge=lfs -text

--- a/torchbenchmark/models/tacotron2/demo.wav
+++ b/torchbenchmark/models/tacotron2/demo.wav
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bad973087880c543a5d283b7a094f4736c988b4dce0e49ff0e1a463d2ffe3b3a
-size 394298

--- a/torchbenchmark/models/tacotron2/waveglow/tacotron2/demo.wav
+++ b/torchbenchmark/models/tacotron2/waveglow/tacotron2/demo.wav
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bad973087880c543a5d283b7a094f4736c988b4dce0e49ff0e1a463d2ffe3b3a
-size 394298

--- a/torchbenchmark/models/tacotron2/waveglow/tacotron2/filelists/ljs_audio_text_train_filelist.txt
+++ b/torchbenchmark/models/tacotron2/waveglow/tacotron2/filelists/ljs_audio_text_train_filelist.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2fbef628e915bae818034e38a45e398157f1d166e63d521246f9c37fe62197d
-size 1524164

--- a/torchbenchmark/models/tacotron2/waveglow/tacotron2/inference.ipynb
+++ b/torchbenchmark/models/tacotron2/waveglow/tacotron2/inference.ipynb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fb2af8b4d79d5c79824933b6808175af21b9cdba765159c63a030baf7ea4bad
-size 437108


### PR DESCRIPTION
On the main branch, after running `install.py`, the git repo will become dirty, showing these to files are modified:
```
(py38) [ec2-user@ip-10-0-8-37 benchmark]$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   torchbenchmark/models/tacotron2/demo.wav
	modified:   torchbenchmark/models/tacotron2/waveglow/tacotron2/demo.wav
```

This PR removes these two files and other two git lfs files which are not used in the benchmark.