### PR TITLE
Enable CUDA graph train on torchvision models

### DIFF
--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -1,6 +1,5 @@
-import argparse
 import torch
-import torch.optim as optim
+import argparse
 from torchbenchmark.util.model import BenchmarkModel
 from typing import List, Tuple
 
@@ -55,6 +54,7 @@ def enable_cudagraph(model: BenchmarkModel, example_inputs: Tuple[torch.tensor])
     torch.cuda.current_stream().wait_stream(s)
     # capture
     g = torch.cuda.CUDAGraph()
+    optimizer.zero_grad(set_to_none=True)
     with torch.cuda.graph(g):
         static_y_pred = model.model(*example_inputs)
         static_loss = loss_fn(static_y_pred, model.example_outputs)

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -40,8 +40,8 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
 
 def enable_cudagraph(model: BenchmarkModel, example_inputs: Tuple[torch.tensor]):
     # setup input and output
-    optimizer = optim.Adam(model.model.parameters())
-    loss_fn = torch.nn.CrossEntropyLoss()
+    optimizer = model.optimizer
+    loss_fn = model.loss_fn
     # warmup
     s = torch.cuda.Stream()
     s.wait_stream(torch.cuda.current_stream())

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -35,7 +35,7 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         model.eval_model = enable_fx2trt(args.eval_bs, args.eval_fp16, model.eval_model, model.eval_example_inputs)
     # apply cuda graph for train
     if args.train_cudagraph:
-        model.model = enable_cudagraph(model)
+        model.model = enable_cudagraph(model, model.example_input)
 
 def enable_cudagraph(model: BenchmarkModel, example_input: Tuple[torch.tensor]):
     # setup input and output

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -38,7 +38,7 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         model.model = enable_cudagraph(model.model)
 
 def enable_cudagraph(model: torch.nn.Module):
-    return torch.cuda.make_graph_callables(model.model, model.example_inputs)
+    return torch.cuda.make_graphed_callables(model.model, model.example_inputs)
 
 def enable_fp16(model: torch.nn.Module, example_input: Tuple[torch.tensor]) -> Tuple[torch.nn.Module, Tuple[torch.tensor]]:
     return model.half(), (example_input[0].half(),)

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -35,7 +35,7 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         model.eval_model = enable_fx2trt(args.eval_bs, args.eval_fp16, model.eval_model, model.eval_example_inputs)
     # apply cuda graph for train
     if args.train_cudagraph:
-        model.model = enable_cudagraph(model, model.example_input)
+        model.model = enable_cudagraph(model, model.example_inputs)
 
 def enable_cudagraph(model: BenchmarkModel, example_input: Tuple[torch.tensor]):
     # setup input and output

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -35,10 +35,10 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         model.eval_model = enable_fx2trt(args.eval_bs, args.eval_fp16, model.eval_model, model.eval_example_inputs)
     # apply cuda graph for train
     if args.train_cudagraph:
-        model.model = enable_cudagraph(model.model)
+        model.model = enable_cudagraph(model.model, model.example_inputs)
 
-def enable_cudagraph(model: torch.nn.Module):
-    return torch.cuda.make_graphed_callables(model.model, model.example_inputs)
+def enable_cudagraph(model: torch.nn.Module, example_input: Tuple[torch.tensor]):
+    return torch.cuda.make_graphed_callables(model, example_input)
 
 def enable_fp16(model: torch.nn.Module, example_input: Tuple[torch.tensor]) -> Tuple[torch.nn.Module, Tuple[torch.tensor]]:
     return model.half(), (example_input[0].half(),)

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -9,7 +9,7 @@ def parse_args(model: BenchmarkModel, extra_args: List[str]) -> argparse.Namespa
     parser.add_argument("--eval-fp16", action='store_false', help="enable eval fp16")
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
     parser.add_argument("--flops", action='store_true', help="enable flops counting")
-    parser.add_argument("--train_cudagraph", action='store_true', help="enable CUDA Graph for train")
+    parser.add_argument("--cudagraph", action='store_true', help="enable CUDA Graph. Currently only implemented for train.")
     args = parser.parse_args(extra_args)
     args.device = model.device
     args.jit = model.jit
@@ -34,7 +34,7 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         assert not args.jit, "fx2trt with JIT is not available."
         model.eval_model = enable_fx2trt(args.eval_bs, args.eval_fp16, model.eval_model, model.eval_example_inputs)
     # apply cuda graph for train
-    if args.train_cudagraph:
+    if args.cudagraph:
         enable_cudagraph(model, model.example_inputs)
 
 def enable_cudagraph(model: BenchmarkModel, example_inputs: Tuple[torch.tensor]):

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -9,7 +9,7 @@ def parse_args(model: BenchmarkModel, extra_args: List[str]) -> argparse.Namespa
     parser.add_argument("--eval-fp16", action='store_false', help="enable eval fp16")
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
     parser.add_argument("--flops", action='store_true', help="enable flops counting")
