### PR TITLE
Cache the huggingface model at install stage

### DIFF
--- a/torchbenchmark/models/hf_Albert/install.py
+++ b/torchbenchmark/models/hf_Albert/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_Bart/install.py
+++ b/torchbenchmark/models/hf_Bart/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_Bert/install.py
+++ b/torchbenchmark/models/hf_Bert/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_BigBird/install.py
+++ b/torchbenchmark/models/hf_BigBird/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_DistilBert/install.py
+++ b/torchbenchmark/models/hf_DistilBert/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_GPT2/install.py
+++ b/torchbenchmark/models/hf_GPT2/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_Longformer/install.py
+++ b/torchbenchmark/models/hf_Longformer/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_Reformer/install.py
+++ b/torchbenchmark/models/hf_Reformer/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_T5/install.py
+++ b/torchbenchmark/models/hf_T5/install.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import sys
-from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
@@ -9,3 +10,5 @@ def pip_install_requirements():
 if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/util/framework/huggingface/patch_hf.py
+++ b/torchbenchmark/util/framework/huggingface/patch_hf.py
@@ -4,8 +4,16 @@ Patch the transformer source code to enable optimizations.
 import os
 import subprocess
 import sys
+from .model_factory import class_models
+from transformers import AutoConfig, ReformerConfig, BigBirdConfig, BertConfig
 
 PATCH_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "patches")
+
+def cache_model(name: str):
+    import transformers
+    model_config = eval(class_models[name][2])
+    model_ctor = getattr(transformers, class_models[name][3])
+    model_ctor.from_config(model_config)
 
 def patch_transformers():
     import transformers


### PR DESCRIPTION
Make sure we download and cache the huggingface models at installation stage.

Fixes https://github.com/pytorch/benchmark/issues/820