### PR TITLE
Enable fp16 by default for hf models

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -32,7 +32,7 @@ def check_fp16(model: 'torchbenchmark.util.model.BenchmarkModel', fp16: str) -> 
 
 # torchvision models uses fp16 half mode by default, others use fp32
 def get_fp16_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
-    if is_torchvision_model(model) and model.test == 'eval' and model.device == 'cuda':
+    if (is_torchvision_model(model) or is_hf_model(model)) and model.test == 'eval' and model.device == 'cuda':
         return "half"
     return "no"
 

--- a/torchbenchmark/util/framework/huggingface/patch_hf.py
+++ b/torchbenchmark/util/framework/huggingface/patch_hf.py
@@ -9,16 +9,15 @@ PATCH_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "patches")
 
 def patch_transformers():
     import transformers
-    import patch
-    patch_file = os.path.join(PATCH_DIR, "0001-transformers-enable-fx.patch")
     transformers_dir = os.path.dirname(transformers.__file__)
-    p = patch.fromfile(patch_file)
-    try:
-        subprocess.check_output(["patch", "-p1", "--forward", "-i", patch_file, "-r", "/tmp/rej"], cwd=transformers_dir)
-    except subprocess.SubprocessError as e:
-        output_str = str(e.output)
-        if "previously applied" in output_str:
-            return
-        else:
-            print(str(output_str))
-            sys.exit(1)
+    for patch_file in os.listdir(PATCH_DIR):
+        patch_file_fullpatch = os.path.join(PATCH_DIR, patch_file)
+        try:
+            subprocess.check_output(["patch", "-p1", "--forward", "-i", patch_file_fullpatch, "-r", "/tmp/rej"], cwd=transformers_dir)
+        except subprocess.SubprocessError as e:
+            output_str = str(e.output)
+            if "previously applied" in output_str:
+                return
+            else:
+                print(str(output_str))
+                sys.exit(1)

--- a/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
+++ b/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
@@ -1,0 +1,12 @@
+diff --git a/models/big_bird/modeling_big_bird.py b/models/big_bird/modeling_big_bird.py
+index 6ac2fb4..2747b5e 100644
+--- a/models/big_bird/modeling_big_bird.py
++++ b/models/big_bird/modeling_big_bird.py
+@@ -1397,6 +1397,7 @@ class BigBirdAttention(nn.Module):
+                 hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
+             )
+
++        self_outputs = tuple(map(lambda x: x.to(hidden_states.dtype), self_outputs)) # fp16 compatibility
+         attention_output = self.output(self_outputs[0], hidden_states)
+         outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
+         return outputs

--- a/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
+++ b/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
@@ -14,7 +14,7 @@ index fa55c58..af5d82d 100644
                  hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
              )
 
-+	self_outputs = tuple(
++   self_outputs = tuple(
 +            tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)
 +        )  # fp16 compatibility
          attention_output = self.output(self_outputs[0], hidden_states)

--- a/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
+++ b/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
@@ -14,7 +14,7 @@ index fa55c58..af5d82d 100644
                  hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
              )
 
-+   self_outputs = tuple(
++        self_outputs = tuple(
 +            tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)
 +        )  # fp16 compatibility
          attention_output = self.output(self_outputs[0], hidden_states)

--- a/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
+++ b/torchbenchmark/util/framework/huggingface/patches/0002-transformers-enable-bigbird-fp16.patch
@@ -1,12 +1,22 @@
 diff --git a/models/big_bird/modeling_big_bird.py b/models/big_bird/modeling_big_bird.py
-index 6ac2fb4..2747b5e 100644
+index fa55c58..af5d82d 100644
 --- a/models/big_bird/modeling_big_bird.py
 +++ b/models/big_bird/modeling_big_bird.py
-@@ -1397,6 +1397,7 @@ class BigBirdAttention(nn.Module):
+@@ -22,6 +22,7 @@ from typing import Optional, Tuple
+
+ import numpy as np
+ import torch
++from torch.utils._pytree import tree_map
+ import torch.utils.checkpoint
+ from packaging import version
+ from torch import nn
+@@ -1397,6 +1398,9 @@ class BigBirdAttention(nn.Module):
                  hidden_states, band_mask, from_mask, to_mask, from_blocked_mask, to_blocked_mask, output_attentions
              )
 
-+        self_outputs = tuple(map(lambda x: x.to(hidden_states.dtype), self_outputs)) # fp16 compatibility
++	self_outputs = tuple(
++            tree_map(lambda x: x.to(hidden_states.dtype) if isinstance(x, torch.Tensor) else x, self_outputs)
++        )  # fp16 compatibility
          attention_output = self.output(self_outputs[0], hidden_states)
          outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
          return outputs


### PR DESCRIPTION
This PR sets `fp16` to be the default precision of all huggingface models.
This PR also includes an extra patch to the transformers package, because `hf_BigBird` needs to be patched in order to support fp16.

I believe this patch should also be upstream-ed: https://github.com/huggingface/transformers/pull/16034