### PR TITLE
First PR to add the correctness checking code to eval tests

### DIFF
--- a/run.py
+++ b/run.py
@@ -65,7 +65,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
         # second according to https://docs.python.org/3/library/time.html#time.time.
         t0 = time.time_ns()
         start_event.record()
-        func()
+        out = func()
         t1 = time.time_ns()
 
         end_event.record()
@@ -82,7 +82,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
 
     else:
         t0 = time.time_ns()
-        func()
+        out = func()
         t1 = time.time_ns()
         wall_latency = t1 - t0
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % ((t1 - t0) / 1_000_000)), sep='')
@@ -92,6 +92,9 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
         flops, batch_size = model_flops
         tflops = flops * batch_size / (wall_latency / 1.0e9) / 1.0e12
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
+    assert(isinstance(out, tuple))
+    for t in out:
+        print(type(t))
 
 
 def profile_one_step(func, nwarmup=WARMUP_ROUNDS):

--- a/run.py
+++ b/run.py
@@ -65,7 +65,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
         # second according to https://docs.python.org/3/library/time.html#time.time.
         t0 = time.time_ns()
         start_event.record()
-        out = func()
+        func()
         t1 = time.time_ns()
 
         end_event.record()
@@ -82,7 +82,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
 
     else:
         t0 = time.time_ns()
-        out = func()
+        func()
         t1 = time.time_ns()
         wall_latency = t1 - t0
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % ((t1 - t0) / 1_000_000)), sep='')

--- a/run.py
+++ b/run.py
@@ -92,10 +92,6 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None):
         flops, batch_size = model_flops
         tflops = flops * batch_size / (wall_latency / 1.0e9) / 1.0e12
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
-    assert(isinstance(out, tuple))
-    for t in out:
-        print(type(t))
-
 
 def profile_one_step(func, nwarmup=WARMUP_ROUNDS):
     activity_groups = []

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -3,9 +3,9 @@ Run a config of benchmarking with a list of models.
 If unspecified, run a sweep of all models.
 """
 import argparse
-from distutils.log import error
 import json
 import os
+import sys
 import torch
 import time
 import pathlib
@@ -101,6 +101,9 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
     except TypeError as e: # TypeError is raised when the model doesn't support variable batch sizes
         status = "TypeError"
         error_message = str(e)
+    except KeyboardInterrupt as e:
+        status = "UserInterrupted"
+        error_message = str(e)
     except Exception as e:
         status = f"{type(e).__name__}"
         error_message = str(e)
@@ -108,6 +111,8 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         print(f"[ {status} ]")
         result.status = status
         result.error_message = error_message
+        if status == "UserInterrupted":
+            sys.exit(1)
         return result
 
 if __name__ == "__main__":

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -11,14 +11,18 @@ import time
 import pathlib
 import dataclasses
 import itertools
-from typing import List, Optional
+import torch
+from typing import List, Optional, Dict, Any, Tuple
 from torchbenchmark import ModelTask
 
 WARMUP_ROUNDS = 3
 MODEL_DIR = ['torchbenchmark', 'models']
 NANOSECONDS_PER_MILLISECONDS = 1_000_000.0
 
-def run_one_step(func, device: str, nwarmup=WARMUP_ROUNDS) -> float:
+def get_cosine_similarity(ra: Tuple[torch.Tensor], rb: Tuple[torch.Tensor]) -> float:
+    return 1.0
+
+def run_one_step(func, device: str, nwarmup=WARMUP_ROUNDS) -> Tuple[float, Optional[Tuple[torch.Tensor]]]:
     "Run one step of the model, and return the latency in milliseconds."
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
@@ -28,15 +32,15 @@ def run_one_step(func, device: str, nwarmup=WARMUP_ROUNDS) -> float:
         # Collect time_ns() instead of time() which does not provide better precision than 1
         # second according to https://docs.python.org/3/library/time.html#time.time.
         t0 = time.time_ns()
-        func()
+        result = func()
         torch.cuda.synchronize()  # Wait for the events to be recorded!
         t1 = time.time_ns()
     else:
         t0 = time.time_ns()
-        func()
+        result = func()
         t1 = time.time_ns()
     wall_latency = (t1 - t0) / NANOSECONDS_PER_MILLISECONDS
-    return wall_latency
+    return (wall_latency, result)
 
 @dataclasses.dataclass
 class ModelTestResult:
@@ -46,8 +50,7 @@ class ModelTestResult:
     extra_args: List[str]
     status: str
     batch_size: Optional[int]
-    latency_ms: Optional[float]
-    error_message: Optional[str]
+    results: Dict[str, Any]
 
 def _list_model_paths(models: List[str]) -> List[str]:
     p = pathlib.Path(__file__).parent.joinpath(*MODEL_DIR)
@@ -76,16 +79,16 @@ def _validate_devices(devices: str) -> List[str]:
 def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool, batch_size: Optional[int], extra_args: List[str]) -> ModelTestResult:
     assert test == "train" or test == "eval", f"Test must be either 'train' or 'eval', but get {test}."
     result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None,
-                             status="OK", latency_ms=None, error_message=None)
+                             status="OK", results={})
     # Run the benchmark test in a separate process
     print(f"Running model {model_path.name} ... ", end='', flush=True)
     status: str = "OK"
     bs_name = "batch_size"
+    eager_eval_result_name = "eager_eval_result"
     error_message: Optional[str] = None
     try:
         task = ModelTask(os.path.basename(model_path))
         if not task.model_details.exists:
-            result.latency_ms = None
             status = "NotExist"
             return
         task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
@@ -94,7 +97,11 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         if batch_size and (not result.batch_size == batch_size):
             raise ValueError(f"User specify batch size {batch_size}, but model {result.name} runs with batch size {result.batch_size}. Please report a bug.")
         func = getattr(task, test)
-        result.latency_ms = run_one_step(func, device)
+        (result.results["latency_ms"], test_result) = run_one_step(func, device)
+        # if the model provides eager eval result, save it for cosine similarity
+        eager_eval_result = task.get_model_attribute(eager_eval_result_name)
+        if eager_eval_result:
+            result.results["cos_sim"] = get_cosine_similarity(eager_eval_result, test_result)
     except NotImplementedError as e:
         status = "NotImplemented"
         error_message = str(e)
@@ -110,7 +117,8 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
     finally:
         print(f"[ {status} ]")
         result.status = status
-        result.error_message = error_message
+        if error_message:
+            result.results["error_message"] = error_message
         if status == "UserInterrupted":
             sys.exit(1)
         return result

--- a/test.py
+++ b/test.py
@@ -88,6 +88,7 @@ def _load_test(path, device):
                 task.set_eval()
                 task.eval()
                 task.check_details_eval(device=device, md=metadata)
+                task.check_eval_output()
                 task.del_model_instance()
             except NotImplementedError:
                 self.skipTest(f'Method eval on {device} is not implemented, skipping...')

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -280,8 +280,10 @@ class ModelTask(base_task.TaskBase):
     @staticmethod
     def get_model_attribute(attr: str) -> Any:
         model = globals()["model"]
-        attr_value = getattr(model, attr)
-        return attr_value
+        if hasattr(model, attr):
+            return getattr(model, attr)
+        else:
+            return None
 
     def gc_collect(self) -> None:
         self.worker.run("""

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -366,6 +366,20 @@ class ModelTask(base_task.TaskBase):
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod
+    def check_eval_output() -> None:
+        instance = globals()["model"]
+        import torch
+        out = instance.eval()
+        model_name = getattr(instance, 'name', None)
+        if not isinstance(out, tuple):
+            raise RuntimeError('Model {model_name} eval() output is not a tuple')
+        for ind, element in enumerate(out):
+            if not isinstance(element, torch.Tensor):
+                raise RuntimeError(f'Model {model_name} eval() output is tuple, but'
+                                   f' its {ind}-th element is not a Tensor.')
+
+    @base_task.run_in_worker(scoped=True)
+    @staticmethod
     def check_device() -> None:
         instance = globals()["model"]
 

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -372,11 +372,11 @@ class ModelTask(base_task.TaskBase):
         out = instance.eval()
         model_name = getattr(instance, 'name', None)
         if not isinstance(out, tuple):
