### PR TITLE
Improve the quality of speech transformer

### DIFF
--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -13,10 +13,14 @@ from .config import SpeechTransformerTrainConfig, SpeechTransformerEvalConfig
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
 
+NUM_TRAIN_BATCH = 1
+NUM_EVAL_BATCH = 1
+
 class Model(BenchmarkModel):
     task = SPEECH.RECOGNITION
     # Original batch size: 32
     # Source: https://github.com/kaituoxu/Speech-Transformer/blob/e6847772d6a786336e117a03c48c62ecbf3016f6/src/bin/train.py#L68
+    # This model does not support adjusting eval bs
     def __init__(self, device=None, jit=False, train_bs=32):
         self.jit = jit
         self.device = device
@@ -24,8 +28,8 @@ class Model(BenchmarkModel):
             return
         if device == "cpu":
             return
-        self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs)
-        self.evalcfg = SpeechTransformerEvalConfig(self.traincfg)
+        self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs, num_train_bs=NUM_TRAIN_BATCH)
+        self.evalcfg = SpeechTransformerEvalConfig(self.traincfg, num_eval_bs=NUM_EVAL_BATCH)
         self.traincfg.model.cuda()
         self.evalcfg.model.cuda()
 

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -28,8 +28,8 @@ class Model(BenchmarkModel):
             return
         if device == "cpu":
             return
-        self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs, num_train_bs=NUM_TRAIN_BATCH)
-        self.evalcfg = SpeechTransformerEvalConfig(self.traincfg, num_eval_bs=NUM_EVAL_BATCH)
+        self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs, num_train_batch=NUM_TRAIN_BATCH)
+        self.evalcfg = SpeechTransformerEvalConfig(self.traincfg, num_eval_batch=NUM_EVAL_BATCH)
         self.traincfg.model.cuda()
         self.evalcfg.model.cuda()
 

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -15,14 +15,16 @@ from torchbenchmark.tasks import SPEECH
 
 class Model(BenchmarkModel):
     task = SPEECH.RECOGNITION
-    def __init__(self, device=None, jit=False):
+    # Original batch size: 32
+    # Source: https://github.com/kaituoxu/Speech-Transformer/blob/e6847772d6a786336e117a03c48c62ecbf3016f6/src/bin/train.py#L68
+    def __init__(self, device=None, jit=False, train_bs=32):
         self.jit = jit
         self.device = device
         if jit:
             return
         if device == "cpu":
             return
-        self.traincfg = SpeechTransformerTrainConfig()
+        self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs)
         self.evalcfg = SpeechTransformerEvalConfig(self.traincfg)
         self.traincfg.model.cuda()
         self.evalcfg.model.cuda()

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -102,7 +102,7 @@ class SpeechTransformerTrainConfig:
         self.data_loader = self.tr_loader if not SpeechTransformerTrainConfig.cross_valid else self.cv_loader
         if prefetch:
             result = []
-            for data in zip(range(num_train_bs), self.data_loader):
+            for _batch_num, data in zip(range(num_train_bs), self.data_loader):
                 padded_input, input_lengths, padded_target = data
                 padded_input = padded_input.cuda()
                 input_lengths = input_lengths.cuda()

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -58,7 +58,7 @@ class SpeechTransformerTrainConfig:
     train_json = "input_data/train/data.json"
     valid_json = "input_data/dev/data.json"
     dict_txt = "input_data/lang_1char/train_chars.txt"
-    def __init__(self, prefetch=True, train_bs=16, num_train_bs=1):
+    def __init__(self, prefetch=True, train_bs=16, num_train_batch=1):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         self.train_json = os.path.join(dir_path, self.train_json)
         self.valid_json = os.path.join(dir_path, self.valid_json)
@@ -102,7 +102,7 @@ class SpeechTransformerTrainConfig:
         self.data_loader = self.tr_loader if not SpeechTransformerTrainConfig.cross_valid else self.cv_loader
         if prefetch:
             result = []
-            for _batch_num, data in zip(range(num_train_bs), self.data_loader):
+            for _batch_num, data in zip(range(num_train_batch), self.data_loader):
                 padded_input, input_lengths, padded_target = data
                 padded_input = padded_input.cuda()
                 input_lengths = input_lengths.cuda()

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -34,7 +34,7 @@ class SpeechTransformerTrainConfig:
     label_smoothing = 0.1
     # minibatch
     shuffle = 1
-    batch_size = 16
+    batch_size = 32
     batch_frames = 15000
     maxlen_in = 800
     maxlen_out = 150
@@ -53,29 +53,30 @@ class SpeechTransformerTrainConfig:
     visdom_lr = 0
     visdom_epoch = 0
     visdom_id = 0
+    cross_valid = False
     # The input files. Their paths are relative to the directory of __file__
     train_json = "input_data/train/data.json"
     valid_json = "input_data/dev/data.json"
     dict_txt = "input_data/lang_1char/train_chars.txt"
-    def __init__(self):
+    def __init__(self, prefetch=True, train_bs=16):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         self.train_json = os.path.join(dir_path, self.train_json)
         self.valid_json = os.path.join(dir_path, self.valid_json)
         self.dict_txt = os.path.join(dir_path, self.dict_txt)
         self.char_list, self.sos_id, self.eos_id = process_dict(self.dict_txt)
         self.vocab_size = len(self.char_list)
