### PR TITLE
Add FAMBench xlmr model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,3 @@
-[submodule "third_party/benchmark"]
-	path = legacy/third_party/benchmark
-	url = https://github.com/google/benchmark
-[submodule "setup/third_party/pytorch-dockerfiles"]
-	path = setup/third_party/pytorch-dockerfiles
-	url = https://github.com/pietern/pytorch-dockerfiles
-[submodule "python/third_party_benchmarks/PyTorch-benchmark"]
-	path = python/third_party_benchmarks/PyTorch-benchmark
-	url = https://github.com/MlWoo/PyTorch-benchmark
-[submodule "third_party/eigen"]
-	path = legacy/third_party/eigen
-	url = https://github.com/eigenteam/eigen-git-mirror
-[submodule "third_party/sleef"]
-	path = legacy/third_party/sleef
-	url = https://github.com/shibatch/sleef
-[submodule "third_party/tbb"]
-	path = legacy/third_party/tbb
-	url = https://github.com/01org/tbb
 [submodule "submodules/FAMBench"]
 	path = submodules/FAMBench
 	url = https://github.com/facebookresearch/FAMBench.git

--- a/install.py
+++ b/install.py
@@ -51,7 +51,7 @@ def pip_install_requirements():
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("models", nargs='+', default=[],
+    parser.add_argument("models", nargs='*', default=[],
                         help="Specify one or more models to install. If not set, install all models.")
     parser.add_argument("--continue_on_fail", action="store_true")
     parser.add_argument("--verbose", "-v", action="store_true")

--- a/install.py
+++ b/install.py
@@ -51,9 +51,9 @@ def pip_install_requirements():
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--continue_on_fail", action="store_true")
-    parser.add_argument("--models", nargs='+', default=[],
+    parser.add_argument("models", nargs='+', default=[],
                         help="Specify one or more models to install. If not set, install all models.")
+    parser.add_argument("--continue_on_fail", action="store_true")
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 

--- a/test.py
+++ b/test.py
@@ -75,7 +75,6 @@ def _load_test(path, device):
         with task.watch_cuda_memory(skip=(device != "cuda"), assert_equal=self.assertEqual):
             try:
                 task.make_model_instance(test="train", device=device, jit=False)
-                task.set_train()
                 task.invoke()
                 task.check_details_train(device=device, md=metadata)
                 task.del_model_instance()
@@ -88,8 +87,6 @@ def _load_test(path, device):
         with task.watch_cuda_memory(skip=(device != "cuda"), assert_equal=self.assertEqual):
             try:
                 task.make_model_instance(test="eval", device=device, jit=False)
-
-                task.set_eval()
                 task.invoke()
                 task.check_details_eval(device=device, md=metadata)
                 task.check_eval_output()

--- a/test_bench.py
+++ b/test_bench.py
@@ -56,7 +56,6 @@ class TestBenchNetwork:
                 return  # Model is not supported.
 
             task.make_model_instance(test="train", device=device, jit=(compiler == 'jit'))
-            task.set_train()
             benchmark(task.invoke)
             benchmark.extra_info['machine_state'] = get_machine_state()
 
@@ -75,7 +74,6 @@ class TestBenchNetwork:
             task.make_model_instance(test="eval", device=device, jit=(compiler == 'jit'))
 
             with task.no_grad(disable_nograd=pytestconfig.getoption("disable_nograd")):
-                task.set_eval()
                 benchmark(task.invoke)
                 benchmark.extra_info['machine_state'] = get_machine_state()
                 if pytestconfig.getoption("check_opt_vs_noopt_jit"):

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -9,12 +9,14 @@ import subprocess
 import sys
 import tempfile
 import threading
+from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple
 from urllib import request
 
 from components._impl.tasks import base as base_task
 from components._impl.workers import subprocess_worker
 
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
 TORCH_DEPS = ['torch', 'torchvision', 'torchtext']
 proxy_suggestion = "Unable to verify https connectivity, " \
                    "required for setup.\n" \

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -134,11 +134,6 @@ class Model(BenchmarkModel):
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
             return self.netG, (image.to(self.device), bg.to(self.device), seg.to(self.device), multi_fr.to(self.device))
 
-    # eval() isn't implemented
-    # train() is on by default
-    def _set_mode(self, train):
-        pass
-
     def train(self, niter=1):
         self.netG.train()
         self.netD.train()

--- a/torchbenchmark/models/LearningToPaint/__init__.py
+++ b/torchbenchmark/models/LearningToPaint/__init__.py
@@ -105,9 +105,3 @@ class Model(BenchmarkModel):
         for _ in range(niter):
             reward, dist = self.evaluate(self.env, self.agent.select_action)
         return (torch.tensor(reward), torch.tensor(dist))
-
-    def _set_mode(self, train):
-        if train:
-            self.agent.train()
-        else:
-            self.agent.eval()

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -27,6 +27,7 @@ import torch.nn.functional as F
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
+    FAMBENCH_MODEL = True
     # original parameters: FAMBench/benchmarks/run_xlmr_ootb.sh
     DEFAULT_TRAIN_BSIZE = 16
     DEFAULT_EVAL_BSIZE = 16
@@ -58,7 +59,12 @@ class Model(BenchmarkModel):
         self.y_true_l = list(map(lambda x: x.to(self.device), self.y_true_l))
 
     def get_module(self):
-        return self.xlmr, (self.x_l[0], )
+        return self.xlmr.extract_features, self.x_l
+
+    def enable_fp16_half(self):
+        self.xmlr = self.xlmr.half()
+        self.x_l = list(map(lambda x: x.half(), self.x_l))
+        self.y_true_l = list(map(lambda x: x.half(), self.y_true_l))
 
     def train(self):
         for i, (x, y_true) in enumerate(zip(self.x_l, self.y_true_l)):

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -1,0 +1,74 @@
+import torch
+import sys
+import os
+from torchbenchmark import REPO_PATH
+
+# Import FAMBench model path
+class add_path():
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        sys.path.insert(0, self.path)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            sys.path.remove(self.path)
+        except ValueError:
+            pass
+XLMR_PATH = os.path.join(REPO_PATH, "submodules", "FAMBench", "benchmarks", "xlmr", "ootb")
+with add_path(XLMR_PATH):
+    from xlmr import generate_dataset
+    from xlmr_parser import init_argparse
+
+from torchbenchmark.util.model import BenchmarkModel
+from torchbenchmark.tasks import NLP
+import torch.nn.functional as F
+
+class Model(BenchmarkModel):
+    task = NLP.LANGUAGE_MODELING
+    # original parameters: FAMBench/benchmarks/run_xlmr_ootb.sh
+    DEFAULT_TRAIN_BSIZE = 16
+    DEFAULT_EVAL_BSIZE = 16
+    DEFAULT_SEQ_LENGTH = 16
+    DEFAULT_VOCAB_SIZE = 250000
+    # TorchBench only runs 1 batch
+    DEFAULT_NUM_BATCHES = 1
+
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+        self.xlmr = torch.hub.load('pytorch/fairseq:main', 'xlmr.large')
+        parser = init_argparse()
+        args = parser.parse_args([f"--num-batches={self.DEFAULT_NUM_BATCHES}", f"--batch-size={self.batch_size} ", \
+                                 f"--sequence-length={self.DEFAULT_SEQ_LENGTH}", f"--vocab-size={self.DEFAULT_VOCAB_SIZE}"])
+        if test == "train":
+            self.learning_rate = 0.01
+            self.optimizer = torch.optim.SGD(self.xlmr.parameters(), lr=self.learning_rate)
+            self.xlmr.train()
+            args.inference_only = False
+        elif test == "eval":
+            self.xlmr.eval()
+            args.inference_only = True
+        # Generate data! y is empty if inference_only.
+        self.x_l, self.y_true_l = generate_dataset(args.num_batches, args.batch_size,
+            args.vocab_size, args.inference_only, uniform_seqlen=args.sequence_length,
+            seqlen_dist=args.seqlen_dist, seq_len_dist_max=args.seqlen_dist_max)
+        # Prefetch the data to device
+        self.x_l = list(map(lambda x: x.to(self.device), self.x_l))
+        self.y_true_l = list(map(lambda x: x.to(self.device), self.y_true_l))
+
+    def get_module(self):
+        return self.xlmr, (self.x_l[0], )
+
+    def train(self):
+        for i, (x, y_true) in enumerate(zip(self.x_l, self.y_true_l)):
+            y_pred = self.xlmr.extract_features(x)
+            loss = F.cross_entropy(y_pred, y_true) 
+            loss.backward()
+            self.optimizer.step()
+            self.optimizer.zero_grad() 
+
+    def eval(self):
+        with torch.no_grad():
+            for i, x in enumerate(self.x_l):
+                y_pred = self.xlmr.extract_features(x) 

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -64,8 +64,6 @@ class Model(BenchmarkModel):
 
     def enable_fp16_half(self):
         self.xmlr = self.xlmr.half()
-        self.x_l = list(map(lambda x: x.half(), self.x_l))
-        self.y_true_l = list(map(lambda x: x.half(), self.y_true_l))
 
     def train(self):
         for i, (x, y_true) in enumerate(zip(self.x_l, self.y_true_l)):

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -75,7 +75,9 @@ class Model(BenchmarkModel):
             self.optimizer.zero_grad() 
 
     def eval(self) -> Tuple[torch.Tensor]:
+        result = None
         with torch.no_grad():
             for i, x in enumerate(self.x_l):
                 y_pred = self.xlmr.extract_features(x)
-                return (y_pred, )
+                result = y_pred
+        return (result, )

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -2,6 +2,7 @@ import torch
 import sys
 import os
 from torchbenchmark import REPO_PATH
+from typing import Tuple
 
 # Import FAMBench model path
 class add_path():
@@ -60,7 +61,7 @@ class Model(BenchmarkModel):
         self.y_true_l = list(map(lambda x: x.to(self.device), self.y_true_l))
 
     def get_module(self):
-        return self.xlmr.extract_features, self.x_l
+        return self.xlmr, self.x_l
 
     def enable_fp16_half(self):
         self.xmlr = self.xlmr.half()
@@ -73,7 +74,8 @@ class Model(BenchmarkModel):
             self.optimizer.step()
             self.optimizer.zero_grad() 
 
-    def eval(self):
+    def eval(self) -> Tuple[torch.Tensor]:
         with torch.no_grad():
             for i, x in enumerate(self.x_l):
-                y_pred = self.xlmr.extract_features(x) 
+                y_pred = self.xlmr.extract_features(x)
+                return (y_pred, )

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -40,6 +40,8 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 96
     DEFAULT_SEQ_LENGTH = 64
     DEFAULT_VOCAB_SIZE = 250000
+    # by default, use fp16 half precision for training
+    DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -54,7 +54,8 @@ class Model(BenchmarkModel):
         self.x_l, self.y_true_l = generate_dataset(args.num_batches, args.batch_size,
             args.vocab_size, args.inference_only, uniform_seqlen=args.sequence_length,
             seqlen_dist=args.seqlen_dist, seq_len_dist_max=args.seqlen_dist_max)
-        # Prefetch the data to device
+        # Prefetch the model and data to device
+        self.xlmr = self.xlmr.to(self.device)
         self.x_l = list(map(lambda x: x.to(self.device), self.x_l))
         self.y_true_l = list(map(lambda x: x.to(self.device), self.y_true_l))
 

--- a/torchbenchmark/models/fambench_xlmr/install.py
+++ b/torchbenchmark/models/fambench_xlmr/install.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import torch
 import subprocess
 from torchbenchmark import REPO_PATH
 
@@ -12,6 +13,10 @@ def update_fambench_submodule():
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
 
+def download_model():
+    torch.hub.load('pytorch/fairseq:main', 'xlmr.large')
+
 if __name__ == "__main__":
     update_fambench_submodule()
     pip_install_requirements()
+    download_model()

--- a/torchbenchmark/models/fambench_xlmr/install.py
+++ b/torchbenchmark/models/fambench_xlmr/install.py
@@ -1,0 +1,12 @@
+import os
+import subprocess
+from torchbenchmark import REPO_PATH
+
+def update_fambench_submodule():
+    "Update FAMBench submodule of the benchmark repo"
+    update_command = ["git", "submodule", "update", 
+                      "--init", "--recursive", os.path.join("submodules","FAMBench")]
+    subprocess.check_call(update_command, cwd=REPO_PATH)
+
+if __name__ == "__main__":
+    update_fambench_submodule()

--- a/torchbenchmark/models/fambench_xlmr/install.py
+++ b/torchbenchmark/models/fambench_xlmr/install.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 from torchbenchmark import REPO_PATH
 
@@ -8,5 +9,9 @@ def update_fambench_submodule():
                       "--init", "--recursive", os.path.join("submodules","FAMBench")]
     subprocess.check_call(update_command, cwd=REPO_PATH)
 
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
 if __name__ == "__main__":
     update_fambench_submodule()
+    pip_install_requirements()

--- a/torchbenchmark/models/fambench_xlmr/metadata.yaml
+++ b/torchbenchmark/models/fambench_xlmr/metadata.yaml
@@ -1,0 +1,6 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+optimized_for_inference: false
+train_benchmark: false
+train_deterministic: false

--- a/torchbenchmark/models/fambench_xlmr/requirements.txt
+++ b/torchbenchmark/models/fambench_xlmr/requirements.txt
@@ -2,3 +2,4 @@ sacrebleu
 bitarray
 omegaconf
 hydra-core
+sentencepiece

--- a/torchbenchmark/models/fambench_xlmr/requirements.txt
+++ b/torchbenchmark/models/fambench_xlmr/requirements.txt
@@ -1,0 +1,4 @@
+sacrebleu
+bitarray
+omegaconf
+hydra-core

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -27,6 +27,9 @@ def is_torchvision_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> b
 def is_hf_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
     return hasattr(model, 'HF_MODEL') and model.HF_MODEL
 
+def is_fambench_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
+    return hasattr(model, 'FAMBENCH_MODEL') and model.FAMBENCH_MODEL
+
 def get_hf_maxlength(model: 'torchbenchmark.util.model.BenchmarkModel') -> Optional[int]:
     return model.max_length if is_hf_model(model) else None
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -132,6 +132,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 out = self.eval()
         return out
 
+    def eval_in_nograd(self):
+        return True
+
     def check_opt_vs_noopt_jit(self):
         if not self.jit:
             return

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -132,19 +132,6 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 out = self.eval()
         return out
 
-    def set_eval(self):
-        self._set_mode(False)
-
-    def set_train(self):
-        self._set_mode(True)
-
-    def eval_in_nograd(self):
-        return True
-
-    def _set_mode(self, train):
-        (model, _) = self.get_module()
-        model.train(train)
-
     def check_opt_vs_noopt_jit(self):
         if not self.jit:
             return


### PR DESCRIPTION
This PR adds the xlmr model from [FAMBench](https://github.com/facebookresearch/FAMBench/blob/main/benchmarks/xlmr/ootb/xlmr.py) to the TorchBench suite.
It uses the same configuration as the original model, but runs only 1 batch.