-            raise RuntimeError('Model {model_name} eval() output is not a tuple')
+            raise RuntimeError(f'Model {model_name} eval() output is not a tuple')
         for ind, element in enumerate(out):
             if not isinstance(element, torch.Tensor):
-                raise RuntimeError('Model {model_name} eval() output is tuple, but'
-                                   ' its {ind}-th element is not a Tensor.')
+                raise RuntimeError(f'Model {model_name} eval() output is tuple, but'
+                                   f' its {ind}-th element is not a Tensor.')
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -375,8 +375,8 @@ class ModelTask(base_task.TaskBase):
             raise RuntimeError('Model {model_name} eval() output is not a tuple')
         for ind, element in enumerate(out):
             if not isinstance(element, torch.Tensor):
-                raise RuntimeError(f'Model {model_name} eval() output is tuple, but'
-                                   f' its {ind}-th element is not a Tensor.')
+                raise RuntimeError('Model {model_name} eval() output is tuple, but'
+                                   ' its {ind}-th element is not a Tensor.')
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -9,6 +9,7 @@ from .bert_pytorch.trainer import BERTTrainer
 from .bert_pytorch.dataset import BERTDataset, WordVocab
 from .bert_pytorch.model import BERT
 from torch.utils.data import DataLoader
+import typing
 
 torch.backends.cudnn.deterministic = False
 torch.backends.cudnn.benchmark = False
@@ -161,7 +162,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.model.bert = new_model
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         model = self.model
         for _ in range(niter):
             # 1. forward the next_sentence_prediction and masked_lm model

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -174,6 +174,7 @@ class Model(BenchmarkModel):
             next_loss = model.criterion(next_sent_output, self.is_next)
             mask_loss = model.criterion(mask_lm_output.transpose(1, 2), self.bert_label)
             loss = next_loss + mask_loss
+        return (next_sent_output, mask_lm_output)
 
     def train(self, niter=1):
         trainer = self.model

--- a/torchbenchmark/models/LearningToPaint/__init__.py
+++ b/torchbenchmark/models/LearningToPaint/__init__.py
@@ -9,6 +9,7 @@ from .baseline.DRL.ddpg import DDPG
 from .baseline.DRL.multi import fastenv
 
 from ...util.model import BenchmarkModel
+from typing import Tuple
 from torchbenchmark.tasks import REINFORCEMENT_LEARNING
 
 from argparse import Namespace
@@ -105,11 +106,12 @@ class Model(BenchmarkModel):
                 episode += 1
             self.step += 1
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
             reward, dist = self.evaluate(self.env, self.agent.select_action)
+        return (reward, dist)
 
     def _set_mode(self, train):
         if train:

--- a/torchbenchmark/models/LearningToPaint/__init__.py
+++ b/torchbenchmark/models/LearningToPaint/__init__.py
@@ -111,7 +111,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         for _ in range(niter):
             reward, dist = self.evaluate(self.env, self.agent.select_action)
-        return (reward, dist)
+        return (torch.tensor(reward), torch.tensor(dist))
 
     def _set_mode(self, train):
         if train:

--- a/torchbenchmark/models/Super_SloMo/__init__.py
+++ b/torchbenchmark/models/Super_SloMo/__init__.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 import torchvision.transforms as transforms
 import random
+from typing import Tuple
 import numpy as np
 
 from argparse import Namespace
@@ -69,12 +70,13 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
         for _ in range(niter):
-            self.model(*self.example_inputs)
+            out = self.model(*self.example_inputs)
+        return out
 
     def train(self, niter=1):
         if self.device == 'cpu':

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -116,7 +116,7 @@ class Model(BenchmarkModel):
         result = None
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
             result = self.model(*(src_seq, trg_seq))
-        return result
+        return (result, )
 
     def train(self, niter=1):
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -112,9 +112,11 @@ class Model(BenchmarkModel):
         for (src_seq, trg_seq, gold) in self.example_inputs:
             return self.model, (*(src_seq, trg_seq), )
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> torch.Tensor:
+        result = None
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
-            self.model(*(src_seq, trg_seq))
+            result = self.model(*(src_seq, trg_seq))
+        return result
 
     def train(self, niter=1):
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):

