### PR TITLE
Fix the installer script path

### DIFF
--- a/install.py
+++ b/install.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 
-    os.chdir(os.path.dirname(__file__))
+    os.chdir(os.path.realpath(os.path.dirname(__file__)))
 
     print(f"checking packages {', '.join(TORCH_DEPS)} are installed...", end="", flush=True)
     try:


### PR DESCRIPTION
Use `os.path.realpath()` to get the absolute path of the current file.