### PR TITLE
Enable fp16 amp for all models

### DIFF
--- a/run_sweep.py
+++ b/run_sweep.py
@@ -102,7 +102,7 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         result.results["latency_ms"] = run_one_step(func, device)
         # if the model provides eager eval result, save it for cosine similarity
         correctness = task.get_model_attribute(correctness_name)
-        if correctness:
+        if not correctness == None:
             result.results[correctness_name] = correctness
     except NotImplementedError as e:
         status = "NotImplemented"

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -159,7 +159,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.model.bert = new_model
 
-    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         model = self.model
         for _ in range(niter):
             # 1. forward the next_sentence_prediction and masked_lm model
@@ -173,7 +173,7 @@ class Model(BenchmarkModel):
             loss = next_loss + mask_loss
         return (next_sent_output, mask_lm_output)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         trainer = self.model
         for _ in range(niter):
             # 1. forward the next_sentence_prediction and masked_lm model

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -128,7 +128,7 @@ class Model(BenchmarkModel):
     def _set_mode(self, train):
         pass
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
@@ -296,5 +296,5 @@ class Model(BenchmarkModel):
             # Change weight every 2 epoch to put more stress on discriminator weight and less on pseudo-supervision
             wt = wt/2
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         raise NotImplementedError()

--- a/torchbenchmark/models/LearningToPaint/__init__.py
+++ b/torchbenchmark/models/LearningToPaint/__init__.py
@@ -73,7 +73,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         episode = episode_steps = 0
@@ -103,7 +103,7 @@ class Model(BenchmarkModel):
                 episode += 1
             self.step += 1
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/Super_SloMo/__init__.py
+++ b/torchbenchmark/models/Super_SloMo/__init__.py
@@ -67,7 +67,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 
@@ -75,7 +75,7 @@ class Model(BenchmarkModel):
             out = self.model(*self.example_inputs)
         return out
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cpu':
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
 

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -109,13 +109,13 @@ class Model(BenchmarkModel):
         for (src_seq, trg_seq, gold) in self.example_inputs:
             return self.model, (*(src_seq, trg_seq), )
 
-    def eval(self, niter=1) -> torch.Tensor:
+    def _eval(self, niter=1) -> torch.Tensor:
         result = None
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
             result = self.model(*(src_seq, trg_seq))
         return (result, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         for _, (src_seq, trg_seq, gold) in zip(range(niter), self.example_inputs):
             self.optimizer.zero_grad()
             example_inputs = (src_seq, trg_seq)

--- a/torchbenchmark/models/dcgan/__init__.py
+++ b/torchbenchmark/models/dcgan/__init__.py
@@ -220,7 +220,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.exmaple_inputs,)
 
-    def eval(self, niter=1):
+    def _eval(self, niter=1):
         for _ in range(niter):
 
             if False == self.inference_just_descriminator:
@@ -231,7 +231,7 @@ class Model(BenchmarkModel):
             output = self.model(self.exmaple_inputs).view(-1)
         return (output, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
 
         # Training Loop
 

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -78,14 +78,14 @@ class Model(BenchmarkModel):
     def get_module(self) -> Tuple[DemucsWrapper, Tuple[Tensor]]:
         return self.model, self.example_inputs
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         for _ in range(niter):
             sources, estimates = self.model(*self.example_inputs)
             sources = center_trim(sources, estimates)
             loss = self.criterion(estimates, sources)
         return (sources, estimates)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == "cpu":
             raise NotImplementedError("Disable CPU training because it is too slow (> 1min)")
         if self.device == "cuda":

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -59,7 +59,7 @@ class Model(BenchmarkModel):
         for data in self.example_inputs:
             return self.model, (data, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if not self.device == "cuda":
             raise NotImplementedError("Only CUDA is supported by this model")
         if self.jit:
@@ -73,7 +73,7 @@ class Model(BenchmarkModel):
                 self.optimizer.step()
                 self.optimizer.zero_grad()
 
-    def eval(self, niter=2) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=2) -> Tuple[torch.Tensor]:
         if not self.device == "cuda":
             raise NotImplementedError("Only CUDA is supported by this model")
         if self.jit:

--- a/torchbenchmark/models/dlrm/__init__.py
+++ b/torchbenchmark/models/dlrm/__init__.py
@@ -198,14 +198,14 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("JIT not supported")
         for _ in range(niter):
             out = self.model(*self.example_inputs)
         return (out, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT not supported")
 

--- a/torchbenchmark/models/drq/__init__.py
+++ b/torchbenchmark/models/drq/__init__.py
@@ -119,7 +119,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
 
-    def train(self, niter=2):
+    def _train(self, niter=2):
         if self.jit:
             raise NotImplementedError()
         episode, episode_reward, episode_step, done = 0, 0, 1, True
@@ -150,7 +150,7 @@ class Model(BenchmarkModel):
             episode_step += 1
             self.step += 1
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         average_episode_reward = 0

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -99,7 +99,7 @@ class Model(BenchmarkModel):
         return self.model, (batch_x["words"], )
 
     # Sliced version of fastNLP.Tester._test()
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("PyTorch JIT compiler is not able to compile this model.")
         self._mode(self.model, is_test=True)
@@ -113,7 +113,7 @@ class Model(BenchmarkModel):
         return (pred_dict['pred_start'], pred_dict['pred_end'] )
 
     # Sliced version of fastNLP.Trainer._train()
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("PyTorch JIT compiler is not able to compile this model.")
         self.step = 0

--- a/torchbenchmark/models/hf_Albert/__init__.py
+++ b/torchbenchmark/models/hf_Albert/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
@@ -41,7 +41,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():

--- a/torchbenchmark/models/hf_Bart/__init__.py
+++ b/torchbenchmark/models/hf_Bart/__init__.py
@@ -44,7 +44,7 @@ class Model(BenchmarkModel):
         return ArgsToKwargsWrapper(self.model), (
                 self.example_inputs['input_ids'], self.example_inputs[k])
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -54,7 +54,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Bert/__init__.py
+++ b/torchbenchmark/models/hf_Bert/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -42,7 +42,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_BigBird/__init__.py
+++ b/torchbenchmark/models/hf_BigBird/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -42,7 +42,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_DistilBert/__init__.py
+++ b/torchbenchmark/models/hf_DistilBert/__init__.py
@@ -31,7 +31,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
 
@@ -46,7 +46,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_GPT2/__init__.py
+++ b/torchbenchmark/models/hf_GPT2/__init__.py
@@ -31,7 +31,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -41,7 +41,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Longformer/__init__.py
+++ b/torchbenchmark/models/hf_Longformer/__init__.py
@@ -31,7 +31,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -41,7 +41,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_Reformer/__init__.py
+++ b/torchbenchmark/models/hf_Reformer/__init__.py
@@ -34,7 +34,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, (self.example_inputs["input_ids"], )
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -44,7 +44,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/hf_T5/__init__.py
+++ b/torchbenchmark/models/hf_T5/__init__.py
@@ -50,7 +50,7 @@ class Model(BenchmarkModel):
                 self.example_inputs['input_ids'], self.example_inputs[k])
 
     # TODO: re-enable train test when infra has capacity
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
         self.model.train()
@@ -60,7 +60,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         self.model.eval()

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -78,14 +78,14 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.module, self.example_inputs
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):
             out = self.module(*self.example_inputs)
         return (out, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -67,7 +67,7 @@ class Model(BenchmarkModel):
 
         return self.model, self.example_inputs
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         if self.jit:
             raise NotImplementedError()
 
@@ -99,7 +99,7 @@ class Model(BenchmarkModel):
 
             meta_opt.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
 

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -34,7 +34,7 @@ class Model(BenchmarkModel):
         self.model.train()
         self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):
@@ -48,7 +48,7 @@ class Model(BenchmarkModel):
         self.model = quantize_fx.convert_fx(self.model)
         self.model.eval()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         example_inputs = self.example_inputs[0][0].unsqueeze(0)
         for _i in range(niter):
             out = self.model(example_inputs)

--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -103,7 +103,7 @@ class Model(BenchmarkModel):
             images = (i[0], i[1])
         return self.model, images
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         """ Recommended
         Runs training on model for `niter` times. When `niter` is left
         to its default value, it should run for at most two minutes, and be representative
@@ -130,7 +130,7 @@ class Model(BenchmarkModel):
                 loss.backward()
                 self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         """ Recommended
         Run evaluation on model for `niter` inputs. One iteration should be sufficient
         to warm up the model for the purpose of profiling.

--- a/torchbenchmark/models/nvidia_deeprecommender/__init__.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/__init__.py
@@ -64,15 +64,14 @@ class Model(BenchmarkModel):
   def set_train(self):
     self.eval_mode = False
 
-  def train(self, niter=1):
+  def _train(self, niter=1):
     self.check_implemented()
 
     for i in range(niter):
       self.model.train(niter)
 
-  def eval(self, niter=1) -> Tuple[torch.Tensor]:
+  def _eval(self, niter=1) -> Tuple[torch.Tensor]:
     self.check_implemented()
-    print("here... ")
     for i in range(niter):
       out = self.model.eval(niter)
     return (out, )