--- a/torchbenchmark/models/dcgan/__init__.py
+++ b/torchbenchmark/models/dcgan/__init__.py
@@ -235,6 +235,7 @@ class Model(BenchmarkModel):
 
             # Since we just updated D, perform another forward pass of all-fake batch through D
             output = self.model(self.exmaple_inputs).view(-1)
+        return (output, )
 
     def train(self, niter=1):
 

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -81,11 +81,12 @@ class Model(BenchmarkModel):
     def get_module(self) -> Tuple[DemucsWrapper, Tuple[Tensor]]:
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         for _ in range(niter):
             sources, estimates = self.model(*self.example_inputs)
             sources = center_trim(sources, estimates)
             loss = self.criterion(estimates, sources)
+        return (sources, estimates)
 
     def train(self, niter=1):
         if self.device == "cpu":

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -3,6 +3,7 @@ import os
 import itertools
 import random
 from pathlib import Path
+from typing import Tuple
 
 # TorchBench imports
 from torchbenchmark.util.model import BenchmarkModel
@@ -73,7 +74,7 @@ class Model(BenchmarkModel):
                 self.optimizer.step()
                 self.optimizer.zero_grad()
 
-    def eval(self, niter=2):
+    def eval(self, niter=2) -> Tuple[torch.Tensor]:
         if not self.device == "cuda":
             raise NotImplementedError("Only CUDA is supported by this model")
         if self.jit:
@@ -81,5 +82,6 @@ class Model(BenchmarkModel):
         self.model.eval()
         with torch.no_grad():
             for idx, data in zip(range(niter), self.example_inputs):
-                self.model(data)
+                out = self.model(data)
+        return (out, )
 

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -2,6 +2,7 @@ import torch
 import os
 import itertools
 import random
+import itertools
 from pathlib import Path
 from typing import Tuple
 
@@ -83,5 +84,11 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for idx, data in zip(range(niter), self.example_inputs):
                 out = self.model(data)
-        return (out, )
-
+        # retrieve output tensors
+        outputs = []
+        for item in out:
+            fields = list(map(lambda x: list(x.get_fields().values()), item.values()))
+            for boxes in fields:
+                tensor_box = list(filter(lambda x: isinstance(x, torch.Tensor), boxes))
+                outputs.extend(tensor_box)
+        return tuple(outputs)

--- a/torchbenchmark/models/dlrm/__init__.py
+++ b/torchbenchmark/models/dlrm/__init__.py
@@ -7,6 +7,7 @@ import functools
 # import shutil
 import time
 import json
+from typing import Tuple
 import sys
 
 # data generation
@@ -200,12 +201,12 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("JIT not supported")
-
         for _ in range(niter):
-            self.model(*self.example_inputs)
+            out = self.model(*self.example_inputs)
+        return out
 
     def train(self, niter=1):
         if self.jit:

--- a/torchbenchmark/models/dlrm/__init__.py
+++ b/torchbenchmark/models/dlrm/__init__.py
@@ -206,7 +206,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("JIT not supported")
         for _ in range(niter):
             out = self.model(*self.example_inputs)
-        return out
+        return (out, )
 
     def train(self, niter=1):
         if self.jit:

--- a/torchbenchmark/models/drq/__init__.py
+++ b/torchbenchmark/models/drq/__init__.py
@@ -6,6 +6,7 @@ import torch
 import os
 import sys
 import torch.nn as nn
+from typing import Tuple
 import torch.nn.functional as F
 from gym import spaces
 
@@ -149,11 +150,11 @@ class Model(BenchmarkModel):
             episode_step += 1
             self.step += 1
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         average_episode_reward = 0
-        for episode in range(niter):
+        for _episode in range(niter):
             obs = self.env.reset()
             episode_reward = 0
             episode_step = 0
@@ -164,3 +165,4 @@ class Model(BenchmarkModel):
             episode_step += 1
             average_episode_reward += episode_reward
         average_episode_reward /= float(niter)
+        return action

--- a/torchbenchmark/models/drq/__init__.py
+++ b/torchbenchmark/models/drq/__init__.py
@@ -165,4 +165,4 @@ class Model(BenchmarkModel):
             episode_step += 1
             average_episode_reward += episode_reward
         average_episode_reward /= float(niter)
-        return action
+        return (torch.Tensor(action), )

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -112,7 +112,8 @@ class Model(BenchmarkModel):
                 for batch_x, batch_y in self.example_inputs:
                     self._move_dict_value_to_device(batch_x, batch_y, device=self.device)
                     pred_dict = self._data_forward(self._predict_func, batch_x)
