### PR TITLE
Enable flops for torchvision models

### DIFF
--- a/run.py
+++ b/run.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     parser.add_argument("--cudastreams", action="store_true",
                         help="Utilization test using increasing number of cuda streams.")
     parser.add_argument("--bs", type=int, help="Specify batch size to the test.")
-    parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result.")
+    parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result.")
     parser.add_argument("--export-dcgm-metrics", action="store_true",
                         help="Export all GPU FP32 unit active ratio records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
     parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
@@ -220,8 +220,7 @@ if __name__ == "__main__":
     if not Model:
         print(f"Unable to find model matching {args.model}.")
         exit(-1)
-    # build the model and get the chosen test method
-    if args.flops:
+    if args.flops and args.flops == "fvcore":
         extra_args.append("--flops")
         extra_args.append(args.flops)
 

--- a/run.py
+++ b/run.py
@@ -142,7 +142,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
                 model_analyzer.export_all_records_to_csv()
         else:
             flops, batch_size = model_flops
-            tflops = flops * batch_size / (cpu_walltime / 1.0e9) / 1.0e12
+            tflops = flops * batch_size / (cpu_walltime / 1.0e3) / 1.0e12
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
 
 

--- a/run.py
+++ b/run.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
     model_flops = None
 
     if args.flops:
-        if args.flops == 'model':
+        if args.flops == 'fvcore':
             assert hasattr(m, "get_flops"), f"The model {args.model} does not support calculating flops."
             model_flops = m.get_flops()
         else:

--- a/torchbenchmark/util/backends/flops.py
+++ b/torchbenchmark/util/backends/flops.py
@@ -1,0 +1,10 @@
+
+# By default, FlopCountAnalysis count one fused-mult-add (FMA) as one flop.
+# However, in our context, we count 1 FMA as 2 flops instead of 1.
+# https://github.com/facebookresearch/fvcore/blob/7a0ef0c0839fa0f5e24d2ef7f5d48712f36e7cd7/fvcore/nn/flop_count.py
+def enable_fvcore_flops(model: 'torchbenchmark.util.model.BenchmarkModel', flops_fma=2.0):
+    assert hasattr(model, 'TORCHVISION_MODEL') and model.TORCHVISION_MODEL, "fvcore flops is only available on torchvision models!"
+    assert model.test == "eval", "fvcore flops is only available on inference tests, as it doesn't measure backward pass."
+    from fvcore.nn import FlopCountAnalysis
+    model.flops = FlopCountAnalysis(model.model, tuple(model.example_inputs)).total()
+    model.flops = model.flops / model.batch_size * flops_fma

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -103,7 +103,6 @@ def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dar
     elif not dargs.precision == "fp32":
         assert False, f"Get an invalid precision option: {dargs.precision}. Please report a bug."
 
-
 # Dispatch arguments based on model type
 def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -2,6 +2,7 @@ import argparse
 from typing import List, Optional, Tuple
 from torchbenchmark.util.backends import list_backends, BACKENDS
 
+from torchbenchmark.util.backends.flops import enable_fvcore_flops
 from torchbenchmark.util.backends.fx2trt import enable_fx2trt
 from torchbenchmark.util.backends.torch_trt import enable_torchtrt
 
@@ -102,6 +103,7 @@ def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dar
     elif not dargs.precision == "fp32":
         assert False, f"Get an invalid precision option: {dargs.precision}. Please report a bug."
 
+
 # Dispatch arguments based on model type
 def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -109,7 +111,7 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
     parser.add_argument("--fuser", type=str, default="", choices=["fuser0", "fuser1", "fuser2"], help="enable fuser")
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
-    parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result")
+    parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"
@@ -123,6 +125,8 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     return args, extra_args
 
 def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace, extra_args: List[str]):
+    if args.flops == "fvcore":
+        enable_fvcore_flops(model)
     if args.backend:
         backend = BACKENDS[args.backend]
         # transform the model using the specified backend

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -54,9 +54,11 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self, niter=3):
+        real_input = [ torch.rand_like(self.example_inputs[0]) ]
+        real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
             self.optimizer.zero_grad()
-            for data, target in zip(self.real_input, self.real_output):
+            for data, target in zip(real_input, real_output):
                 if not self.dynamo and self.opt_args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -30,17 +30,8 @@ class TorchVisionModel(BenchmarkModel):
         elif test == "eval":
             self.model.eval()
 
-    # By default, FlopCountAnalysis count one fused-mult-add (FMA) as one flop.
-    # However, in our context, we count 1 FMA as 2 flops instead of 1.
-    # https://github.com/facebookresearch/fvcore/blob/7a0ef0c0839fa0f5e24d2ef7f5d48712f36e7cd7/fvcore/nn/flop_count.py
-    def get_flops(self, flops_fma=2.0):
-        if self.test == 'eval':
-            flops = self.flops / self.batch_size * flops_fma
-            return flops, self.batch_size
-        elif self.test == 'train':
-            flops = self.flops / self.batch_size * flops_fma
-            return flops, self.batch_size
-        assert False, f"get_flops() only support eval or train mode, but get {self.test}. Please submit a bug report."
+    def get_flops(self):
+        return self.flops, self.batch_size
 
     def gen_inputs(self, num_batches:int=1) -> Tuple[Generator, Optional[int]]:
         def _gen_inputs():

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -54,11 +54,9 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self, niter=3):
-        real_input = [ torch.rand_like(self.example_inputs[0]) ]
-        real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
             self.optimizer.zero_grad()
-            for data, target in zip(real_input, real_output):
+            for data, target in zip(self.real_input, self.real_output):
                 if not self.dynamo and self.opt_args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -27,6 +27,8 @@ class TorchVisionModel(BenchmarkModel):
             # setup optimizer and loss_fn
             self.optimizer = optim.Adam(self.model.parameters())
             self.loss_fn = torch.nn.CrossEntropyLoss()
+            self.real_input = [ torch.rand_like(self.example_inputs[0]) ]
+            self.real_output = [ torch.rand_like(self.example_outputs) ]
         elif test == "eval":
             self.model.eval()
 

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -52,11 +52,9 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self, niter=3):
-        real_input = [ torch.rand_like(self.example_inputs[0]) ]
-        real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
             self.optimizer.zero_grad()
-            for data, target in zip(real_input, real_output):
+            for data, target in zip(self.real_input, self.real_output):
                 if not self.dynamo and self.opt_args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)


### PR DESCRIPTION
Test run on CPU:
```
python run.py mnasnet1_0 --flops
```
Result:
```
CPU Total Wall Time: 931.076 milliseconds
FLOPS:               0.0224 TFLOPs per second
```

Test run on GPU:
```
python run.py resnet50 -d cuda -t eval --flops
```
Result:
```
GPU Time:             31.228 milliseconds
CPU Dispatch Time:     8.527 milliseconds
CPU Total Wall Time:  31.234 milliseconds
FLOPS:               8.4247 TFLOPs per second
```

Note: the `--flops` option only works for eval tests, because `fvcore` flops counter doesn't count backwards computation.