--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -50,7 +50,7 @@ class Model(BenchmarkModel):
 
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if niter != 1:
             raise NotImplementedError("niter not implemented")
         if self.jit:
@@ -66,7 +66,7 @@ class Model(BenchmarkModel):
         self.optimizer.step()
         self.optimizer.zero_grad()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if niter != 1:
             raise NotImplementedError("niter not implemented")
         if self.jit:

--- a/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
@@ -47,10 +47,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -140,10 +140,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -136,10 +136,10 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         raise NotImplementedError("Training not supported")
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         with torch.no_grad():
             for i in range(niter):

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -41,7 +41,7 @@ class Model(BenchmarkModel):
         # and the train mode is on by default
         pass
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         # the training process is not patched to use scripted models
         if self.jit:
             raise NotImplementedError()
@@ -56,7 +56,7 @@ class Model(BenchmarkModel):
             # step rather than 7 epochs, but changing it now would potentially cause discontinuity with existing/historical measurement
             self.training_loop(None)
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         for i in range(niter):
             out = model(*example_inputs)

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -75,11 +75,11 @@ class Model(BenchmarkModel):
     def set_eval(self):
         self.model.eval()
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         for _ in range(niter):
             self.solver.train()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model = self.model
         example_inputs = self.example_inputs
         for _ in range(niter):

--- a/torchbenchmark/models/pytorch_struct/__init__.py
+++ b/torchbenchmark/models/pytorch_struct/__init__.py
@@ -87,7 +87,7 @@ class Model(BenchmarkModel):
     for words, _ in self.example_inputs:
       return self.model, (words, )
 
-  def train(self, niter=1):
+  def _train(self, niter=1):
     if self.jit:
         raise NotImplementedError("JIT is not supported by this model")
     for _, (words, lengths) in zip(range(niter), self.example_inputs):
@@ -101,7 +101,7 @@ class Model(BenchmarkModel):
       torch.nn.utils.clip_grad_norm_(self.model.parameters(), 3.0)
       self.opt.step()
 
-  def eval(self, niter=1):
+  def _eval(self, niter=1):
     raise NotImplementedError("Eval is not supported by this model")
 
 def cuda_sync(func, sync=False):

--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -45,7 +45,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         optimizer = optim.RMSprop(self.model.parameters(), lr=self.args.lr, weight_decay=1e-8, momentum=0.9)
         grad_scaler = torch.cuda.amp.GradScaler(enabled=self.args.amp)
         criterion = nn.CrossEntropyLoss()
@@ -67,7 +67,7 @@ class Model(BenchmarkModel):
                 grad_scaler.step(optimizer)
                 grad_scaler.update()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/models/resnet50_quantized_qat/__init__.py
+++ b/torchbenchmark/models/resnet50_quantized_qat/__init__.py
@@ -41,7 +41,7 @@ class Model(BenchmarkModel):
         self.model = quantize_fx.convert_fx(self.model)
         self.model.eval()
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())
         loss = torch.nn.CrossEntropyLoss()
         for _ in range(niter):
@@ -51,7 +51,7 @@ class Model(BenchmarkModel):
             loss(pred, y).backward()
             optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model = self.model
         example_inputs = self.example_inputs
         example_inputs = example_inputs[0][0].unsqueeze(0)

--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -198,7 +198,7 @@ class Model(BenchmarkModel):
     def set_module(self, new_model):
         self.agent.actor = new_model
         
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         # Setup
@@ -239,7 +239,7 @@ class Model(BenchmarkModel):
                 soft_update(self.target_agent.critic1, self.agent.critic1, self.args.tau)
                 soft_update(self.target_agent.critic2, self.agent.critic2, self.args.tau)
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         with torch.no_grad():

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -59,7 +59,7 @@ class Model(BenchmarkModel):
         elif self.test == "eval":
             self.evalcfg.model = new_model
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == "cpu":
             raise NotImplementedError("CPU is not supported by this model")
         if self.jit:
@@ -67,7 +67,7 @@ class Model(BenchmarkModel):
         for i in range(niter):
             self.traincfg.train(epoch = i)
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == "cpu":
             raise NotImplementedError("CPU is not supported by this model")
         if self.jit:

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -127,7 +127,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError('JIT not supported')
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.device == 'cuda':
             raise NotImplementedError('CUDA disabled due to CUDA out of memory on CI GPU')
         if self.device == 'cpu':
@@ -143,7 +143,7 @@ class Model(BenchmarkModel):
             loss.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.device == 'cuda':
             raise NotImplementedError('CUDA disabled due to CUDA out of memory on CI GPU')
         if self.device == 'cpu':