-        return (pred_dict, )
+        # return a tuple of Tensors
+        return (pred_dict['pred_start'], pred_dict['pred_end'] )
 
     # Sliced version of fastNLP.Trainer._train()
     def train(self, niter=1):

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -6,6 +6,7 @@ Input data simulates [CMRC2018 dataset](https://ymcui.com/cmrc2018/).
 The program runs only for benchmark purposes and doesn't provide correctness results.
 """
 import logging
+from typing import Tuple
 import torch
 import random
 import inspect
@@ -101,7 +102,7 @@ class Model(BenchmarkModel):
         return self.model, (batch_x["words"], )
 
     # Sliced version of fastNLP.Tester._test()
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("PyTorch JIT compiler is not able to compile this model.")
         self._mode(self.model, is_test=True)
@@ -111,6 +112,7 @@ class Model(BenchmarkModel):
                 for batch_x, batch_y in self.example_inputs:
                     self._move_dict_value_to_device(batch_x, batch_y, device=self.device)
                     pred_dict = self._data_forward(self._predict_func, batch_x)
+        return (pred_dict, )
 
     # Sliced version of fastNLP.Trainer._train()
     def train(self, niter=1):

--- a/torchbenchmark/models/hf_Albert/__init__.py
+++ b/torchbenchmark/models/hf_Albert/__init__.py
@@ -1,6 +1,6 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
@@ -42,9 +42,10 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_Albert/__init__.py
+++ b/torchbenchmark/models/hf_Albert/__init__.py
@@ -48,4 +48,6 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        # logits: prediction scores of language modeling head
+        # https://github.com/huggingface/transformers/blob/v4.16.2/src/transformers/modeling_outputs.py#L455
+        return (out.logits, )

--- a/torchbenchmark/models/hf_Bart/__init__.py
+++ b/torchbenchmark/models/hf_Bart/__init__.py
@@ -62,4 +62,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_Bart/__init__.py
+++ b/torchbenchmark/models/hf_Bart/__init__.py
@@ -1,11 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
-
+from typing import Tuple
 
 class ArgsToKwargsWrapper(torch.nn.Module):
     def __init__(self, model):
@@ -57,10 +55,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_Bert/__init__.py
+++ b/torchbenchmark/models/hf_Bert/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
+from typing import Tuple
 from transformers import *
-from datasets import load_dataset
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -44,12 +43,13 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )
 
     

--- a/torchbenchmark/models/hf_Bert/__init__.py
+++ b/torchbenchmark/models/hf_Bert/__init__.py
@@ -50,6 +50,6 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )
 
     

--- a/torchbenchmark/models/hf_BigBird/__init__.py
+++ b/torchbenchmark/models/hf_BigBird/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
+from typing import Tuple
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -44,10 +43,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_BigBird/__init__.py
+++ b/torchbenchmark/models/hf_BigBird/__init__.py
@@ -50,4 +50,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_DistilBert/__init__.py
+++ b/torchbenchmark/models/hf_DistilBert/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
+from typing import Tuple
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -48,10 +47,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_DistilBert/__init__.py
+++ b/torchbenchmark/models/hf_DistilBert/__init__.py
@@ -54,4 +54,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_GPT2/__init__.py
+++ b/torchbenchmark/models/hf_GPT2/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
+from typing import Tuple
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -43,10 +42,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_GPT2/__init__.py
+++ b/torchbenchmark/models/hf_GPT2/__init__.py
@@ -49,4 +49,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_Longformer/__init__.py
+++ b/torchbenchmark/models/hf_Longformer/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
+from typing import Tuple
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -43,10 +42,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_Longformer/__init__.py
+++ b/torchbenchmark/models/hf_Longformer/__init__.py
@@ -49,4 +49,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_Reformer/__init__.py
+++ b/torchbenchmark/models/hf_Reformer/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
+from typing import Tuple
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
@@ -46,10 +45,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/hf_Reformer/__init__.py
+++ b/torchbenchmark/models/hf_Reformer/__init__.py
@@ -52,4 +52,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_T5/__init__.py
+++ b/torchbenchmark/models/hf_T5/__init__.py
@@ -68,4 +68,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
-        return (out, )
+        return (out.logits, )

--- a/torchbenchmark/models/hf_T5/__init__.py
+++ b/torchbenchmark/models/hf_T5/__init__.py
@@ -1,10 +1,9 @@
 import torch
 import torch.optim as optim
-import torchvision.models as models
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import NLP
 from transformers import *
-from datasets import load_dataset
+from typing import Tuple
 
 torch.manual_seed(1337)
 torch.backends.cudnn.deterministic = False
@@ -62,10 +61,11 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
                 out = self.model(**self.example_inputs)
+        return (out, )

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -5,6 +5,7 @@ import torch
 from argparse import Namespace
 from .meta import Meta
 from pathlib import Path
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import OTHER
 
@@ -80,11 +81,12 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.module, self.example_inputs
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
-            self.module(*self.example_inputs)
+            out = self.module(*self.example_inputs)
+        return (out, )
 
     def train(self, niter=1):
         if self.jit:

--- a/torchbenchmark/models/maml/learner.py
+++ b/torchbenchmark/models/maml/learner.py
@@ -29,7 +29,7 @@ class Learner(nn.Module):
         self.vars_bn = nn.ParameterList()
 
         for i, (name, param) in enumerate(self.config):
-            if name is 'conv2d':
+            if name == 'conv2d':
                 # [ch_out, ch_in, kernelsz, kernelsz]
                 w = nn.Parameter(torch.ones(*param[:4]))
                 # gain=1 according to cbfin's implementation
@@ -38,7 +38,7 @@ class Learner(nn.Module):
                 # [ch_out]
                 self.vars.append(nn.Parameter(torch.zeros(param[0])))
 
-            elif name is 'convt2d':
+            elif name == 'convt2d':
                 # [ch_in, ch_out, kernelsz, kernelsz, stride, padding]
                 w = nn.Parameter(torch.ones(*param[:4]))
                 # gain=1 according to cbfin's implementation
@@ -47,7 +47,7 @@ class Learner(nn.Module):
                 # [ch_in, ch_out]
                 self.vars.append(nn.Parameter(torch.zeros(param[1])))
 
-            elif name is 'linear':
+            elif name == 'linear':
                 # [ch_out, ch_in]
                 w = nn.Parameter(torch.ones(*param))
                 # gain=1 according to cbfinn's implementation
@@ -56,7 +56,7 @@ class Learner(nn.Module):
                 # [ch_out]
                 self.vars.append(nn.Parameter(torch.zeros(param[0])))
 
-            elif name is 'bn':
+            elif name == 'bn':
                 # [ch_out]
                 w = nn.Parameter(torch.ones(param[0]))
                 self.vars.append(w)
@@ -84,29 +84,29 @@ class Learner(nn.Module):
         info = ''
 
         for name, param in self.config:
-            if name is 'conv2d':
+            if name == 'conv2d':
                 tmp = 'conv2d:(ch_in:%d, ch_out:%d, k:%dx%d, stride:%d, padding:%d)'\
                       %(param[1], param[0], param[2], param[3], param[4], param[5],)
                 info += tmp + '\n'
 
-            elif name is 'convt2d':
+            elif name == 'convt2d':
                 tmp = 'convTranspose2d:(ch_in:%d, ch_out:%d, k:%dx%d, stride:%d, padding:%d)'\
                       %(param[0], param[1], param[2], param[3], param[4], param[5],)
                 info += tmp + '\n'
 
-            elif name is 'linear':
+            elif name == 'linear':
                 tmp = 'linear:(in:%d, out:%d)'%(param[1], param[0])
                 info += tmp + '\n'
 
-            elif name is 'leakyrelu':
+            elif name == 'leakyrelu':
                 tmp = 'leakyrelu:(slope:%f)'%(param[0])
                 info += tmp + '\n'
 
 
-            elif name is 'avg_pool2d':
+            elif name == 'avg_pool2d':
                 tmp = 'avg_pool2d:(k:%d, stride:%d, padding:%d)'%(param[0], param[1], param[2])
                 info += tmp + '\n'
-            elif name is 'max_pool2d':
+            elif name == 'max_pool2d':
                 tmp = 'max_pool2d:(k:%d, stride:%d, padding:%d)'%(param[0], param[1], param[2])
                 info += tmp + '\n'
             elif name in ['flatten', 'tanh', 'relu', 'upsample', 'reshape', 'sigmoid', 'use_logits', 'bn']:
@@ -122,7 +122,7 @@ class Learner(nn.Module):
     def forward(self, x, vars=None, bn_training=True):
         """
         This function can be called by finetunning, however, in finetunning, we dont wish to update
-        running_mean/running_var. Thought weights/bias of bn is updated, it has been separated by fast_weights.
+        running_mean/running_var. Thought weights/bias of bn == updated, it has been separated by fast_weights.
         Indeed, to not update running_mean/running_var, we need set update_bn_statistics=False
         but weight/bias will be updated and not dirty initial theta parameters via fast_weiths.
         :param x: [b, 1, 28, 28]
@@ -131,62 +131,62 @@ class Learner(nn.Module):
         :return: x, loss, likelihood, kld
         """
 
-        if vars is None:
+        if vars == None:
             vars = self.vars
 
         idx = 0
         bn_idx = 0
 
         for name, param in self.config:
-            if name is 'conv2d':
+            if name == 'conv2d':
                 w, b = vars[idx], vars[idx + 1]
                 # remember to keep synchrozied of forward_encoder and forward_decoder!
                 x = F.conv2d(x, w, b, stride=param[4], padding=param[5])
                 idx += 2
                 # print(name, param, '\tout:', x.shape)
-            elif name is 'convt2d':
+            elif name == 'convt2d':
                 w, b = vars[idx], vars[idx + 1]
                 # remember to keep synchrozied of forward_encoder and forward_decoder!
                 x = F.conv_transpose2d(x, w, b, stride=param[4], padding=param[5])
                 idx += 2
                 # print(name, param, '\tout:', x.shape)
-            elif name is 'linear':
+            elif name == 'linear':
                 w, b = vars[idx], vars[idx + 1]
                 x = F.linear(x, w, b)
                 idx += 2
                 # print('forward:', idx, x.norm().item())
-            elif name is 'bn':
+            elif name == 'bn':
                 w, b = vars[idx], vars[idx + 1]
                 running_mean, running_var = self.vars_bn[bn_idx], self.vars_bn[bn_idx+1]
                 x = F.batch_norm(x, running_mean, running_var, weight=w, bias=b, training=bn_training)
                 idx += 2
                 bn_idx += 2
 
-            elif name is 'flatten':
+            elif name == 'flatten':
                 # print(x.shape)
                 x = x.view(x.size(0), -1)
-            elif name is 'reshape':
+            elif name == 'reshape':
                 # [b, 8] => [b, 2, 2, 2]
                 x = x.view(x.size(0), *param)
-            elif name is 'relu':
+            elif name == 'relu':
                 x = F.relu(x, inplace=param[0])
-            elif name is 'leakyrelu':
+            elif name == 'leakyrelu':
                 x = F.leaky_relu(x, negative_slope=param[0], inplace=param[1])
-            elif name is 'tanh':
+            elif name == 'tanh':
                 x = F.tanh(x)
-            elif name is 'sigmoid':
+            elif name == 'sigmoid':
                 x = torch.sigmoid(x)
-            elif name is 'upsample':
+            elif name == 'upsample':
                 x = F.upsample_nearest(x, scale_factor=param[0])
-            elif name is 'max_pool2d':
+            elif name == 'max_pool2d':
                 x = F.max_pool2d(x, param[0], param[1], param[2])
-            elif name is 'avg_pool2d':
+            elif name == 'avg_pool2d':
                 x = F.avg_pool2d(x, param[0], param[1], param[2])
 
             else:
                 raise NotImplementedError
 
-        # make sure variable is used properly
+        # make sure variable == used properly
         assert idx == len(vars)
         assert bn_idx == len(self.vars_bn)
 
@@ -201,13 +201,13 @@ class Learner(nn.Module):
         :return:
         """
         with torch.no_grad():
-            if vars is None:
+            if vars == None:
                 for p in self.vars:
-                    if p.grad is not None:
+                    if not p.grad == None:
                         p.grad.zero_()
             else:
                 for p in vars:
-                    if p.grad is not None:
+                    if not p.grad == None:
                         p.grad.zero_()
 
     def parameters(self):

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -21,6 +21,7 @@ import torch.optim as optim
 import torch.nn as nn
 import torch.nn.functional as F
 from pathlib import Path
+from typing import Tuple
 import higher
 
 from ...util.model import BenchmarkModel
@@ -98,7 +99,7 @@ class Model(BenchmarkModel):
 
             meta_opt.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
 
@@ -106,4 +107,5 @@ class Model(BenchmarkModel):
         model.eval()
         with torch.no_grad():
             for i in range(niter):
-                model(example_input)
+                out = model(example_input)
+        return (out, )

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -5,6 +5,7 @@ import torchvision.models as models
 from torch.quantization import quantize_fx
 from torchbenchmark.tasks import COMPUTER_VISION
 from ...util.model import BenchmarkModel
+from typing import Tuple
 
 
 class Model(BenchmarkModel):
@@ -47,10 +48,11 @@ class Model(BenchmarkModel):
         self.model = quantize_fx.convert_fx(self.model)
         self.model.eval()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         example_inputs = self.example_inputs[0][0].unsqueeze(0)
         for _i in range(niter):
-            self.model(example_inputs)
+            out = self.model(example_inputs)
+        return (out, )
 
     def get_module(self):
         return self.model, self.example_inputs

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -151,4 +151,4 @@ class Model(BenchmarkModel):
         for i in range(niter):
             for i, (images, _) in enumerate(self.example_inputs):
                 out = self.model(im_q=images[0], im_k=images[1])
-        return (out, )
+        return out

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -12,6 +12,7 @@ import torch.optim
 import torch.utils.data
 import torch.utils.data.distributed
 import torchvision.models as models
+from typing import Tuple
 
 from .moco.builder import MoCo
 from .main_moco import adjust_learning_rate
@@ -132,7 +133,7 @@ class Model(BenchmarkModel):
                 loss.backward()
                 self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         """ Recommended
         Run evaluation on model for `niter` inputs. One iteration should be sufficient
         to warm up the model for the purpose of profiling.
@@ -149,4 +150,5 @@ class Model(BenchmarkModel):
 
         for i in range(niter):
             for i, (images, _) in enumerate(self.example_inputs):
-                self.model(im_q=images[0], im_k=images[1])
+                out = self.model(im_q=images[0], im_k=images[1])
+        return (out, )

--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -72,7 +72,7 @@ class Model(BenchmarkModel):
 
   def eval(self, niter=1) -> Tuple[torch.Tensor]:
     self.check_implemented()
-
+    print("here... ")
     for i in range(niter):
       out = self.model.eval(niter)
     return (out, )

--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -8,12 +8,11 @@
 # been removed.
 
 import torch
-import torch.optim as optim
-import torchvision.models as models
 
 from torchbenchmark.models.attention_is_all_you_need_pytorch.train import train
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import RECOMMENDATION
+from typing import Tuple
 
 import gc
 from .nvtrain import DeepRecommenderTrainBenchmark
@@ -71,11 +70,12 @@ class Model(BenchmarkModel):
     for i in range(niter):
       self.model.train(niter)
 
-  def eval(self, niter=1):
+  def eval(self, niter=1) -> Tuple[torch.Tensor]:
     self.check_implemented()
 
     for i in range(niter):
-      self.model.eval(niter)
+      out = self.model.eval(niter)
+    return (out, )
 
   def check_implemented(self):
     if self.not_implemented_reason != "Implemented":

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -228,6 +228,7 @@ class DeepRecommenderInferenceBenchmark:
                 outf.write("{}\t{}\t{}\t{}\n".format(major_key, self.inv_itemIdMap[ind], self.outputs[ind], targets_np[ind]))
               if i % 10000 == 0:
                 print("Done: {}".format(i))
+    return out
 
   def TimedInferenceRun(self) :
   

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -210,7 +210,7 @@ class DeepRecommenderInferenceBenchmark:
     for iteration in range(niter):
 
       if self.toytest:
-        self.rencoder(self.toyinputs)
+        out = self.rencoder(self.toyinputs)
         continue
 
       for i, ((out, src), majorInd) in enumerate(self.eval_data_layer.iterate_one_epoch_eval(for_inf=True)):

--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -5,6 +5,7 @@ import torch.utils.data as data
 import torchvision.models as models
 from opacus import PrivacyEngine
 from opacus.validators.module_validator import ModuleValidator
+from typing import Tuple
 
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import OTHER
@@ -65,7 +66,7 @@ class Model(BenchmarkModel):
         self.optimizer.step()
         self.optimizer.zero_grad()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if niter != 1:
             raise NotImplementedError("niter not implemented")
         if self.jit:
@@ -75,4 +76,5 @@ class Model(BenchmarkModel):
         model.eval()
         targets = self.example_target
         with torch.no_grad():
-            model(images)
+            out = model(images)
+        return (out, )

--- a/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
@@ -2,6 +2,7 @@ import torch
 from . import eos_pytorch
 from torchbenchmark.tasks import OTHER
 from ...util.model import BenchmarkModel
+from typing import Tuple
 
 def _generate_inputs(size):
     import math
@@ -49,8 +50,9 @@ class Model(BenchmarkModel):
     def train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):
-                model(*example_inputs)
+                out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -148,4 +148,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for i in range(niter):
                 out = model(*example_inputs)
-        return (out, )
+        return out

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -2,6 +2,7 @@ import torch
 from . import isoneutral_pytorch
 from torchbenchmark.tasks import OTHER
 from ...util.model import BenchmarkModel
+from typing import Tuple
 
 def _generate_inputs(size):
     import math
@@ -142,8 +143,9 @@ class Model(BenchmarkModel):
     def train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):
-                model(*example_inputs)
+                out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -144,4 +144,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for i in range(niter):
                 out = model(*example_inputs)
-        return (out, )
+        return out

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -1,5 +1,6 @@
 import torch
 from . import tke_pytorch
+from typing import Tuple
 from torchbenchmark.tasks import OTHER
 from ...util.model import BenchmarkModel
 
@@ -138,8 +139,9 @@ class Model(BenchmarkModel):
     def train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):
-                model(*example_inputs)
+                out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -14,6 +14,7 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
+from typing import Tuple
 
 from .train_cyclegan import prepare_training_loop
 from .test_cyclegan import get_model
@@ -63,7 +64,8 @@ class Model(BenchmarkModel):
             # step rather than 7 epochs, but changing it now would potentially cause discontinuity with existing/historical measurement
             self.training_loop(None)
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         for i in range(niter):
-            model(*example_inputs)
+            out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -27,13 +27,13 @@ def nyi():
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.GENERATION
     DEFAULT_TRAIN_BSIZE = 1
-    DEFAILT_EVAL_BSIZE = 1
+    DEFAULT_EVAL_BSIZE = 1
     ALLOW_CUSTOMIZE_BSIZE = False
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
-        if device != 'cuda' or device != 'lazy':  # NYI implemented for things that aren't on the GPU
+        if device != 'cuda' and device != 'lazy':  # NYI implemented for things that aren't on the GPU
             self.get_module = self.train = self.eval = nyi
             return
 

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -6,6 +6,7 @@ import numpy as np
 from .solver import Solver
 from .data_loader import get_loader
 from .main import parse_config, makedirs
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 
@@ -81,8 +82,9 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             self.solver.train()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model = self.model
         example_inputs = self.example_inputs
         for _ in range(niter):
-            model(*example_inputs)
+            out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import optim
+from typing import Tuple
 
 random.seed(1337)
 torch.manual_seed(1337)
@@ -69,7 +70,7 @@ class Model(BenchmarkModel):
                 grad_scaler.step(optimizer)
                 grad_scaler.update()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
@@ -79,6 +80,7 @@ class Model(BenchmarkModel):
                     mask_pred = (F.sigmoid(mask_pred) > 0.5).float()
                 else:
                     mask_pred = F.one_hot(mask_pred.argmax(dim=1), self.model.n_classes).permute(0, 3, 1, 2).float()
+        return (mask_pred, )
 
     def _get_args(self):
         parser = argparse.ArgumentParser(description='Train the UNet on images and target masks')

--- a/torchbenchmark/models/resnet50_quantized_qat/__init__.py
+++ b/torchbenchmark/models/resnet50_quantized_qat/__init__.py
@@ -6,6 +6,7 @@ import torchvision.models as models
 from torch.quantization import quantize_fx
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
+from typing import Tuple
 
 
 class Model(BenchmarkModel):
@@ -50,9 +51,10 @@ class Model(BenchmarkModel):
             loss(pred, y).backward()
             optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model = self.model
         example_inputs = self.example_inputs
         example_inputs = example_inputs[0][0].unsqueeze(0)
         for i in range(niter):
-            model(example_inputs)
+            out = model(example_inputs)
+        return (out, )

--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import REINFORCEMENT_LEARNING
+from typing import Tuple
 
 from .config import SACConfig
 from .envs import load_gym
@@ -238,7 +239,7 @@ class Model(BenchmarkModel):
                 soft_update(self.target_agent.critic1, self.agent.critic1, self.args.tau)
                 soft_update(self.target_agent.critic2, self.agent.critic2, self.args.tau)
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():
@@ -256,4 +257,4 @@ class Model(BenchmarkModel):
                     episode_return += reward * (discount ** step_num)
                 episode_return_history.append(episode_return)
             retval = torch.tensor(episode_return_history)
-
+        return action

--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -257,4 +257,4 @@ class Model(BenchmarkModel):
                     episode_return += reward * (discount ** step_num)
                 episode_return_history.append(episode_return)
             retval = torch.tensor(episode_return_history)
-        return action
+        return (torch.tensor(action), )

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -12,6 +12,7 @@ import torch
 from .config import SpeechTransformerTrainConfig, SpeechTransformerEvalConfig
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
+from typing import Tuple
 
 NUM_TRAIN_BATCH = 1
 NUM_EVAL_BATCH = 1
@@ -65,10 +66,11 @@ class Model(BenchmarkModel):
         for i in range(niter):
             self.traincfg.train(epoch = i)
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == "cpu":
             raise NotImplementedError("CPU is not supported by this model")
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         for _ in range(niter):
-            self.evalcfg.eval()
+            out = self.evalcfg.eval()
+        return (out, )

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -7,6 +7,7 @@
 # S0002.tar.gz, S0757.tar.gz, S0915.tar.gz
 #
 import os
+import itertools
 import torch
 
 from .config import SpeechTransformerTrainConfig, SpeechTransformerEvalConfig
@@ -73,4 +74,6 @@ class Model(BenchmarkModel):
             raise NotImplementedError("JIT is not supported by this model")
         for _ in range(niter):
             out = self.evalcfg.eval()
-        return (out, )
+        # only the first element of model output is a tensor
+        out = tuple(itertools.chain(*list(map(lambda x: x.values(), out))))
+        return (out[0], )

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -187,3 +187,4 @@ class SpeechTransformerEvalConfig:
         with torch.no_grad():
             for input, input_length in self.example_inputs:
                 nbest_hyps = self.model.recognize(input, input_length, self.char_list, self)
+        return nbest_hyps

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from .text import symbols
 from pathlib import Path
 from ...util.model import BenchmarkModel
+from typing import Tuple
 from torchbenchmark.tasks import SPEECH
 
 
@@ -143,7 +144,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == 'cuda':
             raise NotImplementedError('CUDA disabled due to CUDA out of memory on CI GPU')
         if self.device == 'cpu':
@@ -152,4 +153,5 @@ class Model(BenchmarkModel):
             raise NotImplementedError('JIT not supported')
         self.model.eval()
         for _ in range(niter):
-            self.model(self.example_inputs)
+            out = self.model(self.example_inputs)
+        return out

--- a/torchbenchmark/models/timm_efficientnet/__init__.py
+++ b/torchbenchmark/models/timm_efficientnet/__init__.py
@@ -2,6 +2,7 @@ import torch
 import timm.models.efficientnet
 
 from ...util.model import BenchmarkModel
+from typing import Tuple
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
 
@@ -52,6 +53,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         return self.model, (self.example_inputs,)
@@ -62,8 +64,9 @@ class Model(BenchmarkModel):
             self._step_train()
 
     # TODO: use pretrained model weights, assuming the pretrained model is in .data/ dir
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out = self._step_eval()
+        return (out, )

--- a/torchbenchmark/models/timm_nfnet/__init__.py
+++ b/torchbenchmark/models/timm_nfnet/__init__.py
@@ -4,6 +4,7 @@ import timm.models.nfnet
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
+from typing import Tuple
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -53,6 +54,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         return self.model, (self.example_inputs,)
@@ -64,8 +66,9 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out  = self._step_eval()
+        return (out, )

--- a/torchbenchmark/models/timm_regnet/__init__.py
+++ b/torchbenchmark/models/timm_regnet/__init__.py
@@ -1,6 +1,6 @@
 import torch
 import timm.models.regnet
-
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
@@ -50,6 +50,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         return self.model, (self.example_inputs,)
@@ -59,8 +60,9 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out = self._step_eval()
+        return (out, )

--- a/torchbenchmark/models/timm_resnest/__init__.py
+++ b/torchbenchmark/models/timm_resnest/__init__.py
@@ -2,6 +2,7 @@ import torch
 import timm.models.resnest
 
 from ...util.model import BenchmarkModel
+from typing import Tuple
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
 
@@ -47,6 +48,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         self.example_inputs = self.example_inputs
@@ -57,8 +59,9 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out = self._step_eval()
+        return out

--- a/torchbenchmark/models/timm_resnest/__init__.py
+++ b/torchbenchmark/models/timm_resnest/__init__.py
@@ -64,4 +64,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self._step_eval()
-        return out
+        return (out, )

--- a/torchbenchmark/models/timm_vision_transformer/__init__.py
+++ b/torchbenchmark/models/timm_vision_transformer/__init__.py
@@ -1,6 +1,7 @@
 import torch
 import timm.models.vision_transformer
 
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
@@ -49,6 +50,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         return self.model, (self.example_inputs,)
@@ -59,8 +61,9 @@ class Model(BenchmarkModel):
             self._step_train()
 
     # TODO: use pretrained model weights, assuming the pretrained model is in .data/ dir
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out = self._step_eval()
+        return out

--- a/torchbenchmark/models/timm_vision_transformer/__init__.py
+++ b/torchbenchmark/models/timm_vision_transformer/__init__.py
@@ -66,4 +66,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self._step_eval()
-        return out
+        return (out, )

--- a/torchbenchmark/models/timm_vovnet/__init__.py
+++ b/torchbenchmark/models/timm_vovnet/__init__.py
@@ -63,5 +63,5 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _ in range(niter):
                 out = self._step_eval()
-        return out
+        return (out, )
 

--- a/torchbenchmark/models/timm_vovnet/__init__.py
+++ b/torchbenchmark/models/timm_vovnet/__init__.py
@@ -1,6 +1,7 @@
 import torch
 import timm.models.vovnet
 
+from typing import Tuple
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 from .config import TimmConfig
@@ -47,6 +48,7 @@ class Model(BenchmarkModel):
 
     def _step_eval(self):
         output = self.model(self.example_inputs)
+        return output
 
     def get_module(self):
         return self.model, (self.example_inputs,)
@@ -56,9 +58,10 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):
-                self._step_eval()
+                out = self._step_eval()
+        return out
 

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -1,7 +1,8 @@
 
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import SPEECH
-
+import torch
+from typing import Tuple
 from .angular_tts_main import TTSModel, SYNTHETIC_DATA
 
 class Model(BenchmarkModel):
@@ -34,8 +35,9 @@ class Model(BenchmarkModel):
         # the training process is not patched to use scripted models
         self.model.train(niter)
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
-            self.model.eval()
+            out = self.model.eval()
+        return out

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -40,4 +40,4 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         for _ in range(niter):
             out = self.model.eval()
-        return out
+        return (out, )

--- a/torchbenchmark/models/tts_angular/angular_tts_main.py
+++ b/torchbenchmark/models/tts_angular/angular_tts_main.py
@@ -256,11 +256,8 @@ class TTSModel:
                                      self.global_step, self.c, niter)
 
     def eval(self):
-        start = time.time()
         result = self.model(SYNTHETIC_DATA[0])
-        end = time.time()
-        # print('eval: ', end - start)
-        return end - start
+        return result
 
     def __call__(self, *things):
         return self

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -9,6 +9,7 @@ import numpy as np
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 from pathlib import Path
+from typing import Tuple
 
 # Model specific imports
 import torchvision
@@ -92,10 +93,11 @@ class Model(BenchmarkModel):
             losses.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         self.model.eval()
         with torch.no_grad():
             for _, (images, _targets) in zip(range(niter), self.data_loader):
-                self.model(images)
+                out = self.model(images)
+        return out

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -100,4 +100,4 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _, (images, _targets) in zip(range(niter), self.data_loader):
                 out = self.model(images)
-        return out
+        return (out, )

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -4,6 +4,7 @@ Maskrcnn model from torchvision
 
 import torch
 import os
+import itertools
 import random
 import numpy as np
 from ...util.model import BenchmarkModel
@@ -100,4 +101,5 @@ class Model(BenchmarkModel):
         with torch.no_grad():
             for _, (images, _targets) in zip(range(niter), self.data_loader):
                 out = self.model(images)
-        return (out, )
+        out = list(map(lambda x: x.values(), out))
+        return tuple(itertools.chain(*out))

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -98,7 +98,7 @@ class Model(BenchmarkModel):
             # Apply NMS
             pred = non_max_suppression(pred, 0.3, 0.6,
                                     multi_label=False, classes=None, agnostic=False)
-        return out
+        return (out[0],) + out[1]
 
     @property
     def device_str(self):

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -16,6 +16,7 @@ torch.backends.cudnn.benchmark = True
 from shlex import split
 from .yolo_train import prepare_training_loop
 from . import yolo_train
+from typing import Tuple
 
 from .yolo_models import *  # set ONNX_EXPORT in models.py
 from .yolo_utils.datasets import *
@@ -89,13 +90,15 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
         return self.training_loop(niter)
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         for i in range(niter):
-            pred = model(*example_inputs, augment=False)[0]
+            out = model(*example_inputs, augment=False)
+            pred = out[0]
             # Apply NMS
             pred = non_max_suppression(pred, 0.3, 0.6,
                                     multi_label=False, classes=None, agnostic=False)
+        return out
 
     @property
     def device_str(self):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -1,4 +1,5 @@
 import torch
+import typing
 import torch.optim as optim
 import torchvision.models as models
 from torchbenchmark.util.model import BenchmarkModel
@@ -55,10 +56,12 @@ class TorchVisionModel(BenchmarkModel):
                     self.loss_fn(pred, target).backward()
                     self.optimizer.step()
 
-    def eval(self, niter=1):
+    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         if self.extra_args.cudagraph:
             return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.model
         example_inputs = self.example_inputs
+        result = None
         for _i in range(niter):
-            model(*example_inputs)
+            result = model(*example_inputs)
+        return (result, )

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import warnings
 import inspect
 import os
-from typing import Optional, List
+from typing import Optional, List, Tuple
 from torchbenchmark.util.extra_args import parse_args, apply_args
 
 class PostInitProcessor(type):
@@ -77,10 +77,10 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
     def train(self):
-        raise NotImplementedError()
+        raise NotImplementedError("Base type doesn't have train implementation.")
 
-    def eval(self):
-        raise NotImplementedError()
+    def eval(self) -> Tuple[torch.Tensor]:
+        raise NotImplementedError("Base type doesn't have eval implementation.")
 
     def set_eval(self):
         self._set_mode(False)


### PR DESCRIPTION
This PR prepares adding the correctness checking code to eval tests:

1. Each `eval()` function now returns `Tuple[torch.Tensor]`, i.e., the inference result
2. Add a test to check 1) is true for every model
3. change `run_sweep.py` to prepare for the correctness checking

A follow-up PR is https://github.com/pytorch/benchmark/pull/763, which adds the actual correctness calculation code.