### PR TITLE
Revert D34929680: Multisect successfully blamed D34929680 for test failures

### DIFF
--- a/torchbenchmark/util/backends/fx2trt.py
+++ b/torchbenchmark/util/backends/fx2trt.py
@@ -62,12 +62,11 @@ def lower_to_trt(
     """
     from fx2trt_oss.fx import LowerSetting
     from fx2trt_oss.fx.lower import Lowerer
-    from fx2trt_oss.fx.utils import LowerPrecision
     lower_setting = LowerSetting(
         max_batch_size=max_batch_size,
         max_workspace_size=max_workspace_size,
         explicit_batch_dimension=explicit_batch_dimension,
-        lower_precision=LowerPrecision.FP16,
+        fp16_mode=fp16_mode,
         enable_fuse=enable_fuse,
         verbose_log=verbose_log,
         timing_cache_prefix=timing_cache_prefix,


### PR DESCRIPTION
Reviewed By: brad-mengchi

Differential Revision: D34966585