--- a/torchbenchmark/models/tts_angular/__init__.py
+++ b/torchbenchmark/models/tts_angular/__init__.py
@@ -29,13 +29,13 @@ class Model(BenchmarkModel):
     def set_train(self):
         self.model.model.train()
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError()
         # the training process is not patched to use scripted models
         self.model.train(niter)
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError()
         for _ in range(niter):

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -77,7 +77,7 @@ class Model(BenchmarkModel):
         for (example_inputs, _example_targets) in self.data_loader:
             return self.model, (example_inputs, )
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         self.model.train()
@@ -90,7 +90,7 @@ class Model(BenchmarkModel):
             losses.backward()
             self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         self.model.eval()

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -79,7 +79,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError()
         return self.model, self.example_inputs
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         # the training process is not patched to use scripted models
         if self.jit:
             raise NotImplementedError()
@@ -87,7 +87,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Disabled due to excessively slow runtime - see GH Issue #100")
         return self.training_loop(niter)
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
         for i in range(niter):
             out = model(*example_inputs, augment=False)

--- a/torchbenchmark/util/backends/fp16.py
+++ b/torchbenchmark/util/backends/fp16.py
@@ -1,0 +1,4 @@
+import torch
+
+def enable_fp16_amp(module: torch.nn.Module) -> torch.nn.Module:
+    pass

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -59,6 +59,9 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
     if args.fuser:
         enable_fuser(args.fuser)
     if args.fp16 and not args.fp16 == "no":
+        # get the output tensor of eval eager mode
+        if args.test == "eval":
+            model.eager_output = model.eval()
         if args.fp16 == "half":
             model.model, model.example_inputs = enable_fp16_half(model.model, model.example_inputs)
         elif args.fp16 == "amp":
@@ -66,6 +69,9 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
             model.add_context(torch.cuda.amp.autocast(dtype=torch.float16))
         else:
             assert False, f"Get invalid fp16 value: {args.fp16}. Please report a bug."
+        if args.test == "eval":
+            model.output = model.eval()
+            model.correctness = correctness_check(model.eager_output, model.output)
     if args.jit:
         # model can handle jit code themselves through 'jit_callback' function
         if hasattr(model, 'jit_callback'):

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -63,7 +63,7 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
             model.model, model.example_inputs = enable_fp16_half(model.model, model.example_inputs)
         elif args.fp16 == "amp":
             import torch
-            model.add_context(torch.amp.autocast(dtype=torch.float16))
+            model.add_context(torch.cuda.amp.autocast(dtype=torch.float16))
         else:
             assert False, f"Get invalid fp16 value: {args.fp16}. Please report a bug."
     if args.jit:

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -56,12 +56,12 @@ class TimmModel(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
+    def _train(self, niter=1):
         self.model.train()
         for _ in range(niter):
             self._step_train()
 
-    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         self.model.eval()
         with torch.no_grad():
             for _ in range(niter):

--- a/torchbenchmark/util/framework/vision/args.py
+++ b/torchbenchmark/util/framework/vision/args.py
@@ -25,5 +25,5 @@ def enable_cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', example_
         optimizer.step()
     model.g = g
 
-def enable_fp16(model: torch.nn.Module, example_input: Tuple[torch.tensor]) -> Tuple[torch.nn.Module, Tuple[torch.tensor]]:
+def enable_fp16_half(model: torch.nn.Module, example_input: Tuple[torch.tensor]) -> Tuple[torch.nn.Module, Tuple[torch.tensor]]:
     return model.half(), (example_input[0].half(),)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -45,7 +45,7 @@ class TorchVisionModel(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self, niter=3):
+    def _train(self, niter=3):
         real_input = [ torch.rand_like(self.example_inputs[0]) ]
         real_output = [ torch.rand_like(self.example_outputs) ]
         for _ in range(niter):
@@ -60,7 +60,7 @@ class TorchVisionModel(BenchmarkModel):
                     self.loss_fn(pred, target).backward()
                     self.optimizer.step()
 
-    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
+    def _eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         if self.extra_args.cudagraph:
             return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.model

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -28,7 +28,7 @@ def no_grad(val):
 @contextmanager
 def nested(*contexts):
     """
-    Reimplementation of nested in python 3.
+    Chain and apply a list of contexts
     """
     with ExitStack() as stack:
         for ctx in contexts:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -92,11 +92,11 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
     def train(self):
-        with nested(self.run_contexts):
+        with nested(*self.run_contexts):
             self._train()
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with nested(self.run_contexts):
+        with nested(*self.run_contexts):
             out = self._eval()
         return out
 


### PR DESCRIPTION
This PR adds fp16 amp to all models. Basically, it adds an autocast context to all eval tests:
```
with torch.cuda.amp.autocast():
    eval()
```

