### PR TITLE
Don't use jit when jit=False for pyhpc benchmarks

### DIFF
--- a/torchbenchmark/models/pyhpc_equation_of_state/eos_pytorch.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/eos_pytorch.py
@@ -10,7 +10,6 @@
 import torch
 
 
-@torch.jit.script
 def gsw_dHdT(sa, ct, p):
     """
     d/dT of dynamic enthalpy, analytical derivative

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/isoneutral_pytorch.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/isoneutral_pytorch.py
@@ -1,7 +1,6 @@
 import torch
 
 
-@torch.jit.script
 def get_drhodT(salt, temp, p):
     rho0 = 1024.0
     z0 = 0.0
@@ -16,14 +15,12 @@ def get_drhodT(salt, temp, p):
     return -(betaTs * thetas + betaT * (1 - gammas * grav * zz * rho0)) * rho0
 
 
-@torch.jit.script
 def get_drhodS(salt, temp, p):
     betaS = 0.78e-3
     rho0 = 1024.0
     return betaS * rho0 * torch.ones_like(temp)
 
 
-@torch.jit.script
 def dm_taper(sx):
     """
     tapering function for isopycnal slopes
@@ -33,7 +30,6 @@ def dm_taper(sx):
     return 0.5 * (1.0 + torch.tanh((-torch.abs(sx) + iso_slopec) / iso_dslope))
 
 
-@torch.jit.script
 def isoneutral_diffusion_pre(
     maskT,
     maskU,

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/tke_pytorch.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/tke_pytorch.py
@@ -1,7 +1,6 @@
 import torch
 
 
-@torch.jit.script
 def solve_tridiag(a, b, c, d):
     """
     Solves a tridiagonal matrix system with diagonals a, b, c and RHS vector d.
@@ -24,7 +23,6 @@ def solve_tridiag(a, b, c, d):
     return out
 
 
-@torch.jit.script
 def solve_implicit(ks, a, b, c, d, b_edge):
     land_mask = (ks >= 0)[:, :, None]
     edge_mask = land_mask & (
@@ -42,7 +40,6 @@ def solve_implicit(ks, a, b, c, d, b_edge):
     return solve_tridiag(a_tri, b_tri, c_tri, d_tri), water_mask
 
 
-@torch.jit.script
 def _calc_cr(rjp, rj, rjm, vel):
     """
     Calculates cr value used in superbee advection scheme
@@ -51,7 +48,6 @@ def _calc_cr(rjp, rj, rjm, vel):
     return torch.where(vel > 0.0, rjm, rjp) / torch.where(torch.abs(rj) < eps, eps, rj)
 
 
-@torch.jit.script
 def pad_z_edges(arr):
     arr_shape = list(arr.shape)
     arr_shape[2] += 2
@@ -60,7 +56,6 @@ def pad_z_edges(arr):
     return out
 
 
-@torch.jit.script
 def limiter(cr):
     return torch.maximum(
         torch.tensor([0.0], device=cr.device),
@@ -71,7 +66,6 @@ def limiter(cr):
     )
 
 
-@torch.jit.script
 def _adv_superbee(vel, var, mask, dx, axis: int, cost, cosu, dt_tracer: float):
     if axis == 0:
         dx = cost[None, 2:-2, None] * dx[1:-2, None, None]
@@ -121,7 +115,6 @@ def _adv_superbee(vel, var, mask, dx, axis: int, cost, cosu, dt_tracer: float):
         raise ValueError("axis must be 0, 1, or 2")
 
 
-@torch.jit.script
 def adv_flux_superbee_wgrid(
     adv_fe,
     adv_fn,
@@ -163,7 +156,6 @@ def adv_flux_superbee_wgrid(
     )
 
 
-@torch.jit.script
 def integrate_tke(
     u,
     v,


### PR DESCRIPTION
#651 caused some pretty dramatic changes to my benchmarking results.  It turns out it enabled jit for "eager" mode.  This restores the prior behavior.