### PR TITLE
Remove the use of distro.linux_distribution() 

### DIFF
--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -149,8 +149,7 @@ def get_machine_type():
     # initially, just intend to identify a known environment and for any other 
     # environment revert to no-op.  Expand functionality over time as needed.
     if platform.system() == 'Linux':
-        name = distro.linux_distribution()[0]
-        if name == "Amazon Linux":
+        if distro.name() == "Amazon Linux":
             return MACHINE.AMAZON_LINUX
 
     return MACHINE.UNKNOWN


### PR DESCRIPTION
distro.linux_distribution() is now deprecated and should be replaced with distro.name().