### PR TITLE
Fix bisection workflow broken by vision and ffmpeg upgrade

### DIFF
--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -31,6 +31,8 @@ jobs:
           conda install -y numpy requests=2.22 ninja pyyaml mkl mkl-include setuptools cmake cffi \
                            typing_extensions future six dataclasses tabulate gitpython tqdm
           conda install -y -c pytorch "${MAGMA_VERSION}"
+          # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616
+          conda install -y ffmpeg=4.4.1
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -32,6 +32,8 @@ jobs:
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
+          # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616
+          conda install -y ffmpeg=4.4.1
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"


### PR DESCRIPTION
Torchvision doesn't compile against the latest ffmpeg-5 (https://github.com/pytorch/vision/issues/5616), so we are pinning the ffmpeg version to 4.4.1 until the vision team solves the build issue.