### PR TITLE
Add pygame with gym requirement

### DIFF
--- a/torchbenchmark/models/soft_actor_critic/requirements.txt
+++ b/torchbenchmark/models/soft_actor_critic/requirements.txt
@@ -1,1 +1,2 @@
 gym
+pygame


### PR DESCRIPTION
Currently the CI fails with "ModuleNotFoundError: No module named 'pygame'".
The reason seems to be a recent update go gym, see https://github.com/openai/gym/issues/2634