### PR TITLE
Use py38 and CUDA 11.3 as default in the nightly wheel script

### DIFF
--- a/.github/scripts/generate-abtest-config.py
+++ b/.github/scripts/generate-abtest-config.py
@@ -113,16 +113,18 @@ def generate_bisection_tests(base, tip):
             signal_details[benchmark] = delta_percent
     return (signals, signal_details)
 
-def generate_bisection_config(base_file, tip_file):
+def generate_bisection_config(base_file, tip_file, base_commit, tip_commit):
     result = {}
     with open(base_file, "r") as bf:
         base = json.load(bf)
     with open(tip_file, "r") as tf:
         tip = json.load(tf)
     result["start_version"] = base["machine_info"]["pytorch_version"]
-    result["start"] = base["machine_info"]["pytorch_git_version"]
+    result["start_git_version"] = base["machine_info"]["pytorch_git_version"]
+    result["start"] = base_commit
     result["end_version"] = tip["machine_info"]["pytorch_version"]
-    result["end"] = tip["machine_info"]["pytorch_git_version"]
+    result["end_git_version"] = tip["machine_info"]["pytorch_git_version"]
+    result["end"] = tip_commit
     result["threshold"] = PERF_CHANGE_THRESHOLD
     result["direction"] = "both"
     result["timeout"] = PERF_TEST_TIMEOUT_THRESHOLD
@@ -180,7 +182,7 @@ if __name__ == "__main__":
         if json_file:
             base_version = get_pytorch_version(args.pytorch_dir, json_file)
             if base_version.commit != tip_version.commit:
-                result = generate_bisection_config(json_file, tip_json_file)
+                result = generate_bisection_config(json_file, tip_json_file, base_version.commit, tip_version.commit)
                 break
     with open(args.out, "w") as fo:
         yaml.dump(result, fo)

--- a/.github/workflows/v1-sweep.yml
+++ b/.github/workflows/v1-sweep.yml
@@ -41,7 +41,7 @@ jobs:
             echo "Running config $CONFIG ..."
             # Create a new conda env
             CONFIG_BASE=$(basename ${CONFIG})
-            CONDA_ENV_NAME=$(echo "${CONFIG_BASE}" | sed 's/.*-\(.*\)\.txt/\1/')
+            CONDA_ENV_NAME=$(echo "${CONFIG_BASE}" | sed 's/[^-]*-\(.*\)\.txt/\1/')
             conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION}
             . activate ${CONDA_ENV_NAME}
             conda install -y -c pytorch ${MAGMA_VERSION}

