### PR TITLE
Enable torch_trt and handle subprocess segfault in subprocess_worker

### DIFF
--- a/components/_impl/workers/subprocess_rpc.py
+++ b/components/_impl/workers/subprocess_rpc.py
@@ -194,13 +194,6 @@ class Pipe:
         timeout_callback: typing.Callable[[], typing.NoReturn] = (lambda: None),
     ) -> None:
         self._writer_pid = writer_pid
-        # if _writer_pid is set, check the writer process is the child of current process
-        if self._writer_pid:
-            assert psutil.pid_exists(self._writer_pid), "Writer process must exist. Please report a bug."
-            cur_p = psutil.Process()
-            writer_p = psutil.Process(self._writer_pid)
-            assert writer_p in cur_p.children(), "Writer process must be the child of current process.\
-                                                  Please report a bug."
         self._owns_pipe = read_handle is None and write_handle is None
         if self._owns_pipe:
             self.read_fd, self.write_fd = os.pipe()

--- a/components/_impl/workers/subprocess_rpc.py
+++ b/components/_impl/workers/subprocess_rpc.py
@@ -151,13 +151,12 @@ class _TimeoutPIPE:
         # Spawn a loop thread to periodically check the liveness of subprocess
         w_fd = pipe.write_fd
         assert w_fd is not None, "Cannot timeout without write file descriptor."
-        assert pipe.get_writer_pid() is not None, "Cannot check process livenss without pid."
+        assert pipe.get_writer_pid() is not None, "Cannot check process liveness without pid."
         singleton = cls.singleton()
         with singleton._loop_lock:
             # This will only occur in the case of concurrent reads on different
             # threads (not supported) or a leaked case.
             assert w_fd not in singleton._active_reads, f"{w_fd} is already being watched."
-            # If timeout is None, check the liveness of the process
             singleton._active_reads[w_fd] = (timeout, time.time(), pipe.get_writer_pid())
 
         try:
@@ -251,8 +250,8 @@ class Pipe:
         os.write(self.write_fd, packed_msg)
 
     def get_writer_pid(self) -> int:
-        assert self._writer_pid, "Writer pid is not specified. Maybe calling from child process or input pipe.\
-                                  Please report a bug."
+        assert self._writer_pid is not None, "Writer pid is not specified. Maybe calling from child process or input pipe.\
+                                              Please report a bug."
         return self._writer_pid
 
     def set_writer_pid(self, writer_pid: int) -> None:

--- a/components/_impl/workers/subprocess_rpc.py
+++ b/components/_impl/workers/subprocess_rpc.py
@@ -139,6 +139,10 @@ class _TimeoutPIPE:
                         if not psutil.pid_exists(self._proc_id):
                             os.write(w_fd, _DEAD)
                             self.pop(w_fd)
+                        # if the process still exists but in zombie state
+                        elif psutil.Process(self._proc_id).status == psutil.STATUS_ZOMBIE:
+                            os.write(w_fd, _DEAD)
+                            self.pop(w_fd)
 
     def pop(self, w_fd: int) -> None:
         self._active_reads.pop(w_fd, None)

--- a/components/_impl/workers/subprocess_rpc.py
+++ b/components/_impl/workers/subprocess_rpc.py
@@ -136,11 +136,9 @@ class _TimeoutPIPE:
                             self.pop(w_fd)
                     else:
                         # if timeout is None, only check if the process is still alive
-                        if not psutil.pid_exists(self._proc_id):
-                            os.write(w_fd, _DEAD)
-                            self.pop(w_fd)
-                        # if the process still exists but in zombie state
-                        elif psutil.Process(self._proc_id).status == psutil.STATUS_ZOMBIE:
+                        # it could be in zombie status, or has already been reaped
+                        if not psutil.pid_exists(self._proc_id) or \
+                            psutil.Process(self._proc_id).status() == psutil.STATUS_ZOMBIE:
                             os.write(w_fd, _DEAD)
                             self.pop(w_fd)
 

