### PR TITLE
Improve the `run_sweep.py` script to support precision attribute

### DIFF
--- a/run_sweep.py
+++ b/run_sweep.py
@@ -97,7 +97,7 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         # Check the batch size in the model matches the specified value
         result.batch_size = task.get_model_attribute(bs_name)
-        result.precision = task.get_model_attribute("dargs").fp16
+        result.precision = task.get_model_attribute("dargs", "fp16")
         if batch_size and (not result.batch_size == batch_size):
             raise ValueError(f"User specify batch size {batch_size}, but model {result.name} runs with batch size {result.batch_size}. Please report a bug.")
         result.results["latency_ms"] = run_one_step(task.invoke, device)

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -52,6 +52,7 @@ class ModelTestResult:
     extra_args: List[str]
     status: str
     batch_size: Optional[int]
+    precision: str
     results: Dict[str, Any]
 
 def _list_model_paths(models: List[str]) -> List[str]:
@@ -80,7 +81,7 @@ def _validate_devices(devices: str) -> List[str]:
 
 def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool, batch_size: Optional[int], extra_args: List[str]) -> ModelTestResult:
     assert test == "train" or test == "eval", f"Test must be either 'train' or 'eval', but get {test}."
-    result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None,
+    result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None, precision="no",
                              status="OK", results={})
     # Run the benchmark test in a separate process
     print(f"Running model {model_path.name} ... ", end='', flush=True)
@@ -96,6 +97,7 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         # Check the batch size in the model matches the specified value
         result.batch_size = task.get_model_attribute(bs_name)
+        result.precision = task.get_model_attribute("dargs").fp16
         if batch_size and (not result.batch_size == batch_size):
             raise ValueError(f"User specify batch size {batch_size}, but model {result.name} runs with batch size {result.batch_size}. Please report a bug.")
         result.results["latency_ms"] = run_one_step(task.invoke, device)

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -81,7 +81,7 @@ def _validate_devices(devices: str) -> List[str]:
 
 def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool, batch_size: Optional[int], extra_args: List[str]) -> ModelTestResult:
     assert test == "train" or test == "eval", f"Test must be either 'train' or 'eval', but get {test}."
-    result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None, precision="no",
+    result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None, precision="fp32",
                              status="OK", results={})
     # Run the benchmark test in a separate process
     print(f"Running model {model_path.name} ... ", end='', flush=True)

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -97,7 +97,7 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         # Check the batch size in the model matches the specified value
         result.batch_size = task.get_model_attribute(bs_name)
-        result.precision = task.get_model_attribute("dargs", "fp16")
+        result.precision = task.get_model_attribute("dargs", "precision")
         if batch_size and (not result.batch_size == batch_size):
             raise ValueError(f"User specify batch size {batch_size}, but model {result.name} runs with batch size {result.batch_size}. Please report a bug.")
         result.results["latency_ms"] = run_one_step(task.invoke, device)

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -286,10 +286,14 @@ class ModelTask(base_task.TaskBase):
     # =========================================================================
     @base_task.run_in_worker(scoped=True)
     @staticmethod
-    def get_model_attribute(attr: str) -> Any:
+    def get_model_attribute(attr: str, field: str=None) -> Any:
         model = globals()["model"]
         if hasattr(model, attr):
-            return getattr(model, attr)
+            if field:
+                model_attr = getattr(model, attr)
+                return getattr(model_attr, field)
+            else:
+                return getattr(model, attr)
         else:
             return None
 

--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -23,6 +23,8 @@ class Model(BenchmarkModel):
     task = COMPUTER_VISION.SEGMENTATION
     DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
