### PR TITLE
Fix a env check bug for ondemand ci

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -14,7 +14,6 @@ from urllib import request
 
 from components._impl.tasks import base as base_task
 from components._impl.workers import subprocess_worker
-from .util.env_check import get_pkg_versions
 
 TORCH_DEPS = ['torch', 'torchvision', 'torchtext']
 proxy_suggestion = "Unable to verify https connectivity, " \
@@ -35,6 +34,7 @@ def _test_https(test_url: str = 'https://github.com', timeout: float = 0.5) -> b
 
 
 def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
+    from .util.env_check import get_pkg_versions
     run_args = [
         [sys.executable, install_file],
     ]
@@ -45,6 +45,7 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
 
     output_buffer = None
     _, stdout_fpath = tempfile.mkstemp()
+
     try:
         output_buffer = io.FileIO(stdout_fpath, mode="w")
         if os.path.exists(os.path.join(model_path, install_file)):

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -1,5 +1,8 @@
+"""
+PyTorch benchmark env check utils.
+This file may be loaded without torch packages installed, e.g., in OnDemand CI.
+"""
 import importlib
-import torch
 from typing import List, Dict, Tuple
 
 def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
@@ -18,7 +21,8 @@ def has_native_amp() -> bool:
         pass
     return False
 
-def correctness_check(eager_output: Tuple[torch.Tensor], output: Tuple[torch.Tensor]) -> float:
+def correctness_check(eager_output: Tuple['torch.Tensor'], output: Tuple['torch.Tensor']) -> float:
+    import torch
     # sanity checks
     assert len(eager_output) == len(output), "Correctness check requires two inputs have the same length"
     result = 1.0


### PR DESCRIPTION
In OnDemand CI, the script may load `torchbenchmark` module without pytorch installed (at the first time of running the bisection script).
This PR fixes a bug when it fails because `torch` package is not found.