### PR TITLE
Remove torch requirements in requirements.txt

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,8 +2,11 @@ import argparse
 import subprocess
 import os
 import sys
+import importlib
 import tarfile
 from torchbenchmark import setup, _test_https, proxy_suggestion
+
+DEPS = ['torch', 'torchvision', 'torchtext']
 
 def git_lfs_checkout():
     tb_dir = os.path.dirname(os.path.realpath(__file__))
@@ -56,6 +59,16 @@ if __name__ == '__main__':
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 
+    print(f"checking packages {DEPS} are installed...", end="", flush=True)
+    try:
+        for module in DEPS:
+            module = importlib.import_module(module)
+    except ModuleNotFoundError as e:
+        print("FAIL")
+        print(f"Error: Users must first install packages {DEPS} before installing the benchmark")
+        sys.exit(-1)
+    print("OK")
+
     print("checking out Git LFS files...", end="", flush=True)
     success, errmsg = git_lfs_checkout()
     if success:
@@ -64,7 +77,7 @@ if __name__ == '__main__':
         print("FAIL")
         print("Failed to checkout git lfs files. Please make sure you have installed git lfs.")
         print(errmsg)
-        exit(-1)
+        sys.exit(-1)
     decompress_input()
 
     success, errmsg = pip_install_requirements()

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -14,8 +14,9 @@ from urllib import request
 
 from components._impl.tasks import base as base_task
 from components._impl.workers import subprocess_worker
+from .util.env_check import get_pkg_versions
 
-
+TORCH_DEPS = ['torch', 'torchvision', 'torchtext']
 proxy_suggestion = "Unable to verify https connectivity, " \
                    "required for setup.\n" \
                    "Do you need to use a proxy?"
@@ -50,7 +51,13 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
             if not verbose:
                 run_kwargs['stderr'] = subprocess.STDOUT
                 run_kwargs['stdout'] = output_buffer
+            versions = get_pkg_versions(TORCH_DEPS)
             subprocess.run(*run_args, **run_kwargs)  # type: ignore
+            new_versions = get_pkg_versions(TORCH_DEPS)
+            if versions != new_versions:
+                errmsg = f"The torch packages are re-installed after installing the benchmark deps. \
+                           Before: {versions}, after: {new_versions}"
+                return (False, errmsg, None)
         else:
             return (True, f"No install.py is found in {model_path}. Skip.", None)
     except subprocess.CalledProcessError as e:

--- a/torchbenchmark/models/Super_SloMo/requirements.txt
+++ b/torchbenchmark/models/Super_SloMo/requirements.txt
@@ -1,3 +1,1 @@
-torch
-torchvision
 tensorboardX

--- a/torchbenchmark/models/dcgan/requirements.txt
+++ b/torchbenchmark/models/dcgan/requirements.txt
@@ -1,3 +1,1 @@
 numpy
-torch
-torchvision

--- a/torchbenchmark/models/demucs/requirements.txt
+++ b/torchbenchmark/models/demucs/requirements.txt
@@ -1,4 +1,3 @@
-torch
 ffmpeg-python==0.2.0
 scipy>=1.3.1
 tqdm>=4.36.1

--- a/torchbenchmark/models/dlrm/requirements.txt
+++ b/torchbenchmark/models/dlrm/requirements.txt
@@ -2,7 +2,5 @@ future
 numpy
 onnx
 pydot
-torch
-torchviz
 scikit-learn
 tqdm

--- a/torchbenchmark/models/moco/requirements.txt
+++ b/torchbenchmark/models/moco/requirements.txt
@@ -1,2 +1,0 @@
-torch
-torchvision

--- a/torchbenchmark/models/nvidia_deeprecommender/requirements.txt
+++ b/torchbenchmark/models/nvidia_deeprecommender/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-torch

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/requirements.txt
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/requirements.txt
@@ -1,4 +1,2 @@
-torch>=0.4.1
-torchvision>=0.2.1
 dominate>=2.3.1
 visdom>=0.1.8.3

--- a/torchbenchmark/models/pytorch_struct/requirements.txt
+++ b/torchbenchmark/models/pytorch_struct/requirements.txt
@@ -1,5 +1,3 @@
-torch
-torchtext
 dgl
 wandb
 pytorch-transformers

--- a/torchbenchmark/models/pytorch_unet/pytorch_unet/requirements.txt
+++ b/torchbenchmark/models/pytorch_unet/pytorch_unet/requirements.txt
@@ -1,7 +1,5 @@
 matplotlib
 numpy
 Pillow
-torch
-torchvision
 tqdm
 wandb

--- a/torchbenchmark/models/vision_maskrcnn/requirements.txt
+++ b/torchbenchmark/models/vision_maskrcnn/requirements.txt
@@ -1,2 +1,0 @@
-torch
-torchvision

--- a/torchbenchmark/models/yolov3/requirements.txt
+++ b/torchbenchmark/models/yolov3/requirements.txt
@@ -2,8 +2,6 @@
 numpy
 # opencv-python 4.5 requires numpy 1.8
 opencv-python >= 4.1, < 4.5
-torch >= 1.5
-torchvision
 matplotlib
 pycocotools
 tqdm

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -1,6 +1,15 @@
-import torch
+import importlib
+from typing import List, Dict
+
+def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
+    versions = {}
+    for module in packages:
+        module = importlib.import_module(module)
+        versions[module] = module.__version__
+    return versions
 
 def has_native_amp() -> bool:
+    import torch
     try:
         if getattr(torch.cuda.amp, 'autocast') is not None:
             return True


### PR DESCRIPTION
This PR removes all `torch` and its domain packages from `requirements.txt`.
It also adds check in `install.py` to make sure they are installed before installing the benchmark.