### PR TITLE
Add TorchDynamo support

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -4,65 +4,28 @@ Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 import argparse
 from typing import List
 
+class NullContext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+def null_experiment(args, model_iter_fn, model, example_inputs):
+    """
+    A no-op experiment useful for making sure TorchBenchmark alone works properly.
+    """
+
+    return []
+
 def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     args = parser.parse_args(extra_args)
     group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--coverage", action="store_true", help="(default) " + help(coverage_experiment)
-    )
-    group.add_argument(
-        "--online-autotune", action="store_true", help=help(speedup_experiment)
-    )
-    group.add_argument(
-        "--offline-autotune", action="store_true", help=help(speedup_experiment)
-    )
-    group.add_argument(
-        "--speedup-fixed1",
-        action="store_true",
-        help="speedup using experimental fixed_strategy backend",
-    )
-    group.add_argument(
-        "--speedup-fixed2",
-        action="store_true",
-        help="speedup using experimental fixed_strategy backend",
-    )
-    group.add_argument(
-        "--speedup-ltc",
-        action="store_true",
-        help="speedup using the ltc backend",
-    )
-    group.add_argument(
-        "--speedup-ltc-trivial",
-        action="store_true",
-        help="speedup using the ltc backend without reusing compiled graph",
-    )
-    group.add_argument(
-        "--overhead", action="store_true", help=help(overhead_experiment)
-    )
-    group.add_argument(
-        "--speedup-ts", action="store_true", help=help(speedup_experiment_ts)
-    )
-    group.add_argument(
-        "--speedup-sr", action="store_true", help=help(speedup_experiment_sr)
-    )
-    group.add_argument(
-        "--speedup-onnx", action="store_true", help=help(speedup_experiment_onnx)
-    )
-    group.add_argument(
-        "--speedup-trt", action="store_true", help=help(speedup_experiment_trt)
-    )
-    group.add_argument(
-        "--accuracy-aot-nop",
-        action="store_true",
-        help="Accuracy testing for AOT vs Eager",
-    )
-    group.add_argument(
-        "--speedup-aot-efficient-fusion",
-        action="store_true",
-        help="speedup using experimental fixed_strategy backend",
-    )
     group.add_argument("--nothing", action="store_true", help=help(null_experiment))
+    parser.add_argument(
+        "--nopython", action="store_true", help="Turn graph breaks into errors"
+    )
     group.add_argument(
         "--nops",
         action="store_true",
@@ -71,5 +34,14 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ex
     args = parser.parse_args()
     return args
 
-def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]):
-    pass
+def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
+    import torchdynamo
+    optimize_ctx = NullContext()
+    if args.nothing:
+        pass
+    elif args.nops:
+        optimize_ctx = torchdynamo.eval_frame._optimize_catch_errors(
+            torchdynamo.testing.debug_insert_nops, nopython=args.nopython
+        )
+    model.add_context(optimize_ctx)
+    torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -2,6 +2,7 @@
 Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 """
 import argparse
+import functools
 from typing import List
 
 def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dyamo_args: List[str]) -> argparse.Namespace:
@@ -15,7 +16,5 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dy
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
     import torchdynamo
-    backend = args.torchdynamo
-    optimize_ctx = torchdynamo.optimize(backend)
-    model.add_context(lambda: optimize_ctx)
+    model.add_context(functools.partial(torchdynamo.optimize, args.torchdynamo))
     torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -46,5 +46,5 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         optimize_ctx = torchdynamo.eval_frame._optimize_catch_errors(
             torchdynamo.testing.debug_insert_nops, nopython=args.nopython
         )
-    model.add_context(optimize_ctx)
+    model.add_context(lambda: optimize_ctx)
     torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -4,46 +4,18 @@ Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 import argparse
 from typing import List
 
-class NullContext:
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-def help(fn):
-    return fn.__doc__
-
-def null_experiment(args, model_iter_fn, model, example_inputs):
-    """
-    A no-op experiment useful for making sure TorchBenchmark alone works properly.
-    """
-
-    return []
-
 def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dyamo_args: List[str]) -> argparse.Namespace:
+    import torchdynamo
     parser = argparse.ArgumentParser()
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("--nothing", action="store_true", help=help(null_experiment))
-    group.add_argument(
-        "--nops",
-        action="store_true",
-        help="Test that bytecode rewriting works properly.",
-    )
     parser.add_argument(
-        "--nopython", action="store_true", help="Turn graph breaks into errors"
+        "--torchdynamo", choices=torchdynamo.list_backends(), help="Specify torchdynamo backends"
     )
     args = parser.parse_args(dyamo_args)
     return args
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
     import torchdynamo
-    optimize_ctx = NullContext()
-    if args.nothing:
-        pass
-    elif args.nops:
-        optimize_ctx = torchdynamo.eval_frame._optimize_catch_errors(
-            torchdynamo.testing.debug_insert_nops, nopython=args.nopython
-        )
+    backend = args.torchdynamo
+    optimize_ctx = torchdynamo.optimize(backend)
     model.add_context(lambda: optimize_ctx)
     torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -11,6 +11,9 @@ class NullContext:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
+def help(fn):
+    return fn.__doc__
+
 def null_experiment(args, model_iter_fn, model, example_inputs):
     """
     A no-op experiment useful for making sure TorchBenchmark alone works properly.
