### PR TITLE
Add post train and eval run hook to every model

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -161,7 +161,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.model.bert = new_model
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model = self.model
         for _ in range(niter):
             # 1. forward the next_sentence_prediction and masked_lm model
@@ -174,7 +174,7 @@ class Model(BenchmarkModel):
             mask_loss = model.criterion(mask_lm_output.transpose(1, 2), self.bert_label)
             loss = next_loss + mask_loss
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         trainer = self.model
         for _ in range(niter):
             # 1. forward the next_sentence_prediction and masked_lm model

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -131,7 +131,7 @@ class Model(BenchmarkModel):
     def _set_mode(self, train):
         pass
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
@@ -299,5 +299,5 @@ class Model(BenchmarkModel):
             # Change weight every 2 epoch to put more stress on discriminator weight and less on pseudo-supervision
             wt = wt/2
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         raise NotImplementedError()

--- a/torchbenchmark/models/LearningToPaint/__init__.py
+++ b/torchbenchmark/models/LearningToPaint/__init__.py
@@ -75,7 +75,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         episode = episode_steps = 0
@@ -105,7 +105,7 @@ class Model(BenchmarkModel):
                 episode += 1
             self.step += 1
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/Super_SloMo/__init__.py
+++ b/torchbenchmark/models/Super_SloMo/__init__.py
@@ -69,14 +69,14 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
         for _ in range(niter):
             self.model(*self.example_inputs)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -112,11 +112,11 @@ class Model(BenchmarkModel):
         for (src_seq, trg_seq, gold) in self.example_inputs:
             return self.model, (*(src_seq, trg_seq), )
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
             self.model(*(src_seq, trg_seq))
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
             self.optimizer.zero_grad()
             example_inputs = (src_seq, trg_seq)

--- a/torchbenchmark/models/dcgan/__init__.py
+++ b/torchbenchmark/models/dcgan/__init__.py
@@ -226,7 +226,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.exmaple_inputs,)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         for _ in range(niter):
 
             if False == self.inference_just_descriminator:
