### PR TITLE
Fix broken main branch. Disable half when using CPU device.

### DIFF
--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -3,36 +3,33 @@
 import torch
 import torch.optim as optim
 import torchvision.models as models
+
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
+
     # Train batch size: use the smallest example batch of 128 (assuming only 1 worker)
     # Source: https://arxiv.org/pdf/1404.5997.pdf
     def __init__(self, device=None, jit=False, train_bs=128, eval_bs=16, extra_args=[]):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.alexnet().to(self.device)
         self.eval_model = models.alexnet().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/mnasnet1_0/__init__.py
+++ b/torchbenchmark/models/mnasnet1_0/__init__.py
@@ -6,31 +6,26 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
+
     def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32, extra_args=[]):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
         self.model = models.mnasnet1_0().to(self.device)
         self.eval_model = models.mnasnet1_0().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/mobilenet_v2/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2/metadata.yaml
@@ -1,6 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
+optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/mobilenet_v3_large/__init__.py
+++ b/torchbenchmark/models/mobilenet_v3_large/__init__.py
@@ -6,31 +6,27 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
+    optimized_for_inference = True
+
     def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32, extra_args=[]):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.mobilenet_v3_large().to(self.device)
         self.eval_model = models.mobilenet_v3_large().to(self.device)
-
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             self.model = torch.jit.script(self.model)

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -25,6 +25,7 @@ def _prefetch(loader, size, collate_fn):
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.GENERATION
+    optimized_for_inference = True
 
     # Original train batch size: 16
     # Source: https://github.com/yunjey/stargan/blob/94dd002e93a2863d9b987a937b85925b80f7a19f/main.py#L73

--- a/torchbenchmark/models/resnet18/__init__.py
+++ b/torchbenchmark/models/resnet18/__init__.py
@@ -6,7 +6,7 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
     optimized_for_inference = True
@@ -14,22 +14,17 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.resnet18().to(self.device)
         self.eval_model = models.resnet18().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/resnet50/__init__.py
+++ b/torchbenchmark/models/resnet50/__init__.py
@@ -5,31 +5,27 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
+    optimized_for_inference = True
 
     def __init__(self, device=None, jit=False, train_bs=32, eval_bs=32, extra_args=[]):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.resnet50().to(self.device)
         self.eval_model = models.resnet50().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
-        
+
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -46,12 +42,6 @@ class Model(BenchmarkModel):
 
     def get_module(self):
         return self.model, self.example_inputs
-
-    # vision models have another model
-    # instance for inference that has
-    # already been optimized for inference
-    def set_eval(self):
-        pass
 
     def train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())

--- a/torchbenchmark/models/resnext50_32x4d/__init__.py
+++ b/torchbenchmark/models/resnext50_32x4d/__init__.py
@@ -6,7 +6,7 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -15,22 +15,17 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.resnext50_32x4d().to(self.device)
         self.eval_model = models.resnext50_32x4d().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
@@ -6,7 +6,7 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -15,22 +15,17 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.shufflenet_v2_x1_0().to(self.device)
         self.eval_model = models.shufflenet_v2_x1_0().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -6,7 +6,7 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -19,22 +19,17 @@ class Model(BenchmarkModel):
         self.device = device
         self.jit = jit
         self.epoch_size = 16
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.squeezenet1_1().to(self.device)
         self.eval_model = models.squeezenet1_1().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -1,6 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
+optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -6,10 +6,11 @@ import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
-from torchbenchmark.util.env_check import parse_extraargs
+from torchbenchmark.util.framework.vision.args import parse_args, apply_args
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
+    optimized_for_inference = True
 
     # Original train batch size 256 on 4-GPU system
     # Downscale to 64 to run on single GPU
@@ -18,22 +19,17 @@ class Model(BenchmarkModel):
         super().__init__()
         self.device = device
         self.jit = jit
