### PR TITLE
Improve the quality of demucs model

### DIFF
--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -19,8 +19,8 @@ from typing import Optional, Tuple
 torch.manual_seed(1337)
 random.seed(1337)
 np.random.seed(1337)
-torch.backends.cudnn.deterministic = True
-torch.backends.cudnn.benchmark = False
+torch.backends.cudnn.deterministic = False
+torch.backends.cudnn.benchmark = True
 
 
 class DemucsWrapper(torch.nn.Module):
@@ -102,12 +102,3 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
             self.optimizer.zero_grad()
-
-
-if __name__ == '__main__':
-    for jit in [True, False]:
-        m = Model(device='cuda', jit=jit)
-        module, example_inputs = m.get_module()
-        module(*example_inputs)
-        m.train(niter=1)
-        m.eval(niter=1)

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -40,7 +40,7 @@ class Model(BenchmarkModel):
     task = OTHER.OTHER_TASKS
     # Original train batch size: 64
     # Source: https://github.com/facebookresearch/demucs/blob/3e5ea549ba921316c587e5f03c0afc0be47a0ced/conf/config.yaml#L37
-    def __init__(self, device: Optional[str]=None, jit: bool=False, train_bs=64, eval_bs=64) -> None:
+    def __init__(self, device: Optional[str]=None, jit: bool=False, train_bs=64, eval_bs=32) -> None:
         super().__init__()
         self.device = device
         self.jit = jit
@@ -54,9 +54,8 @@ class Model(BenchmarkModel):
 
         if 1:
             samples = 80000
-            # TODO: calculate the right shape
-            self.example_inputs = (torch.rand([train_bs, 5, 2, 135576], device=device),)
-            self.eval_example_inputs = (torch.rand([eval_bs, 5, 2, 135576], device=device),)
+            self.example_inputs = (torch.rand([train_bs, 5, 2, 426888], device=device),)
+            self.eval_example_inputs = (torch.rand([eval_bs, 5, 2, 426888], device=device),)
 
         self.duration = Fraction(samples + args.data_stride, args.samplerate)
         self.stride = Fraction(args.data_stride, args.samplerate)
@@ -88,7 +87,6 @@ class Model(BenchmarkModel):
         return self.model, self.example_inputs
 
     def eval(self, niter=1):
-        # TODO: implement the eval version
         for _ in range(niter):
             sources, estimates = self.model(*self.eval_example_inputs)
             sources = center_trim(sources, estimates)

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -77,16 +77,16 @@ class Model(BenchmarkModel):
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
-                self.model = torch.jit._script_pdt(self.model, example_inputs = [self.example_inputs, ])
+                self.model = torch.jit._script_pdt(self.model, example_inputs = [self.eval_example_inputs, ])
             else:
-                self.model = torch.jit.script(self.model, example_inputs = [self.example_inputs, ])
+                self.model = torch.jit.script(self.model, example_inputs = [self.eval_example_inputs, ])
 
     def _set_mode(self, train):
         self.model.train(train)
 
     def get_module(self) -> Tuple[DemucsWrapper, Tuple[Tensor]]:
         self.model.eval()
-        return self.model, self.example_inputs
+        return self.model, self.eval_example_inputs
 
     def eval(self, niter=1):
         for _ in range(niter):
@@ -100,7 +100,7 @@ class Model(BenchmarkModel):
         if self.device == "cuda":
             raise NotImplementedError("Disable GPU training because it causes CUDA OOM on T4")
         for _ in range(niter):
-            sources, estimates = self.model(*self.example_inputs)
+            sources, estimates = self.model(*self.eval_example_inputs)
             sources = center_trim(sources, estimates)
             loss = self.criterion(estimates, sources)
             loss.backward()

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -40,7 +40,7 @@ class Model(BenchmarkModel):
     task = OTHER.OTHER_TASKS
     # Original train batch size: 64
     # Source: https://github.com/facebookresearch/demucs/blob/3e5ea549ba921316c587e5f03c0afc0be47a0ced/conf/config.yaml#L37
-    def __init__(self, device: Optional[str]=None, jit: bool=False, train_bs=64, eval_bs=32) -> None:
+    def __init__(self, device: Optional[str]=None, jit: bool=False, train_bs=64, eval_bs=8) -> None:
         super().__init__()
         self.device = device
         self.jit = jit
@@ -54,7 +54,8 @@ class Model(BenchmarkModel):
 
         if 1:
             samples = 80000
-            self.example_inputs = (torch.rand([train_bs, 5, 2, 426888], device=device),)
+            # TODO: enable GPU training after it is supported by infra
+            # self.example_inputs = (torch.rand([train_bs, 5, 2, 426888], device=device),)
             self.eval_example_inputs = (torch.rand([eval_bs, 5, 2, 426888], device=device),)
 
         self.duration = Fraction(samples + args.data_stride, args.samplerate)
@@ -93,6 +94,10 @@ class Model(BenchmarkModel):
             loss = self.criterion(estimates, sources)
 
     def train(self, niter=1):
+        if self.device == "cpu":
+            raise NotImplementedError("Disable CPU training because it is too slow (> 1min)")
+        if self.device == "cuda":
+            raise NotImplementedError("Disable GPU training because it causes CUDA OOM on T4")
         for _ in range(niter):
             sources, estimates = self.model(*self.example_inputs)
             sources = center_trim(sources, estimates)

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -55,6 +55,7 @@ class Model(BenchmarkModel):
         if 1:
             samples = 80000
             # TODO: enable GPU training after it is supported by infra
+            #       see GH issue https://github.com/pytorch/benchmark/issues/652
             # self.example_inputs = (torch.rand([train_bs, 5, 2, 426888], device=device),)
             self.eval_example_inputs = (torch.rand([eval_bs, 5, 2, 426888], device=device),)
 

--- a/torchbenchmark/models/demucs/metadata.yaml
+++ b/torchbenchmark/models/demucs/metadata.yaml
@@ -1,6 +1,6 @@
-eval_benchmark: false
-eval_deterministic: true
+eval_benchmark: true
+eval_deterministic: false
 eval_nograd: true
 optimized_for_inference: false
-train_benchmark: false
-train_deterministic: true
+train_benchmark: true
+train_deterministic: false


### PR DESCRIPTION
Original train batch size is 64, which doesn't work on T4. CPU training is too slow, so disable both GPU and CPU training.

Eval batch size 8 looks good:
![image](https://user-images.githubusercontent.com/502017/145659921-c65f089e-3aad-4f9b-ae08-18fe12719c1d.png)
