### PR TITLE
Adding the model input iterators.

### DIFF
--- a/test.py
+++ b/test.py
@@ -55,7 +55,7 @@ def _create_example_model_instance(task: ModelTask, device: str):
             skip = True
     finally:
         if skip:
-            raise NotImplementedError("Model is not implemented on this device")
+            raise NotImplementedError(f"Model is not implemented on the device {device}")
 
 def _load_test(path, device):
 

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -365,15 +365,6 @@ class ModelTask(base_task.TaskBase):
             module(**example_inputs)
         else:
             module(*example_inputs)
-        from torch.utils._pytree import tree_flatten
-        flat_args, _spec = tree_flatten(example_inputs)
-        new_inputs = next(model.gen_inputs())
-        new_flat_args, _spec = tree_flatten(new_inputs)
-        assert len(flat_args) == len(new_flat_args), \
-            f"Example inputs has length {len(flat_args)}, but gen_inputs() returns {len(new_flat_args)}"
-        for ind in range(len(flat_args)):
-            assert flat_args[ind].size() == new_flat_args[ind].size(), \
-                f"Example inputs has size {flat_args[ind].size()}, but gen_inputs() returns {new_flat_args[ind].size()}"
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -365,6 +365,18 @@ class ModelTask(base_task.TaskBase):
             module(**example_inputs)
         else:
             module(*example_inputs)
+        # If model implements `gen_inputs()` interface, test the first example input it generates
+        try:
+            input_iter, _size = model.gen_inputs()
+            next_input = next(input_iter)
+            if isinstance(example_inputs, dict):
+                # Huggingface models pass **kwargs as arguments, not *args
+                module(**next_input)
+            else:
+                module(*next_input)
+        except NotImplementedError:
+            # We allow models that don't implement this interface
+            pass
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -368,12 +368,13 @@ class ModelTask(base_task.TaskBase):
         # If model implements `gen_inputs()` interface, test the first example input it generates
         try:
             input_iter, _size = model.gen_inputs()
-            next_input = next(input_iter)
-            if isinstance(example_inputs, dict):
-                # Huggingface models pass **kwargs as arguments, not *args
-                module(**next_input)
-            else:
-                module(*next_input)
+            next_inputs = next(input_iter)
+            for input in next_inputs:
+                if isinstance(input, dict):
+                    # Huggingface models pass **kwargs as arguments, not *args
+                    module(**input)
+                else:
+                    module(*input)
         except NotImplementedError:
             # We allow models that don't implement this interface
             pass

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -365,6 +365,15 @@ class ModelTask(base_task.TaskBase):
             module(**example_inputs)
         else:
             module(*example_inputs)
+        from torch.utils._pytree import tree_flatten
+        flat_args, _spec = tree_flatten(example_inputs)
+        new_inputs = next(model.gen_inputs())
+        new_flat_args, _spec = tree_flatten(new_inputs)
+        assert len(flat_args) == len(new_flat_args), \
+            f"Example inputs has length {len(flat_args)}, but gen_inputs() returns {len(new_flat_args)}"
+        for ind in range(len(flat_args)):
+            assert flat_args[ind].size() == new_flat_args[ind].size(), \
+                f"Example inputs has size {flat_args[ind].size()}, but gen_inputs() returns {new_flat_args[ind].size()}"
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -32,6 +32,10 @@ class TimmModel(BenchmarkModel):
         if device == 'cuda':
             torch.cuda.empty_cache()
 
+    def gen_inputs(self):
+        while True:
+            yield self._gen_input(self.batch_size)
+
     def _gen_input(self, batch_size):
         return torch.randn((batch_size,) + self.cfg.input_size, device=self.device)
 

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -3,6 +3,7 @@ import typing
 import timm
 from torchbenchmark.util.model import BenchmarkModel
 from .timm_config import TimmConfig
+from typing import Generator, Tuple, Optional
 
 class TimmModel(BenchmarkModel):
     optimized_for_inference = True
@@ -32,9 +33,11 @@ class TimmModel(BenchmarkModel):
         if device == 'cuda':
             torch.cuda.empty_cache()
 
-    def gen_inputs(self):
-        while True:
-            yield self._gen_input(self.batch_size)
+    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+        def _gen_inputs():
+            while True:
+                yield self._gen_input(self.batch_size)
+        return (_gen_inputs(), None)
 
     def _gen_input(self, batch_size):
         return torch.randn((batch_size,) + self.cfg.input_size, device=self.device)

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -38,7 +38,9 @@ class TimmModel(BenchmarkModel):
             while True:
                 result = []
                 for _i in range(num_batches):