@@ -23,15 +26,15 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ex
     args = parser.parse_args(extra_args)
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--nothing", action="store_true", help=help(null_experiment))
-    parser.add_argument(
-        "--nopython", action="store_true", help="Turn graph breaks into errors"
-    )
     group.add_argument(
         "--nops",
         action="store_true",
         help="Test that bytecode rewriting works properly.",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--nopython", action="store_true", help="Turn graph breaks into errors"
+    )
+    args = parser.parse_args(extra_args)
     return args
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -1,0 +1,75 @@
+"""
+Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
+"""
+import argparse
+from typing import List
+
+def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args(extra_args)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--coverage", action="store_true", help="(default) " + help(coverage_experiment)
+    )
+    group.add_argument(
+        "--online-autotune", action="store_true", help=help(speedup_experiment)
+    )
+    group.add_argument(
+        "--offline-autotune", action="store_true", help=help(speedup_experiment)
+    )
+    group.add_argument(
+        "--speedup-fixed1",
+        action="store_true",
+        help="speedup using experimental fixed_strategy backend",
+    )
+    group.add_argument(
+        "--speedup-fixed2",
+        action="store_true",
+        help="speedup using experimental fixed_strategy backend",
+    )
+    group.add_argument(
+        "--speedup-ltc",
+        action="store_true",
+        help="speedup using the ltc backend",
+    )
+    group.add_argument(
+        "--speedup-ltc-trivial",
+        action="store_true",
+        help="speedup using the ltc backend without reusing compiled graph",
+    )
+    group.add_argument(
+        "--overhead", action="store_true", help=help(overhead_experiment)
+    )
+    group.add_argument(
+        "--speedup-ts", action="store_true", help=help(speedup_experiment_ts)
+    )
+    group.add_argument(
+        "--speedup-sr", action="store_true", help=help(speedup_experiment_sr)
+    )
+    group.add_argument(
+        "--speedup-onnx", action="store_true", help=help(speedup_experiment_onnx)
+    )
+    group.add_argument(
+        "--speedup-trt", action="store_true", help=help(speedup_experiment_trt)
+    )
+    group.add_argument(
+        "--accuracy-aot-nop",
+        action="store_true",
+        help="Accuracy testing for AOT vs Eager",
+    )
+    group.add_argument(
+        "--speedup-aot-efficient-fusion",
+        action="store_true",
+        help="speedup using experimental fixed_strategy backend",
+    )
+    group.add_argument("--nothing", action="store_true", help=help(null_experiment))
+    group.add_argument(
+        "--nops",
+        action="store_true",
+        help="Test that bytecode rewriting works properly.",
+    )
+    args = parser.parse_args()
+    return args
+
+def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]):
+    pass

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -21,9 +21,8 @@ def null_experiment(args, model_iter_fn, model, example_inputs):
 
     return []
 
