### PR TITLE
Improve the quality of soft actor critic model

### DIFF
--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -113,11 +113,16 @@ def learn_standard(
 
 class Model(BenchmarkModel):
     task = REINFORCEMENT_LEARNING.OTHER_RL
-    def __init__(self, device=None, jit=False):
+    # Original train batch size: 256
+    # Source: https://github.com/pranz24/pytorch-soft-actor-critic/blob/398595e0d9dca98b7db78c7f2f939c969431871a/main.py#L31
+    # Eval bs can only be 1 because of the nature of RL model
+    # This model doesn't support prefetching either
+    def __init__(self, device=None, jit=False, train_bs=256):
         super(Model, self).__init__()
         self.device = device
         self.jit = jit
         self.args = SACConfig()
+        self.args.batch_size = train_bs
         # Construct agent
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.train_env = load_gym(self.args.env_id, self.args.seed)


### PR DESCRIPTION
- Fix the train batch size to be 256
- Add comments that eval batch size can't be adjusted
- This model doesn't support prefetching either, because the train data is dynamically generated at runtime according to the environment response

Profile of train, bs=256:
![image](https://user-images.githubusercontent.com/502017/145915840-86de65e4-1c59-43c2-9906-29e7335497cd.png)

Profile of eval, bs=1:
![image](https://user-images.githubusercontent.com/502017/145915882-3a8a4e2c-bd07-4799-8eb8-e0da659861e1.png)


