### PR TITLE
Install the dependencies the first time run the benchmark.

### DIFF
--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -28,11 +28,8 @@ jobs:
           conda create -y -n "$BISECT_CONDA_ENV" python="${PYTHON_VERSION}"
           . activate "$BISECT_CONDA_ENV"
           conda install -y numpy requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi \
-                           typing_extensions future six dataclasses tabulate gitpython
+                           typing_extensions future six dataclasses tabulate gitpython tqdm
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          # Install pytorch nightly
-          conda install -y -c pytorch-nightly torchtext torchvision cudatoolkit="${CUDA_VERSION}"
-          python install.py
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -27,16 +27,14 @@ jobs:
         run: |
           conda create -y -n "$BISECT_CONDA_ENV" python=${{ }}
           . activate "$BISECT_CONDA_ENV"
-          conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six dataclasses tabulate gitpython git-lfs
+          conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi \
+                           typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          # Install pytorch nightly
-          conda install -y -c pytorch-nightly torchtext torchvision cudatoolkit="${CUDA_VER}"
-          python install.py
       - name: Bisection
         run: |
-          export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
-          export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
+          BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
+          BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
           bash ./.github/scripts/run-bisection.sh
           # Update the result json symbolic link
           ln -sf "${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json" "${BISECT_BASE}/result.json"


### PR DESCRIPTION
Strictly speaking, the bisection workflow shouldn't depend on PyTorch nightly: instead, it should install the TorchBench deps after the first time it compiles PyTorch and its domain packages.

This PR does this optimization and removes PyTorch nightly dependencies for bisection jobs. So the bisection jobs and OnDemand CI jobs can proceed even if the nightly packages are unavailable.

The OnDemand PR CI link is here: https://github.com/pytorch/pytorch/pull/71323. It shows we can run PR CI even without installing nightly packages.