### PR TITLE
Enable fp16 run for yolov3 and tacotron2.

### DIFF
--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -1,5 +1,6 @@
 from .train_tacotron2 import load_model, prepare_dataloaders
 import torch
+import argparse
 from .loss_function import Tacotron2Loss
 from argparse import Namespace
 from .text import symbols
@@ -7,7 +8,11 @@ from pathlib import Path
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
 
-from torchbenchmark.util.env_check import parse_extraargs
+def tacotron2_parse_extraargs(extraargs):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--eval-fp16", action='store_false', help="Enable fp16 for inference")
+    args = parser.parse_args(extraargs)
+    return args
 
 class Model(BenchmarkModel):
     task = SPEECH.SYNTHESIS
@@ -23,7 +28,7 @@ class Model(BenchmarkModel):
             # TODO - currently load_model assumes cuda
             return
 
-        self.extra_args = parse_extraargs(extra_args)
+        self.extra_args = tacotron2_parse_extraargs(extra_args)
         self.train_hparams = self.create_hparams(batch_size=train_bs)
         self.eval_hparams = self.create_hparams(batch_size=eval_bs, fp16_run=self.extra_args.eval_fp16)
         self.train_model = load_model(self.train_hparams).to(device=device)

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -1,18 +1,12 @@
 from .train_tacotron2 import load_model, prepare_dataloaders
 import torch
-import argparse
 from .loss_function import Tacotron2Loss
 from argparse import Namespace
 from .text import symbols
 from pathlib import Path
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
-
-def tacotron2_parse_extraargs(extraargs):
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--eval-fp16", action='store_false', help="Enable fp16 for inference")
-    args = parser.parse_args(extraargs)
-    return args
+from torchbenchmark.util.env_check import parse_extraargs
 
 class Model(BenchmarkModel):
     task = SPEECH.SYNTHESIS
@@ -28,7 +22,7 @@ class Model(BenchmarkModel):
             # TODO - currently load_model assumes cuda
             return
 
-        self.extra_args = tacotron2_parse_extraargs(extra_args)
+        self.extra_args = parse_extraargs(extra_args)
         self.train_hparams = self.create_hparams(batch_size=train_bs)
         self.eval_hparams = self.create_hparams(batch_size=eval_bs, fp16_run=self.extra_args.eval_fp16)
         self.train_model = load_model(self.train_hparams).to(device=device)

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -23,7 +23,7 @@ class Model(BenchmarkModel):
             return
 
         self.train_hparams = self.create_hparams(batch_size=train_bs)
-        self.eval_hparams = self.create_hparams(batch_size=eval_bs)
+        self.eval_hparams = self.create_hparams(batch_size=eval_bs, fp16_run=True)
         self.train_model = load_model(self.train_hparams).to(device=device)
         self.eval_model = load_model(self.eval_hparams).to(device=device)
         self.train_optimizer = torch.optim.Adam(self.train_model.parameters(),
@@ -38,7 +38,7 @@ class Model(BenchmarkModel):
 
     # Parameters were obtained from the source code.
     # Source: https://github.com/NVIDIA/tacotron2/blob/bb6761349354ee914909a42208e4820929612069/hparams.py#L5
-    def create_hparams(hparams_string=None, verbose=False, batch_size=64):
+    def create_hparams(hparams_string=None, verbose=False, batch_size=64, fp16_run=False):
         """Create model hyperparameters. Parse nondefault from given string."""
         root = str(Path(__file__).parent.parent.parent)
         hparams = Namespace(**{
@@ -49,7 +49,7 @@ class Model(BenchmarkModel):
             'iters_per_checkpoint': 1000,
             'seed': 1234,
             'dynamic_loss_scaling': True,
-            'fp16_run': False,
+            'fp16_run': fp16_run,
             'distributed_run': False,
             'dist_backend': "nccl",
             'dist_url': "tcp://localhost:54321",

--- a/torchbenchmark/models/timm_efficientnet/__init__.py
+++ b/torchbenchmark/models/timm_efficientnet/__init__.py
@@ -59,7 +59,8 @@ class Model(BenchmarkModel):
         pass
 
     def _step_eval(self):
-        output = self.eval_model(self.cfg.infer_example_inputs)
+        with self.eval_amp_autocast():
+            output = self.eval_model(self.cfg.infer_example_inputs)
 
     def get_module(self):
         return self.model, (self.cfg.example_inputs,)

--- a/torchbenchmark/models/timm_efficientnet/__init__.py
+++ b/torchbenchmark/models/timm_efficientnet/__init__.py
@@ -59,8 +59,7 @@ class Model(BenchmarkModel):
         pass
 
     def _step_eval(self):
-        with self.eval_amp_autocast():
-            output = self.eval_model(self.cfg.infer_example_inputs)
+        output = self.eval_model(self.cfg.infer_example_inputs)
 
     def get_module(self):
         return self.model, (self.cfg.example_inputs,)

--- a/torchbenchmark/models/timm_nfnet/__init__.py
+++ b/torchbenchmark/models/timm_nfnet/__init__.py
@@ -68,7 +68,7 @@ class Model(BenchmarkModel):
         model, self.loader_train, self.loader_validate, self.optimizer, \
             self.train_loss_fn, self.lr_scheduler, self.amp_autocast, \
             self.loss_scaler, self.mixup_fn, self.validate_loss_fn = timm_instantiate_train(args)
-        eval_model, self.loader_eval, self.eval_ampautocast = timm_instantiate_eval(args)
+        eval_model, self.loader_eval, self.eval_amp_autocast = timm_instantiate_eval(args)
         # jit the model if required
         self.model, self.eval_model = jit_if_needed(model, eval_model, jit=jit)
         

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -67,7 +67,7 @@ class Model(BenchmarkModel):
         parser.add_argument('--classes', nargs='+', type=int, help='filter by class')
         parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
         parser.add_argument('--augment', action='store_true', help='augmented inference')
-        opt = parser.parse_args(['--device', self.device])
+        opt = parser.parse_args(['--device', self.device, "--half"])
         opt.cfg = check_file(opt.cfg)  # check file
         opt.names = check_file(opt.names)  # check file
         model = Darknet(opt.cfg, opt.img_size)

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -1,5 +1,12 @@
 import importlib
+import argparse
 from typing import List, Dict
+
+def parse_extraargs(extraargs):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--eval-fp16", action='store_false', help="Enable fp16 for inference")
+    args = parser.parse_args(extraargs)
+    return args
 
 def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
     versions = {}

--- a/torchbenchmark/util/framework/timm/instantiate.py
+++ b/torchbenchmark/util/framework/timm/instantiate.py
@@ -63,7 +63,12 @@ def timm_instantiate_eval(args):
         tf_preprocessing=args.tf_preprocessing,
         persistent_workers=False,
     )
-    return eval_model, loader_eval
+
+    # setup automatic mixed-precision (AMP) loss scaling and op casting
+    amp_autocast = suppress  # do nothing
+    if args.eval_use_amp == 'native':
+        amp_autocast = torch.cuda.amp.autocast
+    return eval_model, loader_eval, amp_autocast
 
 def timm_instantiate_train(args):
     # create train model


### PR DESCRIPTION
Address part of #657. Enable `half()`/`fp16` for inference on Tacotron2 and yolov3.