-def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> argparse.Namespace:
+def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dyamo_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    args = parser.parse_args(extra_args)
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--nothing", action="store_true", help=help(null_experiment))
     group.add_argument(
@@ -34,7 +33,7 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ex
     parser.add_argument(
         "--nopython", action="store_true", help="Turn graph breaks into errors"
     )
-    args = parser.parse_args(extra_args)
+    args = parser.parse_args(dyamo_args)
     return args
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -1,9 +1,8 @@
 import argparse
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from torchbenchmark.util.backends.fx2trt import enable_fx2trt
 from torchbenchmark.util.backends.jit import enable_jit
 from torchbenchmark.util.backends.torch_trt import enable_torchtrt
-from torchbenchmark.util.env_check import correctness_check
 
 def add_bool_arg(parser: argparse.ArgumentParser, name: str, default_value: bool=True):
     group = parser.add_mutually_exclusive_group(required=False)
@@ -38,23 +37,40 @@ def get_fp16_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
         return "half"
     return "no"
 
+def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fp16", choices=["no", "half", "amp"], default=get_fp16_default(model), help="enable fp16 modes from: no fp16, half, or amp")
+    dargs, opt_args = parser.parse_known_args(extra_args)
+    if not check_fp16(model, dargs.fp16):
+        raise NotImplementedError(f"fp16 value: {dargs.fp16}, fp16 (amp mode) is only supported by CUDA inference tests, "
+                                  f"fp16 (half mode) is only supported by torchvision CUDA inference tests.")
+    return (dargs, opt_args)
+
+def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dargs: argparse.Namespace):
+    if dargs.fp16 and not dargs.fp16 == "no":
+        if dargs.fp16 == "half":
+            assert hasattr(model, "enable_fp16_half"), "Model doesn't have method 'enable_fp16_half'. Please report a bug. "
+            model.enable_fp16_half()
+        elif dargs.fp16 == "amp":
+            # model can handle amp if it has 'enable_amp' callback function
+            if hasattr(model, "enable_amp"):
+                model.enable_amp()
+            else:
+                import torch
+                model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
+        else:
+            assert False, f"Get invalid fp16 value: {dargs.fp16}. Please report a bug."
+
 # Dispatch arguments based on model type
-def parse_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> argparse.Namespace:
+def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
     parser.add_argument("--fuser", type=str, default="", choices=["fuser0", "fuser1", "fuser2"], help="enable fuser")
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
-    parser.add_argument("--fp16", choices=["no", "half", "amp"], default=get_fp16_default(model), help="enable fp16 modes from: no fp16, half, or amp")
-    args = parser.parse_args(extra_args)
-    args.device = model.device
+    args = parser.parse_args(opt_args)
     args.jit = model.jit
-    args.test = model.test
-    args.batch_size = model.batch_size
-    if args.device == "cpu":
-        args.fuser = None
-    if not check_fp16(model, args.fp16):
-        raise NotImplementedError(f"fp16 value: {args.fp16}, fp16 (amp mode) is only supported by CUDA inference tests, "
-                                  f"fp16 (half mode) is only supported by torchvision CUDA inference tests.")
+    if model.device == "cpu" and args.fuser:
+        raise NotImplementedError("Fuser only works with GPU.")
     if not (model.device == "cuda" and model.test == "eval"):
         if args.fx2trt or args.torch_trt:
             raise NotImplementedError("TensorRT only works for CUDA inference tests.")
@@ -62,45 +78,20 @@ def parse_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: Li
         args.cudagraph = False
     return args
 
-def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
-    if args.fp16 and not args.fp16 == "no":
-        if args.test == "eval":
-            model.eager_output = model.invoke()
-        if args.fp16 == "half":
-            assert hasattr(model, "enable_fp16_half"), "Model doesn't have method 'enable_fp16_half'. Please report a bug. "
-            model.enable_fp16_half()
-        elif args.fp16 == "amp":
-            # check if the model has native amp support
-            if hasattr(model, "enable_amp"):
-                model.enable_amp()
-            else:
-                import torch
-                model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
-        else:
-            assert False, f"Get invalid fp16 value: {args.fp16}. Please report a bug."
-        if args.test == "eval":
-            model.output = model.invoke()
-            model.correctness = correctness_check(model.eager_output, model.output)
-            del model.eager_output
-            del model.output
+def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
     if args.fuser:
         import torch
         model.add_context(lambda: torch.jit.fuser(args.fuser))
     if args.jit:
-        if args.test == "eval":
+        if model.test == "eval":
             model.eager_output = model.invoke()
-        # model can handle jit code themselves through 'jit_callback' function
+        # model can handle jit code themselves through the 'jit_callback' callback function
         if hasattr(model, 'jit_callback'):
             model.jit_callback()
         else:
             # if model doesn't have customized jit code, use the default jit script code
             module, exmaple_inputs = model.get_module()
-            model.set_module(enable_jit(model=module, example_inputs=exmaple_inputs, test=args.test))
-        if args.test == "eval":
-            model.output = model.invoke()
-            model.correctness = correctness_check(model.eager_output, model.output)
-            del model.eager_output
-            del model.output
+            model.set_module(enable_jit(model=module, example_inputs=exmaple_inputs, test=model.test))
     if args.fx2trt:
         model.eager_output = model.invoke()
         if args.jit:
