### PR TITLE
Add CPU implementation to pytorch_CycleGAN_and_pix2pix

### DIFF
--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -19,9 +19,16 @@ class Model(BenchmarkModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
-        train_args = f"--dataroot {os.path.dirname(__file__)}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 --n_epochs_decay 3"
-        self.training_loop = prepare_training_loop(train_args.split(' '))
-        self.model, self.input = get_model()
+        device_arg = ""
+        if self.device == "cpu":
+            device_arg = "--gpu_ids -1"
+        elif self.device == "cuda":
+            device_arg = "--gpu_ids 0"
+        if self.test == "train":
+            train_args = f"--dataroot {os.path.dirname(__file__)}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 --n_epochs_decay 3 {device_arg}"
+            self.training_loop = prepare_training_loop(train_args.split(' '))
+        args = f"--dataroot {os.path.dirname(__file__)}/datasets/horse2zebra/testA --name horse2zebra_pretrained --model test --no_dropout {device_arg}"
+        self.model, self.input = get_model(args, self.device)
 
     def get_module(self):
         return self.model, self.input

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
@@ -35,8 +35,7 @@ from .util import html
 import torch
 from pathlib import Path
 
-def get_model():
-    args = f"--dataroot {os.path.dirname(__file__)}/datasets/horse2zebra/testA --name horse2zebra_pretrained --model test --no_dropout"
+def get_model(args, device):
     opt = TestOptions().parse(args.split(' '))
     opt.num_threads = 0   # test code only supports num_threads = 1
     opt.batch_size = 1    # test code only supports batch_size = 1
@@ -46,8 +45,8 @@ def get_model():
     model = create_model(opt)      # create a model given opt.model and other options
     model = model.netG.module
     root = str(Path(__file__).parent)
-    data = torch.load(f'{root}/example_input.pt')    
-    input = data['A'].cuda()
+    data = torch.load(f'{root}/example_input.pt')
+    input = data['A'].to(device)
 
     return model, (input,)
 

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
@@ -43,7 +43,7 @@ def get_model(args, device):
     opt.no_flip = True    # no flip; comment this line if results on flipped images are needed.
     opt.display_id = -1   # no visdom display; the test code saves the results to a HTML file.
     model = create_model(opt)      # create a model given opt.model and other options
-    model = model.netG.module
+    model = model.netG.model
     root = str(Path(__file__).parent)
     data = torch.load(f'{root}/example_input.pt')
     input = data['A'].to(device)

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
@@ -43,7 +43,11 @@ def get_model(args, device):
     opt.no_flip = True    # no flip; comment this line if results on flipped images are needed.
     opt.display_id = -1   # no visdom display; the test code saves the results to a HTML file.
     model = create_model(opt)      # create a model given opt.model and other options
-    model = model.netG.model
+    if len(opt.gpu_ids) > 0:
+        # When opt.gpu_ids > 0, netG is converted to torch.nn.DataParallel
+        model = model.netG.module
+    else:
+        model = model.netG
     root = str(Path(__file__).parent)
     data = torch.load(f'{root}/example_input.pt')
     input = data['A'].to(device)


### PR DESCRIPTION
Note that the CPU run is very slow so it is disabled in nightly run by metadata (https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/metadata.yaml#L10).
Still, users can run CPU train or eval test with the `run.py` command:
```
$ python run.py pytorch_CycleGAN_and_pix2pix -d cpu -t [train|eval]
```
Fixes https://github.com/pytorch/benchmark/issues/788