### PR TITLE
Fix GPU memory leak introduced by correctness checking

### DIFF
--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -103,6 +103,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.correctness = correctness_check(self.eager_output, self.output)
             del self.eager_output
             del self.output
+            torch.cuda.empty_cache()
 
     def add_context(self, context_fn):
         ctx = context_fn()


### PR DESCRIPTION
After calling `del`, we need to explicitly call `torch.cuda.empty_cache()` to free up the GPU memory used.