-        self.tr_dataset = AudioDataset(self.train_json, self.batch_size,
+        self.tr_dataset = AudioDataset(self.train_json, train_bs,
                                        self.maxlen_in, self.maxlen_out,
                                        batch_frames=self.batch_frames)
-        self.cv_dataset = AudioDataset(self.valid_json, self.batch_size,
+        self.cv_dataset = AudioDataset(self.valid_json, train_bs,
                                        self.maxlen_in, self.maxlen_out,
                                        batch_frames=self.batch_frames)
-        self.tr_loader = AudioDataLoader(self.tr_dataset, batch_size=1,
+        self.tr_loader = AudioDataLoader(self.tr_dataset, batch_size=train_bs,
                                          num_workers=self.num_workers,
                                          shuffle=self.shuffle,
                                          LFR_m=self.LFR_m,
                                          LFR_n=self.LFR_n)
-        self.cv_loader = AudioDataLoader(self.cv_dataset, batch_size=1,
+        self.cv_loader = AudioDataLoader(self.cv_dataset, batch_size=train_bs,
                                          num_workers=self.num_workers,
                                          LFR_m=self.LFR_m,
                                          LFR_n=self.LFR_n)
@@ -98,6 +99,16 @@ class SpeechTransformerTrainConfig:
         self.optimizer = TransformerOptimizer(torch.optim.Adam(self.model.parameters(), betas=(0.9, 0.98), eps=1e-09),
                                               self.k, self.d_model, self.warmup_steps)
         self._reset()
+        self.data_loader = self.tr_loader if not SpeechTransformerTrainConfig.cross_valid else self.cv_loader
+        if prefetch:
+            result = []
+            for data in self.data_loader:
+                padded_input, input_lengths, padded_target = data
+                padded_input = padded_input.cuda()
+                input_lengths = input_lengths.cuda()
+                padded_target = padded_target.cuda()
+                result.append((padded_input, input_lengths, padded_target))
+            self.data_loader = result
 
     def _reset(self):
         self.prev_val_loss = float("inf")
@@ -106,7 +117,7 @@ class SpeechTransformerTrainConfig:
 
     def _run_one_epoch(self, cross_valid=False):
         total_loss = 0
-        data_loader = self.tr_loader if not cross_valid else self.cv_loader
+        data_loader = self.data_loader
         for i, (data) in enumerate(data_loader):
             padded_input, input_lengths, padded_target = data
             padded_input = padded_input.cuda()
@@ -130,7 +141,7 @@ class SpeechTransformerTrainConfig:
         tr_avg_loss = self._run_one_epoch()
         # Cross validation
         self.model.eval()
-        val_loss = self._run_one_epoch(cross_valid=True)
+        val_loss = self._run_one_epoch(cross_valid=SpeechTransformerTrainConfig.cross_valid)
         self.tr_loss[epoch] = tr_avg_loss
         self.cv_loss[epoch] = val_loss
         if val_loss < self.best_val_loss:
@@ -157,14 +168,17 @@ class SpeechTransformerEvalConfig:
         # Read json data
         with open(self.recog_json, "rb") as f:
             self.js = json.load(f)['utts']
+        self.eval_example_input = []
+        for idx, name in enumerate(list(self.js.keys())[:self.recog_word], 1):
+            feat_path = os.path.join(self.base_path, self.js[name]['input'][0]['feat'])
+            input = kaldi_io.read_mat(feat_path)
+            input = build_LFR_features(input, self.LFR_m, self.LFR_n)
+            input = torch.from_numpy(input).float()
+            input_length = torch.tensor([input.size(0)], dtype=torch.int)
+            input = input.cuda()
+            input_length = input_length.cuda()
+            self.eval_example_input.append((input, input_length))
     def eval(self):
         with torch.no_grad():
-            for idx, name in enumerate(list(self.js.keys())[:self.recog_word], 1):
-                feat_path = os.path.join(self.base_path, self.js[name]['input'][0]['feat'])
-                input = kaldi_io.read_mat(feat_path)
-                input = build_LFR_features(input, self.LFR_m, self.LFR_n)
-                input = torch.from_numpy(input).float()
-                input_length = torch.tensor([input.size(0)], dtype=torch.int)
-                input = input.cuda()
-                input_length = input_length.cuda()
+            for input, input_length in self.eval_example_input:
                 nbest_hyps = self.model.recognize(input, input_length, self.char_list, self)

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -34,7 +34,6 @@ class SpeechTransformerTrainConfig:
     label_smoothing = 0.1
     # minibatch
     shuffle = 1
-    batch_size = 32
     batch_frames = 15000
     maxlen_in = 800
     maxlen_out = 150
@@ -58,7 +57,7 @@ class SpeechTransformerTrainConfig:
     train_json = "input_data/train/data.json"
     valid_json = "input_data/dev/data.json"
     dict_txt = "input_data/lang_1char/train_chars.txt"
-    def __init__(self, prefetch=True, train_bs=16, num_train_batch=1):
+    def __init__(self, prefetch=True, train_bs=32, num_train_batch=1):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         self.train_json = os.path.join(dir_path, self.train_json)
         self.valid_json = os.path.join(dir_path, self.valid_json)


### PR DESCRIPTION
Use original train batch size 32.
Source: https://github.com/kaituoxu/Speech-Transformer/blob/e6847772d6a786336e117a03c48c62ecbf3016f6/src/bin/train.py#L68

Added code to prefetch the data to GPU.

This model doesn't support changing inference batch size.

Profile of train:
![image](https://user-images.githubusercontent.com/502017/146303947-abc1fd00-fcbf-4aeb-b2f5-36013cd72ab4.png)

Profile of eval: 
![image](https://user-images.githubusercontent.com/502017/146304147-a1808284-f274-4091-bcc8-3a2a96430f7c.png)