+        self.train_bs = train_bs
+        self.eval_bs = eval_bs
+
         self.model = models.vgg16().to(self.device)
         self.eval_model = models.vgg16().to(self.device)
         self.example_inputs = (torch.randn((train_bs, 3, 224, 224)).to(self.device),)
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
 
         # process extra args
-        self.extra_args = parse_extraargs(extra_args)
-        if self.extra_args.eval_fp16:
-            self.eval_model.half()
-            self.eval_example_inputs = (self.eval_example_inputs[0].half(),)
-        if self.extra_args.fx2trt:
-            assert self.device == 'cuda', "fx2trt is only available with CUDA."
-            assert not self.jit, "fx2trt with JIT is not available."
-            from torchbenchmark.util.fx2trt import lower_to_trt
-            self.eval_model = lower_to_trt(module=self.eval_model, input=self.eval_example_inputs, \
-                                           max_batch_size=eval_bs, fp16_mode=self.extra_args.eval_fp16)
+        self.args = parse_args(self, extra_args)
+        apply_args(self, self.args)
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):
@@ -46,7 +42,6 @@ class Model(BenchmarkModel):
             # in order to be optimized for inference
             self.eval_model.eval()
             self.eval_model = torch.jit.optimize_for_inference(self.eval_model)
-
 
     def get_module(self):
         return self.model, self.example_inputs

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -43,6 +43,7 @@ def _prefetch(loader, device):
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.DETECTION
+    optimized_for_inference = True
 
     def __init__(self, device=None, jit=False, train_bs=4, eval_bs=4):
         self.device = device

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -1,13 +1,5 @@
 import importlib
-import argparse
 from typing import List, Dict
-
-def parse_extraargs(extra_args: List[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    # by default, enable half precision for inference
-    parser.add_argument("--eval-fp16", action='store_false', help="enable eval fp16")
-    parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
-    return parser.parse_args(extra_args)
 
 def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
     versions = {}

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -1,0 +1,37 @@
+import argparse
+import torch
+from torchbenchmark.util.model import BenchmarkModel
+from typing import List, Tuple
+
+def parse_args(model: BenchmarkModel, extra_args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    # by default, enable half precision for inference
+    parser.add_argument("--eval-fp16", action='store_false', help="enable eval fp16")
+    parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
+    args = parser.parse_args(extra_args)
+    args.device = model.device
+    args.jit = model.jit
+    args.train_bs = model.train_bs
+    args.eval_bs = model.eval_bs
+    # only enable fp16 in GPU inference
+    if args.device == "cpu":
+        args.eval_fp16 = False
+    return args
+
+def apply_args(model: BenchmarkModel, args: argparse.Namespace):
+    # apply eval_fp16
+    if args.eval_fp16:
+        model.eval_model, model.eval_example_inputs = enable_fp16(model.eval_model, model.eval_example_inputs)
+    # apply fx2trt for eval
+    if args.fx2trt:
+        assert args.device == 'cuda', "fx2trt is only available with CUDA."
+        assert not args.jit, "fx2trt with JIT is not available."
+        model.eval_model = enable_fx2trt(args.eval_bs, args.eval_fp16, model.eval_model, model.eval_example_inputs)
+
+def enable_fp16(model: torch.nn.Module, example_input: Tuple[torch.tensor]) -> Tuple[torch.nn.Module, Tuple[torch.tensor]]:
+    return model.half(), (example_input[0].half(),)
+
+def enable_fx2trt(max_batch_size: int, fp16: bool, model: torch.nn.Module, example_inputs: Tuple[torch.tensor]) -> torch.nn.Module:
+    from torchbenchmark.util.fx2trt import lower_to_trt
+    return lower_to_trt(module=model, input=example_inputs, \
+                        max_batch_size=max_batch_size, fp16_mode=fp16)


### PR DESCRIPTION
In https://github.com/pytorch/benchmark/pull/663 we enabled fp16 by default for both CPU and GPU. This actually breaks the test because CPU doesn't support `half()`. This PR clears up the fp16 and fx2trt code, and disables fp16 by default on CPU.