### PR TITLE
Remove numba deps

### DIFF
--- a/torchbenchmark/models/tacotron2/requirements.txt
+++ b/torchbenchmark/models/tacotron2/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 inflect
-librosa
 scipy
 Unidecode
 pillow

--- a/torchbenchmark/models/tacotron2/requirements.txt
+++ b/torchbenchmark/models/tacotron2/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 inflect
 librosa
-numba
 scipy
 Unidecode
 pillow

--- a/torchbenchmark/models/tts_angular/requirements.txt
+++ b/torchbenchmark/models/tts_angular/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 scipy
-numba
 librosa
 phonemizer
 unidecode

--- a/torchbenchmark/models/tts_angular/requirements.txt
+++ b/torchbenchmark/models/tts_angular/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 scipy
-librosa
 phonemizer
 unidecode
 Pillow
@@ -15,5 +14,4 @@ nose
 cardboardlint
 pylint
 gdown
-umap-learn
 pyyaml


### PR DESCRIPTION
numba requires numpy<1.22, but conda environment uses numpy=1.22.3 by default.
Installing numba will fallback to numpy=1.21, which causes the problem of incompatible numpy api version (compile time vs. runtime)