--- a/.github/workflows/v1-sweep.yml
+++ b/.github/workflows/v1-sweep.yml
@@ -71,12 +71,10 @@ jobs:
           pip install boto3
           for RESULT in ${SWEEP_JOB_OUTPUT}/*.json; do
             # Upload when the file is non-empty
-            if [ ! -s $RESULT ]; then
+            if [ -s $RESULT ]; then
               # Generate score file
               SCORE_FILE="${RESULT}.score.json"
               python compute_score.py --score_version v1 --benchmark_data_file "${RESULT}" > "${SCORE_FILE}"
-              # Enable OSS stat uploads
-              wget -O scripts/scribe.py https://github.com/pytorch/pytorch/raw/master/tools/stats/scribe.py || echo "failed to copy oss stat utils"
               # Upload score
               python scripts/upload_scribe.py --pytest_bench_json "${RESULT}" --torchbench_score_file "${SCORE_FILE}"
             fi

--- a/.github/workflows/v2-sweep.yml
+++ b/.github/workflows/v2-sweep.yml
@@ -50,7 +50,7 @@ jobs:
             conda install -y -c pytorch "${MAGMA_VERSION}"
             pip install -r "${CONFIG}"
             python install.py
-            bash .github/scripts/run.sh "${SWEEP_JOB_OUTPUT}"
+            # bash .github/scripts/run.sh "${SWEEP_JOB_OUTPUT}"
             # Remove the conda env
             conda deactivate
             conda env remove --name ${CONDA_ENV_NAME}

--- a/.github/workflows/v2-sweep.yml
+++ b/.github/workflows/v2-sweep.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Running config $CONFIG ..."
             # Create a new conda env
             CONFIG_BASE=$(basename ${CONFIG})
-            CONDA_ENV_NAME=$(echo "${CONFIG_BASE}" | sed 's/.*-\(.*\)\.txt/\1/')
+            CONDA_ENV_NAME=$(echo "${CONFIG_BASE}" | sed 's/[^-]*-\(.*\)\.txt/\1/')
             conda create -y -q --name ${CONDA_ENV_NAME} python=${PYTHON_VER}
             . activate ${CONDA_ENV_NAME}
             conda install -y git-lfs

--- a/.github/workflows/v2-sweep.yml
+++ b/.github/workflows/v2-sweep.yml
@@ -50,7 +50,7 @@ jobs:
             conda install -y -c pytorch "${MAGMA_VERSION}"
             pip install -r "${CONFIG}"
             python install.py
-            # bash .github/scripts/run.sh "${SWEEP_JOB_OUTPUT}"
+            bash .github/scripts/run.sh "${SWEEP_JOB_OUTPUT}"
             # Remove the conda env
             conda deactivate
             conda env remove --name ${CONDA_ENV_NAME}

--- a/.github/workflows/v2-sweep.yml
+++ b/.github/workflows/v2-sweep.yml
@@ -72,14 +72,14 @@ jobs:
           . activate ${CONDA_ENV_NAME}
           pip install -r requirements.txt
           pip install boto3
+          mkdir -p "${SWEEP_JOB_OUTPUT}/scores"
           for RESULT in ${SWEEP_JOB_OUTPUT}/*.json; do
             # Upload when the file is non-empty
-            if [ ! -s $RESULT ]; then
+            if [ -s $RESULT ]; then
               # Generate score file
-              SCORE_FILE="${RESULT}.score.json"
+              RESULT_BASENAME=$(basename "${RESULT}")
+              SCORE_FILE="${SWEEP_JOB_OUTPUT}/scores/${RESULT_BASENAME}.score.json"
               python compute_score.py --score_version "${CONFIG_VER}" --benchmark_data_file "${RESULT}" > "${SCORE_FILE}"
-              # Enable OSS stat uploads
-              wget -O scripts/scribe.py https://github.com/pytorch/pytorch/raw/master/tools/stats/scribe.py || echo "failed to copy oss stat utils"
               # Upload score
               python scripts/upload_scribe_${CONFIG_VER}.py --pytest_bench_json "${RESULT}" --torchbench_score_file "${SCORE_FILE}"
             fi

--- a/scripts/get_torch_nightly_wheels.py
+++ b/scripts/get_torch_nightly_wheels.py
@@ -88,7 +88,7 @@ def get_n_prior_nightly_wheels(packages:list, n:int,
 
 
 def create_requirements_files(root: Path, packages: list, start_date: date, end_date: date,
-                               py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
+                              py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
     root = Path(root)
     curr_date = start_date
     while curr_date < end_date:

--- a/scripts/get_torch_nightly_wheels.py
+++ b/scripts/get_torch_nightly_wheels.py
@@ -6,8 +6,12 @@ from collections import defaultdict
 from datetime import datetime, date, timedelta
 from pathlib import Path
 
-torch_wheel_nightly_base ="https://download.pytorch.org/whl/nightly/cu102/" 
-torch_nightly_wheel_index = "https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html" 
+torch_wheel_cuda_version = "cu113"
+torch_wheel_python_version = "cp38"
+torch_wheel_platform = "linux_x86_64"
+torch_wheel_nightly_base = f"https://download.pytorch.org/whl/nightly/{torch_wheel_cuda_version}/"
+torch_nightly_wheel_index = f"https://download.pytorch.org/whl/nightly/{torch_wheel_cuda_version}/torch_nightly.html"
+
 
 def memoize(function):
     """ 
@@ -39,7 +43,7 @@ def get_wheel_index_data(py_version, platform_version, url=torch_nightly_wheel_i
     return data
 
 def get_nightly_wheel_urls(packages:list, date:date,
-                           py_version='cp37', platform_version='linux_x86_64'):
+                           py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
     """Gets urls to wheels for specified packages matching the date, py_version, platform_version
     """
     date_str = f"{date.year}{date.month:02}{date.day:02}"
@@ -62,7 +66,7 @@ def get_nightly_wheel_urls(packages:list, date:date,
     return tuple(versions)
 
 def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
-                                py_version='cp37', platform_version='linux_x86_64'):
+                                py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
     rc = []
     curr_date = start_date
     while curr_date < end_date:
@@ -76,7 +80,7 @@ def get_nightly_wheels_in_range(packages:list, start_date:date, end_date:date,
     return rc
 
 def get_n_prior_nightly_wheels(packages:list, n:int,
-                               py_version='cp37', platform_version='linux_x86_64'):
+                               py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
     end_date = date.today()
     start_date = end_date - timedelta(days=n)
     return get_nightly_wheels_in_range(packages, start_date, end_date,
@@ -84,7 +88,7 @@ def get_n_prior_nightly_wheels(packages:list, n:int,
 
 
 def create_requirements_files(root: Path, packages: list, start_date: date, end_date: date,
-                              py_version='cp37', platform_version='linux_x86_64'):
+                               py_version=torch_wheel_python_version, platform_version=torch_wheel_platform):
     root = Path(root)
     curr_date = start_date
     while curr_date < end_date:
@@ -102,11 +106,6 @@ def parse_date_str(s: str):
     return datetime.strptime(s, '%Y%m%d').date() 
 
 if __name__ == "__main__":
-    # from tabulate import tabulate
-    # print(tabulate(get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 200)))
-    # wheels = get_n_prior_nightly_wheels(['torch', 'torchvision', 'torchtext'], 200)
-    # for a, b, c in wheels:
-        # print(f"   \"{a} {b} {c}\"  \\")
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('action', choices=['create_requirements'])


### PR DESCRIPTION
Use `py38` and `cu113` as the default version to generate nightly configs.
This PR also fixes a bug in the abtest config generation script which uses the `git_version` instead of master commit hash.