@@ -108,19 +99,11 @@ def apply_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse
         module, exmaple_inputs = model.get_module()
         # get the output tensor of eval
         model.eager_output = model.eval()
-        fp16 = not (args.fp16 == "no")
-        model.set_module(enable_fx2trt(args.batch_size, fp16=fp16, model=module, example_inputs=exmaple_inputs,
+        fp16 = not (model.dargs.fp16 == "no")
+        model.set_module(enable_fx2trt(model.batch_size, fp16=fp16, model=module, example_inputs=exmaple_inputs,
                                        is_hf_model=is_hf_model(model), hf_max_length=get_hf_maxlength(model)))
-        model.output = model.eval()
-        model.correctness = correctness_check(model.eager_output, model.output)
-        del model.eager_output
-        del model.output
     if args.torch_trt:
         model.eager_output = model.invoke()
         module, exmaple_inputs = model.get_module()
-        precision = 'fp16' if not args.fp16 == "no" else 'fp32'
+        precision = 'fp16' if not model.dargs.fp16 == "no" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))
-        model.output = model.invoke()
-        model.correctness = correctness_check(model.eager_output, model.output)
-        del model.eager_output
-        del model.output

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -4,6 +4,14 @@ from torchbenchmark.util.backends.fx2trt import enable_fx2trt
 from torchbenchmark.util.backends.jit import enable_jit
 from torchbenchmark.util.backends.torch_trt import enable_torchtrt
 
+def enable_opt_args(opt_args: argparse.Namespace) -> bool:
+    "Check if any of the optimizations is enabled."
+    opt_args_dict = vars(opt_args)
+    for k in opt_args_dict:
+        if opt_args_dict[k]:
+            return True
+    return False
+
 def add_bool_arg(parser: argparse.ArgumentParser, name: str, default_value: bool=True):
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('--' + name, dest=name, action='store_true')

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -55,7 +55,7 @@ class TorchVisionModel(BenchmarkModel):
         for _ in range(niter):
             self.optimizer.zero_grad()
             for data, target in zip(real_input, real_output):
-                if self.extra_args.cudagraph:
+                if not self.dynamo and self.extra_args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)
                     self.g.replay()
@@ -65,7 +65,7 @@ class TorchVisionModel(BenchmarkModel):
                     self.optimizer.step()
 
     def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
-        if self.extra_args.cudagraph:
+        if not self.dynamo and self.extra_args.cudagraph:
             return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.model
         example_inputs = self.example_inputs

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -55,7 +55,7 @@ class TorchVisionModel(BenchmarkModel):
         for _ in range(niter):
             self.optimizer.zero_grad()
             for data, target in zip(real_input, real_output):
-                if not self.dynamo and self.extra_args.cudagraph:
+                if not self.dynamo and self.opt_args.cudagraph:
                     self.example_inputs[0].copy_(data)
                     self.example_outputs.copy_(target)
                     self.g.replay()
@@ -65,7 +65,7 @@ class TorchVisionModel(BenchmarkModel):
                     self.optimizer.step()
 
     def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
-        if not self.dynamo and self.extra_args.cudagraph:
+        if not self.dynamo and self.opt_args.cudagraph:
             return NotImplementedError("CUDA Graph is not yet implemented for inference.")
         model = self.model
         example_inputs = self.example_inputs

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -81,7 +81,6 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         # if the args contain "--torchdynamo", parse torchdynamo args instead
         if "--torchdynamo" in self.extra_args:
             self.extra_args.remove("--torchdynamo")
-            print(self.extra_args)
             self.extra_args = parse_torchdynamo_args(self, self.extra_args)
             apply_torchdynamo_args(self, self.extra_args)
         else:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -85,6 +85,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.extra_args = parse_torchdynamo_args(self, self.extra_args)
             apply_torchdynamo_args(self, self.extra_args)
         else:
+            self.dynamo = False
             self.extra_args = parse_args(self, self.extra_args)
             apply_args(self, self.extra_args)
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -82,7 +82,6 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         # if the args contain "--torchdynamo", parse torchdynamo args
         if "--torchdynamo" in opt_args:
             self.dynamo = True