+    DEFAULT_TRAIN_CUDA_PRECISION = "amp"
+    DEFAULT_EVAL_CUDA_PRECISION = "amp"
 
     def __init__(self, test, device, batch_size=None, jit=False, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -16,6 +16,8 @@ class Model(BenchmarkModel):
     # Source: https://github.com/NVIDIA/tacotron2/blob/bb6761349354ee914909a42208e4820929612069/hparams.py#L84
     DEFAULT_TRAIN_BSIZE = 64
     DEFAULT_EVAL_BSIZE = 64
+    # Tacotron2 CUDA inference test uses amp precision
+    DEFAULT_EVAL_CUDA_PRECISION = "amp"
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -31,6 +31,8 @@ class Model(BenchmarkModel):
     # Source: https://github.com/ultralytics/yolov3/blob/master/train.py#L447
     DEFAULT_TRAIN_BSIZE = 16
     DEFAULT_EVAL_BSIZE = 16
+    # yolov3 CUDA inference test uses amp precision
+    DEFAULT_EVAL_CUDA_PRECISION = "amp"
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -103,5 +103,5 @@ def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argp
                                        is_hf_model=is_hf_model(model), hf_max_length=get_hf_maxlength(model)))
     if args.torch_trt:
         module, exmaple_inputs = model.get_module()
-        precision = 'fp16' if not model.dargs.precision == "fp16" else 'fp32'
+        precision = 'fp16' if not model.dargs.precision == "fp32" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -30,40 +30,39 @@ def is_hf_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
 def get_hf_maxlength(model: 'torchbenchmark.util.model.BenchmarkModel') -> Optional[int]:
     return model.max_length if is_hf_model(model) else None
 
-def check_fp16(model: 'torchbenchmark.util.model.BenchmarkModel', fp16: str) -> bool:
-    if fp16 == "half":
+def check_precision(model: 'torchbenchmark.util.model.BenchmarkModel', precision: str) -> bool:
+    if precision == "fp16":
         return model.test == 'eval' and model.device == 'cuda' and hasattr(model, "enable_fp16_half")
-    if fp16 == "amp":
+    if precision == "amp":
         return model.test == 'eval' and model.device == 'cuda'
     return True
 
-# torchvision models uses fp16 half mode by default, others use fp32
-def get_fp16_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
+def get_precision_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
     if hasattr(model, "DEFAULT_EVAL_CUDA_PRECISION") and model.test == 'eval' and model.device == 'cuda':
         return model.DEFAULT_EVAL_CUDA_PRECISION
     return "no"
 
 def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> Tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--fp16", choices=["no", "half", "amp"], default=get_fp16_default(model), help="enable fp16 modes from: no fp16, half, or amp")
+    parser.add_argument("--precision", choices=["fp32", "fp16", "amp"], default=get_precision_default(model), help="choose precisions from: fp32, fp16, or amp")
     dargs, opt_args = parser.parse_known_args(extra_args)
-    if not check_fp16(model, dargs.fp16):
-        raise NotImplementedError(f"fp16 value: {dargs.fp16}, fp16 is only supported on CUDA inference tests, "
-                                  f"fp16 (half mode) is only supported if the model implements `enable_fp16_half()` callback function.")
+    if not check_precision(model, dargs.precision):
+        raise NotImplementedError(f"precision value: {dargs.precision}, fp16 or amp precision is only supported on CUDA inference tests, "
+                                  f"fp16 is only supported if the model implements the `enable_fp16_half()` callback function.")
     return (dargs, opt_args)
 
 def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dargs: argparse.Namespace):
-    if dargs.fp16 == "half":
+    if dargs.precision == "half":
         model.enable_fp16_half()
-    elif dargs.fp16 == "amp":
+    elif dargs.precision == "amp":
         # model handles amp itself if it has 'enable_amp' callback function
         if hasattr(model, "enable_amp"):
             model.enable_amp()
         else:
             import torch
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
-    elif not dargs.fp16 == "no":
-        assert False, f"Get an invalid fp16 value: {dargs.fp16}. Please report a bug."
+    elif not dargs.precision == "no":
+        assert False, f"Get an invalid fp16 value: {dargs.precision}. Please report a bug."
 
 # Dispatch arguments based on model type
 def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:
@@ -98,10 +97,10 @@ def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argp
         if args.jit:
             raise NotImplementedError("fx2trt with JIT is not available.")
         module, exmaple_inputs = model.get_module()
