### PR TITLE
Improve the quality of tts_angular, fix train and eval batch sizes

### DIFF
--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -6,7 +6,9 @@ from .angular_tts_main import TTSModel, EVAL_SYNTHETIC_DATA
 
 class Model(BenchmarkModel):
     task = SPEECH.SYNTHESIS
-    def __init__(self, device=None, jit=False, train_bs=128, eval_bs=128):
+    # Original train batch size: 64
+    # Source: https://github.com/mozilla/TTS/blob/master/TTS/speaker_encoder/config.json#L38
+    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=128):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -2,19 +2,19 @@
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
 
-from .angular_tts_main import TTSModel, SYNTHETIC_DATA
+from .angular_tts_main import TTSModel, EVAL_SYNTHETIC_DATA
 
 class Model(BenchmarkModel):
     task = SPEECH.SYNTHESIS
-    def __init__(self, device=None, jit=False):
+    def __init__(self, device=None, jit=False, train_bs=128, eval_bs=128):
         super().__init__()
         self.device = device
         self.jit = jit
-        self.model = TTSModel(device=self.device)
+        self.model = TTSModel(device=self.device, train_bs=train_bs, eval_bs=eval_bs)
         self.model.model.to(self.device)
 
     def get_module(self):
-        return self.model.model, [SYNTHETIC_DATA[0], ]
+        return self.model.model, [EVAL_SYNTHETIC_DATA[0], ]
 
     def set_train(self):
         # another model instance is used for training
@@ -32,11 +32,3 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         for _ in range(niter):
             self.model.eval()
-
-
-if __name__ == '__main__':
-    m = Model(device='cpu', jit=False)
-    model, example_inputs = m.get_module()
-    model(*example_inputs)
-    m.train()
-    m.eval()

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -8,7 +8,7 @@ class Model(BenchmarkModel):
     task = SPEECH.SYNTHESIS
     # Original train batch size: 64
     # Source: https://github.com/mozilla/TTS/blob/master/TTS/speaker_encoder/config.json#L38
-    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=128):
+    def __init__(self, device=None, jit=False, train_bs=64, eval_bs=256):
         super().__init__()
         self.device = device
         self.jit = jit

--- a/torchbenchmark/models/tts_angular/angular_tts_main.py
+++ b/torchbenchmark/models/tts_angular/angular_tts_main.py
@@ -254,10 +254,10 @@ class TTSModel:
         del TRAIN_SYNTHETIC_DATA[0]
         del EVAL_SYNTHETIC_DATA[0]
 
-    def train(self, niter, bs):
+    def train(self, niter):
         _, global_step = self._train(self.model, self.criterion,
                                      self.optimizer, self.scheduler, None,
-                                     self.global_step, self.c, niter, bs)
+                                     self.global_step, self.c, niter)
 
     def eval(self):
         start = time.time()

--- a/torchbenchmark/models/tts_angular/angular_tts_main.py
+++ b/torchbenchmark/models/tts_angular/angular_tts_main.py
@@ -240,8 +240,8 @@ class TTSModel:
                                     num_lstm_layers=c.model['num_lstm_layers'])
         self.optimizer = RAdam(self.model.parameters(), lr=c.lr)
         self.criterion = AngleProtoLoss()
-        TRAIN_SYNTHETIC_DATA.append(T.rand(train_bs, 64, 50, 40).to(device=self.device))
-        EVAL_SYNTHETIC_DATA.append(T.rand(eval_bs, 64, 50, 40).to(device=self.device))
+        TRAIN_SYNTHETIC_DATA.append(T.rand(train_bs, 50, 40).to(device=self.device))
+        EVAL_SYNTHETIC_DATA.append(T.rand(eval_bs, 50, 40).to(device=self.device))
 
         if self.use_cuda:
             self.model = self.model.cuda()


### PR DESCRIPTION
Train (bs=64):
![image](https://user-images.githubusercontent.com/502017/145630415-4c03dfef-cddf-48b2-a9ef-de78755252ec.png)


Train bs=64 is default for the model, source: https://github.com/mozilla/TTS/blob/master/TTS/speaker_encoder/config.json#L38

Eval (bs=256):
![image](https://user-images.githubusercontent.com/502017/145630266-6e01b278-2296-429a-9a5d-4ada5c2300e0.png)

256 is the largest BS supported by T4.