-    parser.add_argument("--train_cudagraph", action='store_false', help="enable CUDA Graph for train")
+    parser.add_argument("--train_cudagraph", action='store_true', help="enable CUDA Graph for train")
     args = parser.parse_args(extra_args)
     args.device = model.device
     args.jit = model.jit
@@ -23,8 +23,8 @@ def parse_args(model: BenchmarkModel, extra_args: List[str]) -> argparse.Namespa
 def apply_args(model: BenchmarkModel, args: argparse.Namespace):
     if args.flops:
         from fvcore.nn import FlopCountAnalysis
-        model.train_flops = FlopCountAnalysis(model.model, tuple(self.example_inputs)).total()
-        model.eval_flops = FlopCountAnalysis(model.eval_model, tuple(self.eval_example_inputs)).total()
+        model.train_flops = FlopCountAnalysis(model.model, tuple(model.example_inputs)).total()
+        model.eval_flops = FlopCountAnalysis(model.eval_model, tuple(model.eval_example_inputs)).total()
     # apply eval_fp16
     if args.eval_fp16:
         model.eval_model, model.eval_example_inputs = enable_fp16(model.eval_model, model.eval_example_inputs)

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -38,7 +38,6 @@ def apply_args(model: BenchmarkModel, args: argparse.Namespace):
         enable_cudagraph(model, model.example_inputs)
 
 def enable_cudagraph(model: BenchmarkModel, example_inputs: Tuple[torch.tensor]):
-    # setup input and output
     optimizer = model.optimizer
     loss_fn = model.loss_fn
     # warmup

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -62,7 +62,7 @@ class TorchVisionModel(BenchmarkModel):
         for _ in range(niter):
             self.optimizer.zero_grad()
             for data, target in zip(real_input, real_output):
-                if self.args.train_cudagraph:
+                if self.args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)
                     self.g.replay()
@@ -72,6 +72,8 @@ class TorchVisionModel(BenchmarkModel):
                     self.optimizer.step()
 
     def eval(self, niter=1):
+        if self.args.cudagraph:
+            return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.eval_model
         example_inputs = self.eval_example_inputs
         for _i in range(niter):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -62,7 +62,7 @@ class TorchVisionModel(BenchmarkModel):
         real_input = [ torch.rand_like(self.example_inputs[0]) ]
         real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
-            for data, target in real_input, real_output:
+            for data, target in zip(real_input, real_output):
                 if self.args.train_cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -21,17 +21,13 @@ class TorchVisionModel(BenchmarkModel):
         self.eval_example_inputs = (torch.randn((eval_bs, 3, 224, 224)).to(self.device),)
         self.example_outputs = torch.rand_like(self.model(*self.example_inputs))
 
-        # setup target shapes, used in cuda graph
-        target_shape = [32, 1000]
-        self.target = torch.empty(target_shape[0], dtype=torch.long, device=self.device).random_(target_shape[1])
+        # setup optimizer and loss_fn
+        self.optimizer = optim.Adam(self.model.parameters())
+        self.loss_fn = torch.nn.CrossEntropyLoss()
 
         # process extra args
         self.args = parse_args(self, extra_args)
         apply_args(self, self.args)
-
-        # setup optimizer and loss_fn
-        self.optimizer = optim.Adam(self.model.parameters())
-        self.loss_fn = torch.nn.CrossEntropyLoss()
 
         if self.jit:
             if hasattr(torch.jit, '_script_pdt'):


### PR DESCRIPTION
Adds CUDA Graph for torchvision models. Since we have used batch sizes that either matches original paper (train), or saturate GPU (device), we won't see much improvement for default batch sizes. However, the performance gain occurs mostly when the batch size is small.

Without CUDA Graph (with batch size 32):
```
$ python run.py resnet50 -t train -d cuda
Running train method from resnet50 on cuda in eager mode.
GPU Time:            1034.030 milliseconds
CPU Dispatch Time:   1026.865 milliseconds
CPU Total Wall Time: 1034.011 milliseconds
```

 With CUDA Graph (with batch size 32):
```
$ python run.py resnet50 -t train -d cuda --train_cudagraph
Running train method from resnet50 on cuda in eager mode.
GPU Time:            1038.927 milliseconds
CPU Dispatch Time:   346.313 milliseconds
CPU Total Wall Time: 1038.941 milliseconds
```

# Latency by batch size (Train, fp32, on V100)

<google-sheets-html-origin>

Batch Size | Eager (ms) | CUDA Graph (ms) | Speedup
-- | -- | -- | --
1 | 89.033 | 50.233 | 43.58%
2 | 92.854 | 56.13 | 39.55%
4 | 93.676 | 71.465 | 23.71%
8 | 105.099 | 105.381 | -0.27%
16 | 167.292 | 167.966 | -0.40%
32 | 297.315 | 297.989 | -0.23%
64 | 561.262 | 562.029 | -0.14%

