### PR TITLE
Add accelerate to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+accelerate
 bs4
 patch
 py-cpuinfo


### PR DESCRIPTION
Used by `torchbenchmark.e2e_models.hf_bert`

```
  File "/raid/shenli/benchmark/torchbenchmark/e2e_models/hf_bert/__init__.py", line 9, in <module>
    from accelerate import Accelerator
ModuleNotFoundError: No module named 'accelerate'
```