### PR TITLE
Remove the numpy version requirement 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ timm == 0.4.12
 MonkeyType
 psutil
 pyyaml
-numpy == 1.21.0
+numpy
 scipy  # for lazy_bench.py


### PR DESCRIPTION
We shouldn't specify the numpy version because pytorch package should always depend on the default numpy version installed in conda.

Initially, the version constraint was added because pycocotools which yolov3 depends on has a bug: https://github.com/cocodataset/cocoapi/issues/356. Since the bug has been fixed by https://github.com/cocodataset/cocoapi/pull/354, we don't need to lock numpy to this version anymore.