### PR TITLE
Don't load empty directory in unit tests

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -76,8 +76,12 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
 
 
 def _list_model_paths() -> List[str]:
+    def dir_contains_file(dir, file_name) -> bool:
+        names = map(lambda x: x.name, filter(lambda x: x.is_file(), dir.iterdir()))
+        return file_name in names
     p = pathlib.Path(__file__).parent.joinpath(model_dir)
-    return sorted(str(child.absolute()) for child in p.iterdir() if child.is_dir())
+    # Only load the model directories that contain a "__init.py__" file
+    return sorted(str(child.absolute()) for child in p.iterdir() if child.is_dir() and dir_contains_file(child, "__init__.py"))
 
 
 def setup(models: List[str] = [], verbose: bool = True, continue_on_fail: bool = False) -> bool:


### PR DESCRIPTION
In development, sometimes there will be empty directories left in the `models` directory (usually caused by branch switching). Only load the model directories that have a `__init__.py` file, which means it is not empty.