### PR TITLE
Improve the microbenchmark framework

### DIFF
--- a/run_microbenchmarks.py
+++ b/run_microbenchmarks.py
@@ -15,10 +15,10 @@ def run():
     args, bm_args = parser.parse_known_args()
 
     try:
-        microbenchmark = importlib.import_module(f"torchbenchmark.microbenchmarks.{args}")
+        microbenchmark = importlib.import_module(f"torchbenchmark.microbenchmarks.{args.bm_name}")
+        microbenchmark.run(bm_args)
     except ImportError as e:
         print(f"Failed to import microbenchmark module {args.bm_name}, error: {str(e)}")
-    microbenchmark.run(bm_args)
 
 if __name__ == "__main__":
     run()

--- a/run_microbenchmarks.py
+++ b/run_microbenchmarks.py
@@ -1,21 +1,24 @@
+import os
 import argparse
 import importlib
 from typing import List
-from torchbenchmark.microbenchmarks.nvfuser import run_nvfuser_microbenchmarks
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+MICROBENCHMARKS_DIR = os.path.join(CURRENT_DIR, "torchbenchmark", "microbenchmarks")
 
 def list_microbenchmarks() -> List[str]:
-    pass
+    return os.listdir(MICROBENCHMARKS_DIR)
 
 def run():
     parser = argparse.ArgumentParser(description="Run TorchBench microbenchmarks")
-    parser.add_argument("bm_name", help='name of the microbenchmark')
-    parser.add_argument("--filter", nargs="*", default=[], help='List of benchmarks to test')
-    args, extra_args = parser.parse_known_args()
-    args = parser.parse_args()
+    parser.add_argument("bm_name", choices=list_microbenchmarks(), help='name of the microbenchmark')
+    args, bm_args = parser.parse_known_args()
 
-    microbenchmark = importlib.import_module(f"torchbenchmark.microbenchmarks.{args}")
-    run_nvfuser_microbenchmarks(args.filter, extra_args)
-
+    try:
+        microbenchmark = importlib.import_module(f"torchbenchmark.microbenchmarks.{args}")
+    except ImportError as e:
+        print(f"Failed to import microbenchmark module {args.bm_name}, error: {str(e)}")
+    microbenchmark.run(bm_args)
 
 if __name__ == "__main__":
     run()

--- a/run_microbenchmarks.py
+++ b/run_microbenchmarks.py
@@ -1,13 +1,19 @@
 import argparse
+import importlib
+from typing import List
 from torchbenchmark.microbenchmarks.nvfuser import run_nvfuser_microbenchmarks
 
+def list_microbenchmarks() -> List[str]:
+    pass
 
 def run():
-    parser = argparse.ArgumentParser(description="Run nvfuser microbenchmarks")
+    parser = argparse.ArgumentParser(description="Run TorchBench microbenchmarks")
+    parser.add_argument("bm_name", help='name of the microbenchmark')
     parser.add_argument("--filter", nargs="*", default=[], help='List of benchmarks to test')
     args, extra_args = parser.parse_known_args()
     args = parser.parse_args()
 
+    microbenchmark = importlib.import_module(f"torchbenchmark.microbenchmarks.{args}")
     run_nvfuser_microbenchmarks(args.filter, extra_args)
 
 

--- a/torchbenchmark/microbenchmarks/nvfuser/__init__.py
+++ b/torchbenchmark/microbenchmarks/nvfuser/__init__.py
@@ -105,8 +105,9 @@ def parse_fusers(extra_args: List[str]):
         default=[],
         choices=["no_fuser", "fuser0", "fuser1", "fuser2"],
         help="List of fusers to run tests on")
+    parser.add_argument("--filter", nargs="*", default=[], help='List of fuser microbenchmarks to test')
     args = parser.parse_args(extra_args)
-    return args.fusers
+    return args
 
 
 class NVFuserBenchmark():
@@ -131,10 +132,10 @@ class NVFuserBenchmark():
 def run_nvfuser_microbenchmarks(filters: List[str], extra_args: List[str]):
     from torchbenchmark.microbenchmarks.nvfuser.ir import ir_list
     benchmarks = [NVFuserBenchmark(name, ir) for name, ir in ir_list]
+    args = parse_fusers(extra_args)
+    filters, fusers = args.filters, args.fusers
     if len(filters) > 0:
         benchmarks = [x for x in benchmarks if x.name in filters]
-
-    fusers = parse_fusers(extra_args)
     if len(fusers) == 0:
         fusers = ["no_fuser", "fuser1", "fuser2"]
 
@@ -144,3 +145,6 @@ def run_nvfuser_microbenchmarks(filters: List[str], extra_args: List[str]):
             inputs = b.get_inputs()
             outputs.append((fuser, b.run_test(inputs, fuser)))
         print(f"{b.name}:", "; ".join(f"{name} = {time:.3f} ms" for name, time in outputs))
+
+def run(args: List[str]):
+    run_nvfuser_microbenchmarks(extra_args=args)

--- a/torchbenchmark/microbenchmarks/nvfuser/__init__.py
+++ b/torchbenchmark/microbenchmarks/nvfuser/__init__.py
@@ -105,7 +105,7 @@ def parse_fusers(extra_args: List[str]):
         default=[],
         choices=["no_fuser", "fuser0", "fuser1", "fuser2"],
         help="List of fusers to run tests on")
-    parser.add_argument("--filter", nargs="*", default=[], help='List of fuser microbenchmarks to test')
+    parser.add_argument("--filters", nargs="*", default=[], help='List of fuser microbenchmarks to test')
     args = parser.parse_args(extra_args)
     return args
 
@@ -129,7 +129,7 @@ class NVFuserBenchmark():
         return inputs
 
 
-def run_nvfuser_microbenchmarks(filters: List[str], extra_args: List[str]):
+def run_nvfuser_microbenchmarks(extra_args: List[str]):
     from torchbenchmark.microbenchmarks.nvfuser.ir import ir_list
     benchmarks = [NVFuserBenchmark(name, ir) for name, ir in ir_list]
     args = parse_fusers(extra_args)


### PR DESCRIPTION
This PR reorganizes the nvfuser microbenchmark code to make it easier to add more microbenchmarks.
It moves the `--filters` argument to `nvfuser/__init__.py` since it is benchmark-specific.
It defines a single function, `run(extra_args: List[str])` as the interface.