-        fp16 = not (model.dargs.fp16 == "no")
+        fp16 = not (model.dargs.precision == "fp32")
         model.set_module(enable_fx2trt(model.batch_size, fp16=fp16, model=module, example_inputs=exmaple_inputs,
                                        is_hf_model=is_hf_model(model), hf_max_length=get_hf_maxlength(model)))
     if args.torch_trt:
         module, exmaple_inputs = model.get_module()
-        precision = 'fp16' if not model.dargs.fp16 == "no" else 'fp32'
+        precision = 'fp16' if not model.dargs.precision == "fp16" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -29,7 +29,7 @@ class ArgsToKwargsWrapper(torch.nn.Module):
 class HuggingFaceModel(BenchmarkModel):
     HF_MODEL = True
     # Default eval precision on CUDA device is fp16(half mode)
-    DEFAULT_EVAL_CUDA_PRECISION = "half"
+    DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 
     def __init__(self, name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -28,6 +28,8 @@ class ArgsToKwargsWrapper(torch.nn.Module):
 
 class HuggingFaceModel(BenchmarkModel):
     HF_MODEL = True
+    # Default eval precision on CUDA device is fp16(half mode)
+    DEFAULT_EVAL_CUDA_PRECISION = "half"
 
     def __init__(self, name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -41,7 +41,7 @@ class TimmModel(BenchmarkModel):
                 result = []
                 for _i in range(num_batches):
                     result.append((self._gen_input(self.batch_size), ))
-                if self.dargs.fp16 == "half":
+                if self.dargs.precision == "fp16":
                     result = list(map(lambda x: (x[0].half(), ), result))
                 yield result
         return (_gen_inputs(), None)

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -12,8 +12,8 @@ class TimmModel(BenchmarkModel):
     # These two variables should be defined by subclasses
     DEFAULT_TRAIN_BSIZE = None
     DEFAULT_EVAL_BSIZE = None
-    # Default eval precision on CUDA device is fp16(half mode)
-    DEFAULT_EVAL_CUDA_PRECISION = "half"
+    # Default eval precision on CUDA device is fp16
+    DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 
     def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -12,6 +12,8 @@ class TimmModel(BenchmarkModel):
     # These two variables should be defined by subclasses
     DEFAULT_TRAIN_BSIZE = None
     DEFAULT_EVAL_BSIZE = None
+    # Default eval precision on CUDA device is fp16(half mode)
+    DEFAULT_EVAL_CUDA_PRECISION = "half"
 
     def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -49,7 +49,7 @@ class TorchVisionModel(BenchmarkModel):
                 result = []
                 for _i in range(num_batches):
                     result.append((torch.randn((self.batch_size, 3, 224, 224)).to(self.device),))
-                if self.dargs.fp16 == "half":
+                if self.dargs.precision == "fp16":
                     result = list(map(lambda x: (x[0].half(), ), result))
                 yield result
         return (_gen_inputs(), None)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -12,8 +12,8 @@ class TorchVisionModel(BenchmarkModel):
     # These two variables should be defined by subclasses
     DEFAULT_TRAIN_BSIZE = None
     DEFAULT_EVAL_BSIZE = None
-    # Default eval precision on CUDA device is fp16(half mode)
-    DEFAULT_EVAL_CUDA_PRECISION = "half"
+    # Default eval precision on CUDA device is fp16
+    DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 
     def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -12,6 +12,8 @@ class TorchVisionModel(BenchmarkModel):
     # These two variables should be defined by subclasses
     DEFAULT_TRAIN_BSIZE = None
     DEFAULT_EVAL_BSIZE = None
+    # Default eval precision on CUDA device is fp16(half mode)
+    DEFAULT_EVAL_CUDA_PRECISION = "half"
 
     def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)


### PR DESCRIPTION
Rename the `fp16` option to `precision`, providing 3 options: `fp32`, `fp16`, `amp`. It also adds the `precision` attribute to the result of `run_sweep.py`.

Renaming the option to `precision` makes it easier to support other precisions in the future, such as `bfloat16`.