### PR TITLE
Switch to python 3.8 as default in CI and readme.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Install Conda
           command: ./scripts/install_basics.sh
       - run:
-          name: Install CUDA 11.1
+          name: Install CUDA 11.3
           command: sudo ./scripts/install_cuda.sh
       - run:
           name: Install PyTorch nightly

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ conda install -y python=3.8
 # or, using a new conda environment
 conda create -n torchbenchmark python=3.8
 conda activate torchbenchmark
-# we depend on git lfs tool to store minimal input dataset such as images and annotations, the size of which is ~20 MB
+# we depend on git lfs tool to store minimal input dataset such as images and annotations
+# the total size of input dataset is ~20 MB
 conda install -y git-lfs
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ except for the torch products which are intended to be installed separately so
 different torch versions can be benchmarked.
 
 ### Using Pre-built Packages
-We support python 3.7 and 3.8 and 3.8 is recommended. Currently, there are compatibility issues with 3.9+.  Conda is optional but suggested. To switch to python 3.8 in conda:
+We support python 3.7 and 3.8, and 3.8 is recommended. Currently, there are compatibility issues with 3.9+.  Conda is optional but suggested. To switch to python 3.8 in conda:
 ```
 # using your current conda environment:
 conda install -y python=3.8

--- a/README.md
+++ b/README.md
@@ -11,24 +11,31 @@ except for the torch products which are intended to be installed separately so
 different torch versions can be benchmarked.
 
 ### Using Pre-built Packages
-Use python 3.7 as currently there are compatibility issues with 3.8+.  Conda is optional but suggested.  To switch to python 3.7 in conda:
+We support python 3.7 and 3.8 and 3.8 is recommended. Currently, there are compatibility issues with 3.9+.  Conda is optional but suggested. To switch to python 3.8 in conda:
 ```
 # using your current conda environment:
-conda install -y python=3.7
+conda install -y python=3.8
 
 # or, using a new conda environment
-conda create -n torchbenchmark python=3.7
+conda create -n torchbenchmark python=3.8
 conda activate torchbenchmark
+# we depend on git lfs tool to store minimal input dataset such as images and annotations, the size of which is ~20 MB
+conda install -y git-lfs
 ```
 
-Install pytorch, torchtext, and torchvision using conda:
+If you are running Nvidia GPU tests, we support CUDA 10.2+, and CUDA 11.3 is recommended:
 ```
-conda install -y pytorch torchtext torchvision -c pytorch-nightly
+conda install -y -c pytorch magma-cuda113
+```
+
+Then install pytorch, torchtext, and torchvision using conda:
+```
+conda install -y pytorch torchtext torchvision cudatoolkit=11.3 -c pytorch-nightly
 ```
 Or use pip:
 (but don't mix and match pip and conda for the torch family of libs! - [see notes below](#notes))
 ```
-pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
 ```
 
 Install the benchmark suite, which will recursively install dependencies for all the models.  Currently, the repo is intended to be installed from the source tree.
@@ -129,6 +136,3 @@ See [Unidash](https://www.internalfb.com/intern/unidash/dashboard/pytorch_benchm
 ## Adding new models
 
 See [Adding Models](torchbenchmark/models/ADDING_MODELS.md).
-
-## Legacy
-See `legacy` for rnn benchmarks and related scripts that were previously at the top level of this repo.

--- a/components/_impl/tasks/base.py
+++ b/components/_impl/tasks/base.py
@@ -1,6 +1,7 @@
 """Add Task abstraction to reduce the friction of controlling a remote worker."""
 import abc
 import ast
+import sys
 import functools
 import inspect
 import marshal
@@ -119,16 +120,28 @@ def parse_f(f: typing.Callable) -> typing.Tuple[inspect.Signature, str]:
     src_lines = f_src.splitlines(keepends=False)
 
     node: ast.AST
-    for node in f_ast.body[0].body:
+    for idx, node in enumerate(f_ast.body[0].body):
         # In Python 3.7, there is a bug in `ast` that causes it to incorrectly
         # report the start line of bare multi-line strings:
         #   https://bugs.python.org/issue16806
         # Given that the only use for such strings is a docstring (or multi
         # line comment), we simply elect to skip over them and index on the
         # first node that will give valid indices.
-        if node.col_offset == -1:
-            assert isinstance(node.value, ast.Str), f"Expected `ast.Str`, got {type(node)}. ({node}) {node.lineno}"
-            continue
+        # To support both Python 3.7 and 3.8,
+        # We also need to drop bare multi-line strings in 3.8
+        if sys.version_info[:2] == (3, 7):
+            if node.col_offset == -1:
+                assert isinstance(node.value, ast.Str), f"Expected `ast.Str`, got {type(node)}. ({node}) {node.lineno}" 
+                continue
+        else:
+            if idx == 0 and isinstance(node, ast.Expr):
+                text: Option[str] = None
+                if isinstance(node.value, ast.Str):
+                    text = node.value.s
+                elif isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    text = node.value
+                if text and "\n" in text and ast.get_docstring(f_ast.body[0], clean=False) == text:
+                    continue
 
         raw_body_lines = src_lines[node.lineno - 1:]
         col_offset = node.col_offset

--- a/components/test/test_subprocess.py
+++ b/components/test/test_subprocess.py
@@ -90,7 +90,7 @@ class TestParseFunction(TestCase):
             \"\"\"Docstring
 
             Note: This will be dropped in Python 3.7. See `parse_f` for details.
-            \"\"\"\n\n""" if not sys.version_info[:2] == (3,7) else ""
+            \"\"\"\n\n""" if sys.version_info[:2] > (3,7) else ""
         self.assertExpectedInline(
             self._indent(body), f"""{docstring}\
             x += 1
@@ -132,7 +132,7 @@ class TestParseFunction(TestCase):
             \"\"\"Identity, but with more steps
 
             Culled, as this is a multi-line docstring
-            \"\"\"\n""" if not sys.version_info[:2] == (3, 7) else ""
+            \"\"\"\n""" if sys.version_info[:2] > (3,7) else ""
         self.assertExpectedInline(
             self._indent(body), f"""{docstring}\
             return x""",
@@ -175,7 +175,7 @@ class TestParseFunction(TestCase):
             \"\"\"Begin the actual body.
 
             (For better or worse...)
-            \"\"\"\n""" if not sys.version_info[:2]==(3,7) else ""
+            \"\"\"\n""" if sys.version_info[:2] > (3,7) else ""
         self.assertExpectedInline(
             self._indent(body), f"""{docstring}\
             del x

--- a/components/test/test_subprocess.py
+++ b/components/test/test_subprocess.py
@@ -86,26 +86,13 @@ class TestParseFunction(TestCase):
 
         _, body = task_base.parse_f(f)
         # Python 3.7 removes docstring but 3.8+ doesn't. See `parse_f` for details.
-        if sys.version_info[:2] == (3, 7):
-            self.assertExpectedInline(
-                self._indent(body), """\
-            x += 1
-
-            y = \"\"\"
-                This is preserved.
-            \"\"\"
-
-            # Comment in src.
-            return y""",
-            )
-        else:
-            self.assertExpectedInline(
-                self._indent(body), """\
+        docstring = """\
             \"\"\"Docstring
 
             Note: This will be dropped in Python 3.7. See `parse_f` for details.
-            \"\"\"
-
+            \"\"\"\n\n""" if not sys.version_info[:2] == (3,7) else ""
+        self.assertExpectedInline(
+            self._indent(body), f"""{docstring}\
             x += 1
 
             y = \"\"\"
@@ -115,7 +102,6 @@ class TestParseFunction(TestCase):
             # Comment in src.
             return y""",
             )
-
 
     def test_parse_method(self) -> None:
         class MyClass:
@@ -142,21 +128,15 @@ class TestParseFunction(TestCase):
 
         _, body = task_base.parse_f(MyClass.g)
         # Python 3.7 removes docstring but 3.8+ doesn't. See `parse_f` for details.
-        if sys.version_info[:2] == (3, 7):
-            self.assertExpectedInline(
-                self._indent(body), """\
-            return x""",
-            )
-        else:
-            self.assertExpectedInline(
-                self._indent(body), """\
+        docstring = """\
             \"\"\"Identity, but with more steps
 
             Culled, as this is a multi-line docstring
-            \"\"\"
+            \"\"\"\n""" if not sys.version_info[:2] == (3, 7) else ""
+        self.assertExpectedInline(
+            self._indent(body), f"""{docstring}\
             return x""",
-            )
-
+        )
 
     def test_parse_pathological(self) -> None:
         def f(
@@ -191,31 +171,13 @@ class TestParseFunction(TestCase):
 
         _, body = task_base.parse_f(f)
         # Python 3.7 removes docstring but 3.8+ doesn't. See `parse_f` for details.
-        if sys.version_info[:2] == (3, 7):
-            self.assertExpectedInline(
-                self._indent(body), """\
-            del x
-            q = y.get(
-                z,
-                None,
-            )
-
-            # Intermediate comment
-
-            if False:
-                return 1
-            elif q:
-                raise ValueError
-
-            q = 1""",
-            )
-        else:
-            self.assertExpectedInline(
-                self._indent(body), """\
+        docstring = """\
             \"\"\"Begin the actual body.
 
             (For better or worse...)
-            \"\"\"
+            \"\"\"\n""" if not sys.version_info[:2]==(3,7) else ""
+        self.assertExpectedInline(
+            self._indent(body), f"""{docstring}\
             del x
             q = y.get(
                 z,
@@ -230,8 +192,7 @@ class TestParseFunction(TestCase):
                 raise ValueError
 
             q = 1""",
-            )
-            
+        )
 
     def test_fully_typed(self) -> None:
         def f(x):

--- a/components/test/test_subprocess.py
+++ b/components/test/test_subprocess.py
@@ -156,8 +156,6 @@ class TestParseFunction(TestCase):
                 raise ValueError
 
             q = 1
-            # Trailing comment isn't part of the execution, so it is actually
-            # dropped by `inspect`. (Surprisingly.)
 
         _, body = task_base.parse_f(f)
         self.assertExpectedInline(

--- a/scripts/install_basics.sh
+++ b/scripts/install_basics.sh
@@ -13,7 +13,7 @@ chmod +x "$filename"
 
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
-# Use python3.8 by default, supports python 3.7 and 3.8
+# Use python3.8 by default
 conda install -y python=3.8
 
 

--- a/scripts/install_basics.sh
+++ b/scripts/install_basics.sh
@@ -11,9 +11,9 @@ wget "$CONDA"
 chmod +x "$filename"
 ./"$filename" -b -u
 
-# Force to use python3.7
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
-conda install -y python=3.7
+# Use python3.8 by default, supports python 3.7 and 3.8
+conda install -y python=3.8
 
 

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -3,28 +3,27 @@
 set -ex
 
 echo "Installing nvidia kernel driver"
-DRIVER_FN="NVIDIA-Linux-x86_64-460.39.run"
+DRIVER_FN="NVIDIA-Linux-x86_64-470.86.run"
 wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
 sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
 nvidia-smi
 
-echo "Installing CUDA 11.1 and CuDNN"
-rm -rf /usr/local/cuda-11.1 /usr/local/cuda
-# install CUDA 11.1 in the same container
-# CUDA download archive: https://developer.nvidia.com/cuda-toolkit-archive
-CUDA_INSTALLER=cuda_11.1.1_455.32.00_linux.run
-wget -q https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/$CUDA_INSTALLER
-chmod +x $CUDA_INSTALLER
-./$CUDA_INSTALLER --toolkit --silent
-rm -f ${CUDA_INSTALLER}
-rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.1 /usr/local/cuda
+echo "Installing CUDA 11.3 and CuDNN"
+rm -rf /usr/local/cuda-11.3 /usr/local/cuda
+# install CUDA 11.3 in the same container
+CUDA_INSTALLER=cuda_11.3.1_465.19.01_linux.run
+wget -q https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/"${CUDA_INSTALLER}"
+chmod +x "${CUDA_INSTALLER}"
+./"${CUDA_INSTALLER}" --toolkit --silent
+rm -f "${CUDA_INSTALLER}"
+rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.3 /usr/local/cuda
 
-# install CUDA 11.1 CuDNN 8.0.4
+# install CUDA 11.3 CuDNN 8.2.0
 # cuDNN download archive: https://developer.nvidia.com/rdp/cudnn-archive
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 mkdir tmp_cudnn && cd tmp_cudnn
-wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.4/cudnn-11.1-linux-x64-v8.0.4.30.tgz -O cudnn-8.0.tgz
-tar xf cudnn-8.0.tgz
+wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.2.0/cudnn-11.3-linux-x64-v8.2.0.53.tgz -O cudnn-8.2.tgz
+tar xf cudnn-8.2.tgz
 cp -a cuda/include/* /usr/local/cuda/include/
 cp -a cuda/lib64/* /usr/local/cuda/lib64/
 cd ..

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -4,15 +4,12 @@ set -e
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-# pycocotools requires numpy 1.17 https://github.com/cocodataset/cocoapi/issues/356
-conda install -y numpy=1.17 requests=2.22 ninja pyyaml setuptools gitpython
-
-# conda install -y pytorch torchvision -c pytorch-nightly
-# Changing to pip to work around https://github.com/pytorch/pytorch/issues/49375
+conda install -y numpy requests ninja pyyaml setuptools gitpython
+conda install -y -c pytorch magma-cuda113
 
 pip install --pre torch torchvision torchtext \
     --progress-bar off \
-    -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
+    -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
 
 conda install -y expecttest -c conda-forge
 

--- a/scripts/recreate_conda_environment.sh
+++ b/scripts/recreate_conda_environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 NAME=torchbenchmark
-PYTHON_VERSION=${PYTHON_VERSION:-3.7}
+PYTHON_VERSION=${PYTHON_VERSION:-3.8}
 
 source $(conda info --base)/etc/profile.d/conda.sh
 

--- a/scripts/setup_ci.sh
+++ b/scripts/setup_ci.sh
@@ -32,8 +32,3 @@ git lfs fetch
 git lfs checkout .
 
 sudo pkill -SIGHUP dockerd
-
-DRIVER_FN="NVIDIA-Linux-x86_64-440.59.run"
-wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
-sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
-nvidia-smi


### PR DESCRIPTION
After fixing a few compatibility issues, torchbenchmark can now run on both Python 3.7 and 3.8. We should switch to version 3.8 as default in the CircleCI and README.md.
This PR also moves to CUDA 11.3 as this is the CUDA version used in the nightly CI environment.