@@ -236,7 +236,7 @@ class Model(BenchmarkModel):
             # Since we just updated D, perform another forward pass of all-fake batch through D
             output = self.model(self.exmaple_inputs).view(-1)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
 
         # Training Loop
 

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -81,13 +81,13 @@ class Model(BenchmarkModel):
     def get_module(self) -> Tuple[DemucsWrapper, Tuple[Tensor]]:
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         for _ in range(niter):
             sources, estimates = self.model(*self.example_inputs)
             sources = center_trim(sources, estimates)
             loss = self.criterion(estimates, sources)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == "cpu":
             raise NotImplementedError("Disable CPU training because it is too slow (> 1min)")
         if self.device == "cuda":

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -59,7 +59,7 @@ class Model(BenchmarkModel):
         for data in self.example_inputs:
             return self.model, (data, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if not self.device == "cuda":
             raise NotImplementedError("Only CUDA is supported by this model")
         if self.jit:
@@ -73,7 +73,7 @@ class Model(BenchmarkModel):
                 self.optimizer.step()
                 self.optimizer.zero_grad()
 
-    def eval(self, niter=2):
+    def _eval(self, niter=2):
         if not self.device == "cuda":
             raise NotImplementedError("Only CUDA is supported by this model")
         if self.jit:

--- a/torchbenchmark/models/dlrm/__init__.py
+++ b/torchbenchmark/models/dlrm/__init__.py
@@ -200,14 +200,14 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT not supported")
 
         for _ in range(niter):
             self.model(*self.example_inputs)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT not supported")
 

--- a/torchbenchmark/models/drq/__init__.py
+++ b/torchbenchmark/models/drq/__init__.py
@@ -118,7 +118,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
 
-    def train(self, niter=2):
+    def _train(self, niter=2):
         if self.jit:
             raise NotImplementedError()
         episode, episode_reward, episode_step, done = 0, 0, 1, True
@@ -149,7 +149,7 @@ class Model(BenchmarkModel):
             episode_step += 1
             self.step += 1
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         average_episode_reward = 0

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -101,7 +101,7 @@ class Model(BenchmarkModel):
         return self.model, (batch_x["words"], )
 
     # Sliced version of fastNLP.Tester._test()
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError("PyTorch JIT compiler is not able to compile this model.")
         self._mode(self.model, is_test=True)
@@ -113,7 +113,7 @@ class Model(BenchmarkModel):
                     pred_dict = self._data_forward(self._predict_func, batch_x)
 
     # Sliced version of fastNLP.Trainer._train()
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("PyTorch JIT compiler is not able to compile this model.")
         self.step = 0

--- a/torchbenchmark/models/hf_Albert/__init__.py
+++ b/torchbenchmark/models/hf_Albert/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
@@ -42,7 +42,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():

--- a/torchbenchmark/models/hf_Bart/__init__.py
+++ b/torchbenchmark/models/hf_Bart/__init__.py
@@ -47,7 +47,7 @@ class Model(BenchmarkModel):
         return ArgsToKwargsWrapper(self.model), (
                 self.example_inputs['input_ids'], self.example_inputs[k])
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -57,7 +57,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Bert/__init__.py
+++ b/torchbenchmark/models/hf_Bert/__init__.py
@@ -34,7 +34,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -44,7 +44,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_BigBird/__init__.py
+++ b/torchbenchmark/models/hf_BigBird/__init__.py
@@ -34,7 +34,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -44,7 +44,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_DistilBert/__init__.py
+++ b/torchbenchmark/models/hf_DistilBert/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
 
@@ -48,7 +48,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_GPT2/__init__.py
+++ b/torchbenchmark/models/hf_GPT2/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -43,7 +43,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Longformer/__init__.py
+++ b/torchbenchmark/models/hf_Longformer/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -43,7 +43,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Reformer/__init__.py
+++ b/torchbenchmark/models/hf_Reformer/__init__.py
@@ -36,7 +36,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -46,7 +46,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_T5/__init__.py
+++ b/torchbenchmark/models/hf_T5/__init__.py
@@ -52,7 +52,7 @@ class Model(BenchmarkModel):
                 self.example_inputs['input_ids'], self.example_inputs[k])
 
     # TODO: re-enable train test when infra has capacity
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -62,7 +62,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -80,13 +80,13 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.module, self.example_inputs
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
             self.module(*self.example_inputs)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -66,7 +66,7 @@ class Model(BenchmarkModel):
 
         return self.model, self.example_inputs
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
 
@@ -98,7 +98,7 @@ class Model(BenchmarkModel):
 
             meta_opt.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
 

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -33,7 +33,7 @@ class Model(BenchmarkModel):
         self.model.train()
         self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):
@@ -47,7 +47,7 @@ class Model(BenchmarkModel):
         self.model = quantize_fx.convert_fx(self.model)
         self.model.eval()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         example_inputs = self.example_inputs[0][0].unsqueeze(0)
         for _i in range(niter):
             self.model(example_inputs)

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -105,7 +105,7 @@ class Model(BenchmarkModel):
             images = (i[0], i[1])
         return self.model, images
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         """ Recommended
         Runs training on model for `niter` times. When `niter` is left
         to its default value, it should run for at most two minutes, and be representative
@@ -132,7 +132,7 @@ class Model(BenchmarkModel):
                 loss.backward()
                 self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         """ Recommended
         Run evaluation on model for `niter` inputs. One iteration should be sufficient
         to warm up the model for the purpose of profiling.

--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -65,13 +65,13 @@ class Model(BenchmarkModel):
   def set_train(self):
     self.eval_mode = False
 
-  def train(self, niter=1):
+  def _train(self, niter=1):
     self.check_implemented()
 
     for i in range(niter):
       self.model.train(niter)
 