-                    result.append(self._gen_input(self.batch_size))
+                    result.append((self._gen_input(self.batch_size), ))
+                if self.dargs.fp16 == "half":
+                    result = list(map(lambda x: x.half(), result))
                 yield result
         return (_gen_inputs(), None)
 

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -40,7 +40,7 @@ class TimmModel(BenchmarkModel):
                 for _i in range(num_batches):
                     result.append((self._gen_input(self.batch_size), ))
                 if self.dargs.fp16 == "half":
-                    result = list(map(lambda x: x.half(), result))
+                    result = list(map(lambda x: (x[0].half(), ), result))
                 yield result
         return (_gen_inputs(), None)
 

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -33,10 +33,13 @@ class TimmModel(BenchmarkModel):
         if device == 'cuda':
             torch.cuda.empty_cache()
 
-    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+    def gen_inputs(self, num_batches:int=1) -> Tuple[Generator, Optional[int]]:
         def _gen_inputs():
             while True:
-                yield self._gen_input(self.batch_size)
+                result = []
+                for _i in range(num_batches):
+                    result.append(self._gen_input(self.batch_size))
+                yield result
         return (_gen_inputs(), None)
 
     def _gen_input(self, batch_size):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -41,10 +41,13 @@ class TorchVisionModel(BenchmarkModel):
             return flops, self.batch_size
         assert False, f"get_flops() only support eval or train mode, but get {self.test}. Please submit a bug report."
 
-    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+    def gen_inputs(self, num_batches:int=1) -> Tuple[Generator, Optional[int]]:
         def _gen_inputs():
             while True:
-                yield (torch.randn((self.batch_size, 3, 224, 224)).to(self.device),)
+                result = []
+                for _i in range(num_batches):
+                    result.append((torch.randn((self.batch_size, 3, 224, 224)).to(self.device),))
+                yield result
         return (_gen_inputs(), None)
 
     def enable_fp16_half(self):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -1,10 +1,9 @@
 import torch
-import random
-import numpy as np
 import typing
 import torch.optim as optim
 import torchvision.models as models
 from torchbenchmark.util.model import BenchmarkModel
+from typing import Tuple, Generator, Optional
 
 class TorchVisionModel(BenchmarkModel):
     optimized_for_inference = True
@@ -42,9 +41,11 @@ class TorchVisionModel(BenchmarkModel):
             return flops, self.batch_size
         assert False, f"get_flops() only support eval or train mode, but get {self.test}. Please submit a bug report."
 
-    def gen_inputs(self):
-        while True:
-            yield (torch.randn((self.batch_size, 3, 224, 224)).to(self.device),)
+    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+        def _gen_inputs():
+            while True:
+                yield (torch.randn((self.batch_size, 3, 224, 224)).to(self.device),)
+        return (_gen_inputs(), None)
 
     def enable_fp16_half(self):
         self.model = self.model.half()

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -47,6 +47,8 @@ class TorchVisionModel(BenchmarkModel):
                 result = []
                 for _i in range(num_batches):
                     result.append((torch.randn((self.batch_size, 3, 224, 224)).to(self.device),))
+                if self.dargs.fp16 == "half":
+                    result = list(map(lambda x: x.half(), result))
                 yield result
         return (_gen_inputs(), None)
 

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -42,6 +42,10 @@ class TorchVisionModel(BenchmarkModel):
             return flops, self.batch_size
         assert False, f"get_flops() only support eval or train mode, but get {self.test}. Please submit a bug report."
 
+    def gen_inputs(self):
+        while True:
+            yield (torch.randn((self.batch_size, 3, 224, 224)).to(self.device),)
+
     def enable_fp16_half(self):
         self.model = self.model.half()
         self.example_inputs = (self.example_inputs[0].half(), )

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -48,7 +48,7 @@ class TorchVisionModel(BenchmarkModel):
                 for _i in range(num_batches):
                     result.append((torch.randn((self.batch_size, 3, 224, 224)).to(self.device),))
                 if self.dargs.fp16 == "half":
-                    result = list(map(lambda x: x.half(), result))
+                    result = list(map(lambda x: (x[0].half(), ), result))
                 yield result
         return (_gen_inputs(), None)
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -118,11 +118,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
     def gen_inputs(self):