--- a/components/_impl/workers/subprocess_rpc.py
+++ b/components/_impl/workers/subprocess_rpc.py
@@ -152,7 +152,7 @@ class _TimeoutPIPE:
         w_fd = pipe.write_fd
         assert w_fd is not None, "Cannot timeout without write file descriptor."
         assert pipe.get_writer_pid() is not None, "Cannot check process livenss without pid."
-        singleton = cls.singleton(pipe.get_pid())
+        singleton = cls.singleton()
         with singleton._loop_lock:
             # This will only occur in the case of concurrent reads on different
             # threads (not supported) or a leaked case.

--- a/components/_impl/workers/subprocess_worker.py
+++ b/components/_impl/workers/subprocess_worker.py
@@ -117,6 +117,11 @@ class SubprocessWorker(base.WorkerBase):
             **popen_kwargs,
         )
 
+        # setup the pid of child process for the pipes
+        self._input_pipe.set_pid(self._proc.pid)
+        self._output_pipe.set_pid(self._proc.pid)
+        self._load_pipe.set_pid(self._proc.pid)
+
         self._worker_bootstrap_finished: bool = False
         self._bootstrap_worker()
         self._alive = True
@@ -192,6 +197,7 @@ class SubprocessWorker(base.WorkerBase):
                 sys.path.extend([i for i in sys_path_old if i and i not in sys.path])
                 from components._impl.workers import subprocess_rpc
                 output_pipe = subprocess_rpc.Pipe(
+                    proc_id={os.getpid()},
                     write_handle={self._output_pipe.write_handle})
                 output_pipe.write(subprocess_rpc.BOOTSTRAP_IMPORT_SUCCESS)
                 subprocess_rpc.run_loop(
@@ -223,6 +229,7 @@ class SubprocessWorker(base.WorkerBase):
                 # worker died or the bootstrap failed. (E.g. failed to resolve
                 # import path.) This simply allows us to raise a good error.
                 bootstrap_pipe = subprocess_rpc.Pipe(
+                    proc_id=self._proc.pid,
                     read_handle=self._output_pipe.read_handle,
                     write_handle=self._output_pipe.write_handle,
                     timeout=self._bootstrap_timeout,

--- a/components/test/test_subprocess.py
+++ b/components/test/test_subprocess.py
@@ -309,7 +309,7 @@ class TestSubprocessRPC(TestCase):
 
         # We have to run this in a thread, because if the timeout mechanism
         # fails we don't want the entire unit test suite to hang.
-        pipe = subprocess_rpc.Pipe(timeout=0.5, timeout_callback=callback)
+        pipe = subprocess_rpc.Pipe(writer_pid=os.getpid(), timeout=0.5, timeout_callback=callback)
         def target():
             try:
                 pipe.read()
@@ -334,7 +334,7 @@ class TestSubprocessRPC(TestCase):
 
         timeouts = [0.5, 1.0, 1.5]
         pipes = [
-            subprocess_rpc.Pipe(timeout=timeout, timeout_callback=callback)
+            subprocess_rpc.Pipe(writer_pid=os.getpid(), timeout=timeout, timeout_callback=callback)
             for timeout in timeouts
         ]
 

--- a/components/test/test_worker.py
+++ b/components/test/test_worker.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import signal
 import textwrap
 import typing
 
@@ -216,6 +217,15 @@ class TestBenchmarkWorker(TestCase):
         worker = subprocess_worker.SubprocessWorker()
         self._generic_worker_tests(worker)
         self._test_child_trace_exception(worker)
+
+    def test_subprocess_worker_segv_handling(self):
+        worker = subprocess_worker.SubprocessWorker(timeout=1)
+        with self.assertRaisesRegex(OSError, f"Subprocess terminates with code {int(signal.SIGSEGV)}"):
+            worker.run("""
+                import os
+                import signal
+                os.kill(os.getpid(), signal.SIGSEGV)
+            """)
 
     def test_subprocess_worker_fault_handling(self):
         worker = subprocess_worker.SubprocessWorker(timeout=1)

--- a/install.py
+++ b/install.py
@@ -2,11 +2,8 @@ import argparse
 import subprocess
 import os
 import sys
-import importlib
 import tarfile
-from torchbenchmark import setup, _test_https, proxy_suggestion, TORCH_DEPS
-from torchbenchmark.util.env_check import get_pkg_versions
-
+from install_utils import TORCH_DEPS, proxy_suggestion, get_pkg_versions, _test_https
 
 def git_lfs_checkout():
     tb_dir = os.path.dirname(os.path.realpath(__file__))
@@ -92,6 +89,7 @@ if __name__ == '__main__':
         print(f"The torch packages are re-installed after installing the benchmark deps. \
                 Before: {versions}, after: {new_versions}")
         sys.exit(-1)
+    from torchbenchmark import setup
     success &= setup(models=args.models, verbose=args.verbose, continue_on_fail=args.continue_on_fail)
     if not success:
         if args.continue_on_fail:

--- a/install_utils/__init__.py
+++ b/install_utils/__init__.py
@@ -1,0 +1,22 @@
+import importlib
+from urllib import request
+from typing import List, Dict
+
+TORCH_DEPS = ['torch', 'torchvision', 'torchtext']
+proxy_suggestion = "Unable to verify https connectivity, " \
+                   "required for setup.\n" \
+                   "Do you need to use a proxy?"
+
+def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
+    versions = {}
+    for module in packages:
+        module = importlib.import_module(module)
+        versions[module] = module.__version__
+    return versions
+
+def _test_https(test_url: str = 'https://github.com', timeout: float = 0.5) -> bool:
+    try:
+        request.urlopen(test_url, timeout=timeout)
+    except OSError:
+        return False
+    return True

--- a/torchbenchmark/util/backends/torch_trt.py
+++ b/torchbenchmark/util/backends/torch_trt.py
@@ -1,7 +1,7 @@
 import torch
 from typing import Tuple
 
-def enable_torchtrt(example_input: Tuple[torch.tensor], precision: str, model: torch.nn.Module) -> torch.nn.Module:
+def enable_torchtrt(precision: str, model: torch.nn.Module, example_inputs: Tuple[torch.tensor]) -> torch.nn.Module:
     import torch_tensorrt
     if precision == "fp16":
         torchtrt_dtype = torch_tensorrt.dtype.half
@@ -11,6 +11,6 @@ def enable_torchtrt(example_input: Tuple[torch.tensor], precision: str, model: t
         torch_dtype = torch.float32
     else:
         raise NotImplementedError("torch_tensorrt only supports fp32 or fp16 precision")
-    trt_input = [torch_tensorrt.Input(shape=example_input[0].shape, dtype=torch_dtype)]
+    trt_input = [torch_tensorrt.Input(shape=example_inputs[0].shape, dtype=torch_dtype)]
 
     return torch_tensorrt.compile(model, inputs=trt_input, enabled_precisions=torchtrt_dtype)

--- a/torchbenchmark/util/backends/torch_trt.py
+++ b/torchbenchmark/util/backends/torch_trt.py
@@ -1,11 +1,16 @@
 import torch
 from typing import Tuple
 
-def enable_torchtrt(eval_input: Tuple[torch.tensor], eval_fp16: bool, eval_model: torch.nn.Module) -> torch.nn.Module:
+def enable_torchtrt(example_input: Tuple[torch.tensor], precision: str, model: torch.nn.Module) -> torch.nn.Module:
     import torch_tensorrt
-    trt_input = [torch_tensorrt.Input(eval_input[0].shape)]
-    if eval_fp16:
-        enabled_precisions = torch_tensorrt.dtype.half
+    if precision == "fp16":
+        torchtrt_dtype = torch_tensorrt.dtype.half
+        torch_dtype = torch.half
+    elif precision == "fp32":
+        torchtrt_dtype = torch_tensorrt.dtype.float
+        torch_dtype = torch.float32
     else:
-        enabled_precisions = torch_tensorrt.dtype.float
-    return torch_tensorrt.compile(eval_model, inputs=trt_input, enabled_precisions=enabled_precisions)
+        raise NotImplementedError("torch_tensorrt only supports fp32 or fp16 precision")
+    trt_input = [torch_tensorrt.Input(shape=example_input[0].shape, dtype=torch_dtype)]
+
+    return torch_tensorrt.compile(model, inputs=trt_input, enabled_precisions=torchtrt_dtype)

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -33,5 +33,5 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
         enable_fuser(args.fuser)
     if args.torch_trt:
         module, exmaple_inputs = model.get_module()
-        model.set_module(enable_torchtrt(args.batch_size, fp16=False, model=module, example_inputs=exmaple_inputs))
+        model.set_module(enable_torchtrt(args.batch_size, precision='fp32', model=module, example_inputs=exmaple_inputs))
 

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -2,12 +2,14 @@ import argparse
 from typing import List
 from torchbenchmark.util.backends.fx2trt import enable_fx2trt
 from torchbenchmark.util.backends.fuser import enable_fuser
+from torchbenchmark.util.backends.torch_trt import enable_torchtrt
 
 # Dispatch arguments based on model type
 def parse_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
-    parser.add_argument("--fuser", type=str, default="", help="enable nvfuser")
+    parser.add_argument("--fuser", type=str, default="", help="enable fuser")
+    parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     args = parser.parse_args(extra_args)
     args.device = model.device
     args.jit = model.jit
@@ -15,18 +17,21 @@ def parse_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: Li
     if args.device == "cpu":
         args.fuser = None
     if not (model.device == "cuda" and model.test == "eval"):
-        args.fx2trt = False
+        if args.fx2trt or args.torch_trt:
+            raise NotImplementedError("TensorRT only works for CUDA inference tests.")
     if hasattr(model, 'TORCHVISION_MODEL') and model.TORCHVISION_MODEL:
         args.cudagraph = False
     return args
 
 def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
-    # apply fx2trt
     if args.fx2trt:
-        assert not args.jit, "fx2trt with JIT is not available."
+        if args.jit:
+            raise NotImplementedError("fx2trt with JIT is not available.")
         module, exmaple_inputs = model.get_module()
         model.set_module(enable_fx2trt(args.batch_size, fp16=False, model=module, example_inputs=exmaple_inputs))
-    # apply nvfuser
     if args.fuser:
         enable_fuser(args.fuser)
+    if args.torch_trt:
+        module, exmaple_inputs = model.get_module()
+        model.set_module(enable_torchtrt(args.batch_size, fp16=False, model=module, example_inputs=exmaple_inputs))
 

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -33,5 +33,5 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
         enable_fuser(args.fuser)
     if args.torch_trt:
         module, exmaple_inputs = model.get_module()
-        model.set_module(enable_torchtrt(args.batch_size, precision='fp32', model=module, example_inputs=exmaple_inputs))
+        model.set_module(enable_torchtrt(precision='fp32', model=module, example_inputs=exmaple_inputs))
 


### PR DESCRIPTION
This PR enables [torch_trt](https://github.com/NVIDIA/Torch-TensorRT) module on all the models.
Currently the library will segfault on some models, and the subprocess_worker needs to correctly handle that (otherwise, it will just hang forever because it is blocked by `os.read()` on a pipe whose input process is dead).

We introduce the following mechanism to handle subprocess segfault:
1. The `Pipe` class stores the pid of the child process if the pipe is reading from the child process.
2. When the pipe reads, it always creates a thread that periodically checks the status of the other process at the other end. If the other process dies or is in zombie status, the threads writes a special string, `_DEAD`, into the pipe, together with its exit code.
3. The main thread in the process checks the return message in the pipe, if it finds the `_DEAD` message, throw an exception, which is handled in `subprocess_worker`.