-  def eval(self, niter=1):
+  def _eval(self, niter=1):
     self.check_implemented()
 
     for i in range(niter):

--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -49,7 +49,7 @@ class Model(BenchmarkModel):
 
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if niter != 1:
             raise NotImplementedError("niter not implemented")
         if self.jit:
@@ -65,7 +65,7 @@ class Model(BenchmarkModel):
         self.optimizer.step()
         self.optimizer.zero_grad()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if niter != 1:
             raise NotImplementedError("niter not implemented")
         if self.jit:

--- a/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
@@ -46,10 +46,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -139,10 +139,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -135,10 +135,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -48,7 +48,7 @@ class Model(BenchmarkModel):
         # and the train mode is on by default
         pass
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         # the training process is not patched to use scripted models
         if self.jit:
             raise NotImplementedError()
@@ -63,7 +63,7 @@ class Model(BenchmarkModel):
             # step rather than 7 epochs, but changing it now would potentially cause discontinuity with existing/historical measurement
             self.training_loop(None)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model, example_inputs = self.get_module()
         for i in range(niter):
             model(*example_inputs)

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -77,11 +77,11 @@ class Model(BenchmarkModel):
     def set_eval(self):
         self.model.eval()
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         for _ in range(niter):
             self.solver.train()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model = self.model
         example_inputs = self.example_inputs
         for _ in range(niter):

--- a/torchbenchmark/models/pytorch_struct/__init__.py
+++ b/torchbenchmark/models/pytorch_struct/__init__.py
@@ -90,7 +90,7 @@ class Model(BenchmarkModel):
     for words, _ in self.example_inputs:
       return self.model, (words, )
 
-  def train(self, niter=1):
+  def _train(self, niter=1):
     if self.jit:
         raise NotImplementedError("JIT is not supported by this model")
     for _, (words, lengths) in zip(range(niter), self.example_inputs):
@@ -104,7 +104,7 @@ class Model(BenchmarkModel):
       torch.nn.utils.clip_grad_norm_(self.model.parameters(), 3.0)
       self.opt.step()
 
-  def eval(self, niter=1):
+  def _eval(self, niter=1):
     raise NotImplementedError("Eval is not supported by this model")
 
 def cuda_sync(func, sync=False):

--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -47,7 +47,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         optimizer = optim.RMSprop(self.model.parameters(), lr=self.args.lr, weight_decay=1e-8, momentum=0.9)
         grad_scaler = torch.cuda.amp.GradScaler(enabled=self.args.amp)
         criterion = nn.CrossEntropyLoss()
@@ -69,7 +69,7 @@ class Model(BenchmarkModel):
                 grad_scaler.step(optimizer)
                 grad_scaler.update()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/resnet50_quantized_qat/__init__.py
+++ b/torchbenchmark/models/resnet50_quantized_qat/__init__.py
@@ -40,7 +40,7 @@ class Model(BenchmarkModel):
         self.model = quantize_fx.convert_fx(self.model)
         self.model.eval()
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):
@@ -50,7 +50,7 @@ class Model(BenchmarkModel):
             loss(pred, y).backward()
             optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model = self.model
         example_inputs = self.example_inputs
         example_inputs = example_inputs[0][0].unsqueeze(0)

--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -197,7 +197,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
         
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         # Setup
@@ -238,7 +238,7 @@ class Model(BenchmarkModel):
                 soft_update(self.target_agent.critic1, self.agent.critic1, self.args.tau)
                 soft_update(self.target_agent.critic2, self.agent.critic2, self.args.tau)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -57,7 +57,7 @@ class Model(BenchmarkModel):
         elif self.test == "eval":
             self.evalcfg.model = new_model
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == "cpu":
             raise NotImplementedError("CPU is not supported by this model")
         if self.jit:
