### PR TITLE
Add an option to dump the latest successful nightly build to a file.

### DIFF
--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -121,7 +121,8 @@ if __name__ == "__main__":
                 dump_wheels(wheels, args.dump_latest_build)
                 exit(0)
             else:
-                # TODO: check if end_date is earlier than the earliest version available in pip nightly builds
+                # TODO: check if d is earlier than the earliest version available in pip nightly builds
+                # Unlikely to happen, but still good to check
                 d = d - timedelta(days=1)
 
     wheels = get_n_prior_nightly_wheels(packages=args.packages,

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -110,7 +110,8 @@ if __name__ == "__main__":
     parser.add_argument("--priordays", type=int, default=1, help="Number of days")
     parser.add_argument("--reverse", action="store_true", help="Return reversed result")
     parser.add_argument("--packages", required=True, type=str, nargs="+", help="List of package names")
-    parser.add_argument("--dump-latest-build", type=str, help="Find the latest successful build of packages and dump into a file")
+    parser.add_argument("--dump-latest-wheels", type=str,
+                        help="Dump the latest successful build of pytorch domain packages into a file")
     args = parser.parse_args()
 
     if args.dump_latest_build:

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -52,7 +52,7 @@ def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_i
     return data
 
 def get_nightly_wheel_urls(packages:list, date:date,
-                           py_version='cp37', platform_version='linux_x86_64'):
+                           py_version='cp38', platform_version='linux_x86_64'):
     """Gets urls to wheels for specified packages matching the date, py_version, platform_version
     """
     date_str = f"{date.year}{date.month:02}{date.day:02}"
@@ -73,7 +73,7 @@ def get_nightly_wheel_urls(packages:list, date:date,
     return rc
 
 def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
-                                py_version='cp37', platform_version='linux_x86_64', reverse=False):
+                                py_version='cp38', platform_version='linux_x86_64', reverse=False):
     rc = []
     curr_date = start_date
     while curr_date <= end_date:
@@ -88,7 +88,7 @@ def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
     return rc
 
 def get_n_prior_nightly_wheels(packages:list, n:int,
-                               py_version='cp37', platform_version='linux_x86_64', reverse=False):
+                               py_version='cp38', platform_version='linux_x86_64', reverse=False):
     end_date = date.today()
     start_date = end_date - timedelta(days=n)
     return get_nightly_wheels_in_range(packages, start_date, end_date,
@@ -105,7 +105,7 @@ def dump_wheels(wheels, out_file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--pyver", type=str, default="cp37", help="PyTorch Python version")
+    parser.add_argument("--pyver", type=str, default="cp38", help="PyTorch Python version")
     parser.add_argument("--platform", type=str, default="linux_x86_64", help="PyTorch platform")
     parser.add_argument("--priordays", type=int, default=1, help="Number of days")
     parser.add_argument("--reverse", action="store_true", help="Return reversed result")

--- a/torchbenchmark/util/torch_nightly.py
+++ b/torchbenchmark/util/torch_nightly.py
@@ -114,12 +114,12 @@ if __name__ == "__main__":
                         help="Dump the latest successful build of pytorch domain packages into a file")
     args = parser.parse_args()
 
-    if args.dump_latest_build:
+    if args.dump_latest_wheels:
         d = date.today()
         while True:
             wheels = get_nightly_wheel_urls(args.packages, d, py_version=args.pyver, platform_version=args.platform)
             if wheels and wheels_contain_all_packages(wheels, args.packages):
-                dump_wheels(wheels, args.dump_latest_build)
+                dump_wheels(wheels, args.dump_latest_wheels)
                 exit(0)
             else:
                 # TODO: check if d is earlier than the earliest version available in pip nightly builds


### PR DESCRIPTION
Sometimes the pytorch nightly build fails, and our script should be able to generate a list of wheels that has the most recent successful build.