### PR TITLE
Factor the core lowering component into a pass function

### DIFF
--- a/torchbenchmark/util/backends/fx2trt.py
+++ b/torchbenchmark/util/backends/fx2trt.py
@@ -54,6 +54,7 @@ def lower_to_trt(
         verbose_log=verbose_log,
         timing_cache_prefix=timing_cache_prefix,
         save_timing_cache=save_timing_cache,
+        cuda_graph_batch_size=cuda_graph_batch_size,
     )
     lowerer = Lowerer.create(lower_setting=lower_setting)
     return lowerer(module, input)


### PR DESCRIPTION
Summary:
The core lowering component is taking a fx.GraphModule, and turning it into a lowered, `nn.Module` (generally speaking). Or more specifically,
turning it into a `TRTModule` in the case of fx2trt.

```
[nn.Module, PassContext] -> [nn.Module, PassContext]
```

As a matter of fact, the above signature is just a general module transformation pass function we should have consolidated and used across our stack.

Today this involves two steps:

1. Run TRTInterpreter
2. Turn the TRTInterpreterResult into a TRTModule

We wrap it into the above pass function.

Why? This is one step towards making it possible to swap in a different fx -> trt implementation, e.g., torch-tensorrt. (see [discussion](https://fb.workplace.com/groups/890926038157430/posts/1058116424771723/)

Differential Revision: D34540677