@@ -65,7 +65,7 @@ class Model(BenchmarkModel):
         for i in range(niter):
             self.traincfg.train(epoch = i)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.device == "cpu":
             raise NotImplementedError("CPU is not supported by this model")
         if self.jit:

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -21,7 +21,7 @@ class Model(TorchVisionModel):
     
     # Temporarily disable training because this will cause CUDA OOM in CI
     # TODO: re-enable this test when better hardware is available
-    def train(self, niter=1):
+    def _train(self, niter=1):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -127,7 +127,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError('JIT not supported')
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cuda':
             raise NotImplementedError('CUDA disabled due to CUDA out of memory on CI GPU')
         if self.device == 'cpu':
@@ -143,7 +143,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.device == 'cuda':
             raise NotImplementedError('CUDA disabled due to CUDA out of memory on CI GPU')
         if self.device == 'cpu':

--- a/torchbenchmark/models/timm_efficientnet/__init__.py
+++ b/torchbenchmark/models/timm_efficientnet/__init__.py
@@ -56,13 +56,13 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
     # TODO: use pretrained model weights, assuming the pretrained model is in .data/ dir
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/timm_nfnet/__init__.py
+++ b/torchbenchmark/models/timm_nfnet/__init__.py
@@ -57,14 +57,14 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == "cuda":
             raise NotImplementedError("Disable the train test because it causes CUDA OOM on Nvidia T4")
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/timm_regnet/__init__.py
+++ b/torchbenchmark/models/timm_regnet/__init__.py
@@ -54,12 +54,12 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/timm_resnest/__init__.py
+++ b/torchbenchmark/models/timm_resnest/__init__.py
@@ -52,12 +52,12 @@ class Model(BenchmarkModel):
         self.example_inputs = self.example_inputs
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/timm_vision_transformer/__init__.py
+++ b/torchbenchmark/models/timm_vision_transformer/__init__.py
@@ -53,13 +53,13 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
     # TODO: use pretrained model weights, assuming the pretrained model is in .data/ dir
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/timm_vovnet/__init__.py
+++ b/torchbenchmark/models/timm_vovnet/__init__.py
@@ -51,12 +51,12 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -28,13 +28,13 @@ class Model(BenchmarkModel):
     def set_train(self):
         self.model.model.train()
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         # the training process is not patched to use scripted models
         self.model.train(niter)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -79,7 +79,7 @@ class Model(BenchmarkModel):
         for (example_inputs, _example_targets) in self.data_loader:
             return self.model, (example_inputs, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         self.model.train()
@@ -92,7 +92,7 @@ class Model(BenchmarkModel):
             losses.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         self.model.eval()

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -81,7 +81,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         # the training process is not patched to use scripted models
         if self.jit:
             raise NotImplementedError()
@@ -89,7 +89,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
         return self.training_loop(niter)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         model, example_inputs = self.get_module()
         for i in range(niter):
             pred = model(*example_inputs, augment=False)[0]

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -40,7 +40,7 @@ class TorchVisionModel(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         real_input = [ torch.rand_like(self.example_inputs[0]) ]
         real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
@@ -55,7 +55,7 @@ class TorchVisionModel(BenchmarkModel):
                     self.loss_fn(pred, target).backward()
                     self.optimizer.step()
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         if self.extra_args.cudagraph:
             return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.model

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -76,11 +76,19 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
+    def __post_train__(self):
+        pass
+
+    def __post_eval__(self):
+        pass
+
     def train(self):
-        raise NotImplementedError()
+        self._train()
+        self.__post_train__()
 
     def eval(self):
-        raise NotImplementedError()
+        self._eval()
+        self.__post_eval__()
 
     def set_eval(self):
         self._set_mode(False)


### PR DESCRIPTION
This is needed for adding the dispatch flops counter.

The design is to rename `train()` and `eval()` in each model into `_train()` and `_eval()`, and the actual `train()` and `eval()` function in the base class `BenchmarkModel` will call the inner implementation first, then call the post execution hook method.