### PR TITLE
Improve quality of pytorch_stargan

### DIFF
--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
-import random
-import argparse
-import torch
 import os
+import torch
+import random
 import numpy as np
-from torch.utils import data
 from .solver import Solver
 from .data_loader import get_loader
 from .main import parse_config, makedirs

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -23,7 +23,10 @@ class Model(BenchmarkModel):
     task = COMPUTER_VISION.GENERATION
     optimized_for_inference = True
 
-    def __init__(self, device=None, jit=False):
+    # Original train batch size: 16
+    # Source: https://github.com/yunjey/stargan/blob/94dd002e93a2863d9b987a937b85925b80f7a19f/main.py#L73
+    # This model doesn't support setting eval batch size and will use the same bs as train
+    def __init__(self, device=None, jit=False, train_bs=16):
         super().__init__()
         self.device = device
         self.jit = jit
@@ -32,7 +35,7 @@ class Model(BenchmarkModel):
         config.celeba_image_dir = os.path.join(os.path.dirname(__file__), 'data/celeba/images')
         config.attr_path = os.path.join(os.path.dirname(__file__), 'data/celeba/list_attr_celeba.txt')
         config.num_iters = 1
-        config.batch_size = 24
+        config.batch_size = train_bs
         config.use_tensorboard = False
         config.device = device
         config.should_script = jit

--- a/torchbenchmark/models/pytorch_stargan/metadata.yaml
+++ b/torchbenchmark/models/pytorch_stargan/metadata.yaml
@@ -1,6 +1,6 @@
-eval_benchmark: false
-eval_deterministic: true
+eval_benchmark: true
+eval_deterministic: false
 eval_nograd: true
 optimized_for_inference: true
-train_benchmark: false
-train_deterministic: true
+train_benchmark: true
+train_deterministic: false


### PR DESCRIPTION
Default train batch size: 16
Source: https://github.com/yunjey/stargan/blob/94dd002e93a2863d9b987a937b85925b80f7a19f/main.py#L73

Added data prefetch and eval batch size support.

Train profile (bs=16):
![image](https://user-images.githubusercontent.com/502017/146257343-91e9fae4-7810-4c80-a7c8-793077e7c16c.png)

Eval profile (bs=16):
![image](https://user-images.githubusercontent.com/502017/145923896-5050a5a5-16c0-45fb-991e-a8caaf202e65.png)
