### PR TITLE
Fixes Background_Matting get_module interface

### DIFF
--- a/test.py
+++ b/test.py
@@ -50,13 +50,9 @@ def _load_test(path, device):
     def example_fn(self):
         task = ModelTask(path, timeout=TIMEOUT)
         with task.watch_cuda_memory(skip=(device != "cuda"), assert_equal=self.assertEqual):
-            try:
-                task.make_model_instance(test="eval", device=device, jit=False)
-                task.check_example()
-                task.del_model_instance()
-
-            except NotImplementedError:
-                self.skipTest('Method get_module is not implemented, skipping...')
+            task.make_model_instance(test="eval", device=device, jit=False)
+            task.check_example()
+            task.del_model_instance()
 
     def train_fn(self):
         metadata = get_metadata_from_yaml(path)

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -123,6 +123,7 @@ class Model(BenchmarkModel):
             break
 
     def get_module(self):
+        # use netG (generation) for the return module
         for _i, data in enumerate(self.train_data):
             bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -121,7 +121,10 @@ class Model(BenchmarkModel):
             break
 
     def get_module(self):
-        raise NotImplementedError()
+        for _i, data in enumerate(self.train_data):
+            bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
+                'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
+            return self.netD, ((image, bg, seg, multi_fr), )
 
     # eval() isn't implemented
     # train() is on by default

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -30,6 +30,8 @@ class Model(BenchmarkModel):
     # Original hardware: unknown
     # Source: https://arxiv.org/pdf/2004.00626.pdf
     DEFAULT_TRAIN_BSIZE = 4
+    DEFAULT_EVAL_BSIZE = 1
+    ALLOW_CUSTOMIZE_BSIZE = False
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -124,7 +124,7 @@ class Model(BenchmarkModel):
         for _i, data in enumerate(self.train_data):
             bg, image, seg, multi_fr, seg_gt, back_rnd = data['bg'], data[
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
-            return self.netD, ((image, bg, seg, multi_fr), )
+            return self.netG, (image.to(self.device), bg.to(self.device), seg.to(self.device), multi_fr.to(self.device))
 
     # eval() isn't implemented
     # train() is on by default


### PR DESCRIPTION
Given the importance of the `get_module()` interface, we must implement it for every model.
This PR forces the implementation of the `get_module()` interface across all models, and properly implement it for the `Background_Matting` model.

Fixes https://github.com/pytorch/benchmark/issues/567.