-            opt_args.remove("--torchdynamo")
             self.opt_args = parse_torchdynamo_args(self, opt_args)
         else:
             self.dynamo = False

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -87,7 +87,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.dynamo = False
             self.opt_args = parse_opt_args(self, opt_args)
         # if test is eval and opt_args is not empty, check correctness
-        if self.test == "eval" and vars(self.opt_args):
+        if self.device == "cuda" and self.test == "eval" and vars(self.opt_args):
             self.eager_output = self.invoke()
         # apply decoration and optimization args
         apply_decoration_args(self, self.dargs)
@@ -96,7 +96,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             apply_opt_args(self, self.opt_args)
         # if test is eval, check correctness
-        if self.test == "eval" and vars(self.opt_args):
+        if self.device == "cuda" and self.test == "eval" and vars(self.opt_args):
             self.output = self.invoke()
             self.correctness = correctness_check(self.eager_output, self.output)
             del self.eager_output

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -80,6 +80,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
         # if the args contain "--torchdynamo", parse torchdynamo args instead
         if "--torchdynamo" in self.extra_args:
+            self.dynamo = True
             self.extra_args.remove("--torchdynamo")
             self.extra_args = parse_torchdynamo_args(self, self.extra_args)
             apply_torchdynamo_args(self, self.extra_args)

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -81,6 +81,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         # if the args contain "--torchdynamo", parse torchdynamo args instead
         if "--torchdynamo" in self.extra_args:
             self.extra_args.remove("--torchdynamo")
+            print(self.extra_args)
             self.extra_args = parse_torchdynamo_args(self, self.extra_args)
             apply_torchdynamo_args(self, self.extra_args)
         else:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -78,7 +78,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
     def __post__init__(self):
         # sanity checks of the options
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
-        self.dargs, opt_args = parse_decoration_args(self.extra_args)
+        self.dargs, opt_args = parse_decoration_args(self, self.extra_args)
         # if the args contain "--torchdynamo", parse torchdynamo args
         if "--torchdynamo" in opt_args:
             self.dynamo = True

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -86,8 +86,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             self.dynamo = False
             self.opt_args = parse_opt_args(self, opt_args)
-        # if test is eval, check correctness
-        if self.test == "eval":
+        # if test is eval and opt_args is not empty, check correctness
+        if self.test == "eval" and vars(self.opt_args):
             self.eager_output = self.invoke()
         # apply decoration and optimization args
         apply_decoration_args(self, self.dargs)
@@ -96,7 +96,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             apply_opt_args(self, self.opt_args)
         # if test is eval, check correctness
-        if self.test == "eval":
+        if self.test == "eval" and vars(self.opt_args):
             self.output = self.invoke()
             self.correctness = correctness_check(self.eager_output, self.output)
             del self.eager_output

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -80,6 +80,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
         # if the args contain "--torchdynamo", parse torchdynamo args instead
         if "--torchdynamo" in self.extra_args:
+            self.extra_args.remove("--torchdynamo")
             self.extra_args = parse_torchdynamo_args(self, self.extra_args)
             apply_torchdynamo_args(self, self.extra_args)
         else:


### PR DESCRIPTION
Add torchdynamo support to TorchBench. Use `torchdynamo.list_backends()` to list available backends and apply them.

Test Plan:
```
$ python run.py resnet18 -d cuda -t eval --torchdynamo ofi
Running eval method from resnet18 on cuda in eager mode.
jit error
Traceback (most recent call last):
  File "/home/xzhao9/torchdynamo/torchdynamo/utils.py", line 192, in torchscript
    return torch.jit.trace(model, example_inputs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/jit/_trace.py", line 741, in trace
    return trace_module(
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/jit/_trace.py", line 956, in trace_module
    example_inputs = make_tuple(example_inputs)
  File "/home/xzhao9/data/miniconda3/envs/py38/lib/python3.8/site-packages/torch/jit/_trace.py", line 549, in make_tuple
    return tuple(example_inputs)
TypeError: 'NoneType' object is not iterable
GPU Time:              6.079 milliseconds
CPU Dispatch Time:     3.310 milliseconds
CPU Total Wall Time:   6.104 milliseconds
Correctness:            0.999988675117493
```

```
$ python run.py resnet18 -d cuda -t eval --torchdynamo eager
Running eval method from resnet18 on cuda in eager mode.
GPU Time:              6.668 milliseconds
CPU Dispatch Time:     6.023 milliseconds
CPU Total Wall Time:   6.693 milliseconds
Correctness:            0.999996900558472
```