-        _model, example_input = self.get_module()
-        while True:
-            new_inputs = tree_map(lambda x: torch.rand_like(x) if isinstance(x, torch.Tensor) else x,
-                                 example_input)
-            yield new_inputs
+        raise NotImplementedError("Default input generation function is not implemented. "
+                                  "Please submit an issue if you need input iterator implementation for the model.")
 
     def invoke(self) -> Optional[Tuple[torch.Tensor]]:
         out = None

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -117,7 +117,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
-    def gen_inputs(self):
+    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+        """Generate a tuple of (iterator of model input, the size of the iterator).
+           If size is None, the input is randomly generated and has infinite size. """
         raise NotImplementedError("Default input generation function is not implemented. "
                                   "Please submit an issue if you need input iterator implementation for the model.")
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -15,14 +15,6 @@ class PostInitProcessor(type):
         obj.__post__init__()
         return obj
 
-def _is_tuple_tensor(var: Any) -> bool:
-    if not isinstance(var, tuple):
-        return False
-    for x in var:
-        if not isinstance(x, torch.Tensor):
-            return False
-    return True
-
 @contextmanager
 def no_grad(val):
     """Some meta-learning models (e.g. maml) may need to train a target(another) model
@@ -127,11 +119,10 @@ class BenchmarkModel(metaclass=PostInitProcessor):
 
     def gen_inputs(self):
         _model, example_input = self.get_module()
-        if not _is_tuple_tensor(example_input):
-            raise NotImplementedError("The model doesn't support generating random input.")
         while True:
-            new_input = tuple(map(lambda x: torch.rand_like(x), example_input))
-            yield new_input
+            new_inputs = tree_map(lambda x: torch.rand_like(x) if isinstance(x, torch.Tensor) else x,
+                                 example_input)
+            yield new_inputs
 
     def invoke(self) -> Optional[Tuple[torch.Tensor]]:
         out = None

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -117,7 +117,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
-    def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
+    def gen_inputs(self, num_batches: int=1) -> Tuple[Generator, Optional[int]]:
         """Generate a tuple of (iterator of model input, the size of the iterator).
            If size is None, the input is randomly generated and has infinite size."""
         raise NotImplementedError("Default input generation function is not implemented. "

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -15,6 +15,14 @@ class PostInitProcessor(type):
         obj.__post__init__()
         return obj
 
+def _is_tuple_tensor(var: Any) -> bool:
+    if not isinstance(var, tuple):
+        return False
+    for x in var:
+        if not isinstance(x, torch.Tensor):
+            return False
+    return True
+
 @contextmanager
 def no_grad(val):
     """Some meta-learning models (e.g. maml) may need to train a target(another) model
@@ -116,6 +124,14 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.model = new_model
         else:
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
+
+    def gen_inputs(self):
+        _model, example_input = self.get_module()
+        if not _is_tuple_tensor(example_input):
+            raise NotImplementedError("The model doesn't support generating random input.")
+        while True:
+            new_input = tuple(map(lambda x: torch.rand_like(x), example_input))
+            yield new_input
 
     def invoke(self) -> Optional[Tuple[torch.Tensor]]:
         out = None

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -3,7 +3,7 @@ import torch
 from contextlib import contextmanager, ExitStack
 import warnings
 import inspect
-from typing import ContextManager, Optional, List, Tuple
+from typing import ContextManager, Optional, List, Tuple, Generator
 from torchbenchmark.util.backends.torchdynamo import parse_torchdynamo_args, apply_torchdynamo_args
 from torchbenchmark.util.extra_args import enable_opt_args, parse_opt_args, apply_opt_args, \
                                            parse_decoration_args, apply_decoration_args
@@ -119,7 +119,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
 
     def gen_inputs(self) -> Tuple[Generator, Optional[int]]:
         """Generate a tuple of (iterator of model input, the size of the iterator).
-           If size is None, the input is randomly generated and has infinite size. """
+           If size is None, the input is randomly generated and has infinite size."""
         raise NotImplementedError("Default input generation function is not implemented. "
                                   "Please submit an issue if you need input iterator implementation for the model.")
 


### PR DESCRIPTION
This PR adds a new interface, `gen_inputs(self) -> Tuple[Generator, Optional[int]]`. The first element is an iterator of the input data, and the second element is the size of the iterator. If the iterator is infinite, the second value is set to None.

Currently, only implement this on `timm` and `torchvision` models. Both of them use randomly generated inputs, therefore the second value is set to None in both cases.