### PR TITLE
Patch speech_transformer data loading to load from absolute path

### DIFF
--- a/run.py
+++ b/run.py
@@ -163,7 +163,8 @@ if __name__ == "__main__":
         print(f"Unable to find model matching {args.model}.")
         exit(-1)
     model_args = inspect.signature(Model)
-    if extra_args and not 'extra_args' in model_args.parameters:
+    support_extra_args = 'extra_args' in model_args.parameters
+    if extra_args and not support_extra_args:
         print(f"The model {args.model} doesn't accept extra args: {extra_args}")
         exit(-1)
     print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode.")
@@ -174,14 +175,23 @@ if __name__ == "__main__":
     if args.bs:
         try:
             if args.test == "eval":
-                m = Model(device=args.device, jit=(args.mode == "jit"), eval_bs=args.bs, extra_args=extra_args)
+                if support_extra_args:
+                    m = Model(device=args.device, jit=(args.mode == "jit"), eval_bs=args.bs, extra_args=extra_args)
+                else:
+                    m = Model(device=args.device, jit=(args.mode == "jit"), eval_bs=args.bs)
             elif args.test == "train":
-                m = Model(device=args.device, jit=(args.mode == "jit"), train_bs=args.bs, extra_args=extra_args)
+                if support_extra_args:
+                    m = Model(device=args.device, jit=(args.mode == "jit"), train_bs=args.bs, extra_args=extra_args)
+                else:
+                    m = Model(device=args.device, jit=(args.mode == "jit"), eval_bs=args.bs)
         except:
             print(f"The model {args.model} doesn't support specifying batch size, please remove --bs argument in the commandline.")
             exit(1)
     else:
-        m = Model(device=args.device, jit=(args.mode == "jit"), extra_args=extra_args)
+        if support_extra_args:
+            m = Model(device=args.device, jit=(args.mode == "jit"), extra_args=extra_args)
+        else:
+            m = Model(device=args.device, jit=(args.mode == "jit"))
 
     test = getattr(m, args.test)
     model_flops = None

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -30,8 +30,8 @@ class Model(BenchmarkModel):
             return
         self.traincfg = SpeechTransformerTrainConfig(prefetch=True, train_bs=train_bs, num_train_batch=NUM_TRAIN_BATCH)
         self.evalcfg = SpeechTransformerEvalConfig(self.traincfg, num_eval_batch=NUM_EVAL_BATCH)
-        self.traincfg.model.cuda()
-        self.evalcfg.model.cuda()
+        self.traincfg.model.to(self.device)
+        self.evalcfg.model.to(self.device)
 
     def get_module(self):
         if self.device == "cpu":
@@ -40,7 +40,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("JIT is not supported by this model")
         for data in self.traincfg.tr_loader:
             padded_input, input_lengths, padded_target = data
-            return self.traincfg.model, (padded_input.cuda(), input_lengths.cuda(), padded_target.cuda())
+            return self.traincfg.model, (padded_input.to(self.device), input_lengths.to(self.device), padded_target.to(self.device))
 
     def train(self, niter=1):
         if self.device == "cpu":

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -37,7 +37,11 @@ class SpeechTransformerTrainConfig:
     batch_frames = 15000
     maxlen_in = 800
     maxlen_out = 150
-    num_workers = 4
+    # don't use subprocess in dataloader
+    # because TorchBench is only running 1 batch
+    num_workers = 0
+    # original value
+    # num_workers = 4
     # optimizer
     k = 0.2
     warmup_steps = 1

--- a/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
+++ b/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
@@ -148,7 +148,7 @@ def load_inputs_and_targets(batch, LFR_m=1, LFR_n=1):
     # TorchBench: Patch the input data with current file directory
     # Current file path: TORCHBENCH_ROOT/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
     TORCHBENCH_ROOT = Path(__file__).parents[5]
-    xs = [kaldi_io.read_mat(TORCHBENCH_ROOT.joinpath(b[1]['input'][0]['feat'])) for b in batch]
+    xs = [kaldi_io.read_mat(TORCHBENCH_ROOT.joinpath(b[1]['input'][0]['feat']).resolve()) for b in batch]
     ys = [b[1]['output'][0]['tokenid'].split() for b in batch]
 
     if LFR_m != 1 or LFR_n != 1:

--- a/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
+++ b/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
@@ -10,6 +10,7 @@ Logic:
 """
 import json
 
+from pathlib import Path
 import numpy as np
 import torch
 import torch.utils.data as data
@@ -144,7 +145,10 @@ def load_inputs_and_targets(batch, LFR_m=1, LFR_n=1):
     # load acoustic features and target sequence of token ids
     # for b in batch:
     #     print(b[1]['input'][0]['feat'])
-    xs = [kaldi_io.read_mat(b[1]['input'][0]['feat']) for b in batch]
+    # TorchBench: Patch the input data with current file directory
+    # Current file path: TORCHBENCH_ROOT/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
+    TORCHBENCH_ROOT = Path(__file__).parents[5]
+    xs = [kaldi_io.read_mat(TORCHBENCH_ROOT.joinpath(b[1]['input'][0]['feat'])) for b in batch]
     ys = [b[1]['output'][0]['tokenid'].split() for b in batch]
 
     if LFR_m != 1 or LFR_n != 1:

--- a/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
+++ b/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
@@ -148,7 +148,7 @@ def load_inputs_and_targets(batch, LFR_m=1, LFR_n=1):
     # TorchBench: Patch the input data with current file directory
     # Current file path: TORCHBENCH_ROOT/torchbenchmark/models/speech_transformer/speech_transformer/data/data.py
     TORCHBENCH_ROOT = Path(__file__).parents[5]
-    xs = [kaldi_io.read_mat(TORCHBENCH_ROOT.joinpath(b[1]['input'][0]['feat']).resolve()) for b in batch]
+    xs = [kaldi_io.read_mat(str(TORCHBENCH_ROOT.joinpath(b[1]['input'][0]['feat']).resolve())) for b in batch]
     ys = [b[1]['output'][0]['tokenid'].split() for b in batch]
 
     if LFR_m != 1 or LFR_n != 1:


### PR DESCRIPTION
Lazy Tensor users would like to run the benchmark from a different directory. Yet the data loading script in speech transformer model always assume the code runs under the `benchmark/` directory.

This PR patches the dataloading code of speech transformer model such that it finds the absolute path of input data, and load data from there.

It also fixes a bug in `run.py` related to `extra_args`.