### PR TITLE
NVFuser microbenchmark - clear CU before each run

### DIFF
--- a/torchbenchmark/microbenchmarks/nvfuser/__init__.py
+++ b/torchbenchmark/microbenchmarks/nvfuser/__init__.py
@@ -63,7 +63,7 @@ def load_graph_and_inputs(ir: str) -> Tuple[Any, List[Any]]:
 def time_cuda(fn, inputs, test_runs):
     t = Timer(stmt="fn(*inputs)", globals={"fn": fn, "inputs": inputs})
     times = t.blocked_autorange()
-    return times * 1000  # time in ms
+    return times.median * 1000  # time in ms
 
 
 def time_cpu(fn, inputs, test_runs):

--- a/torchbenchmark/microbenchmarks/nvfuser/__init__.py
+++ b/torchbenchmark/microbenchmarks/nvfuser/__init__.py
@@ -82,6 +82,7 @@ def time_cpu(fn, inputs, test_runs):
 
 
 def run_test(ir, inputs, *, warmup_runs=10, test_runs=20) -> float:
+    torch.jit._state._python_cu.drop_all_functions()
     graph, _ = load_graph_and_inputs(ir)
     for _ in range(warmup_runs):
         graph(*inputs)

--- a/torchbenchmark/microbenchmarks/nvfuser/__init__.py
+++ b/torchbenchmark/microbenchmarks/nvfuser/__init__.py
@@ -32,6 +32,7 @@ def no_fuser(*args, **kwargs):
         torch._C._jit_set_nvfuser_enabled(old_nvfuser_state)
 
 
+'''
 def make_tensor_from_type(inp_type: torch._C.TensorType):
     if inp_type.requires_grad() is not False:
         raise NotImplementedError("Tensors with requires_grad are not implemented")
@@ -39,6 +40,14 @@ def make_tensor_from_type(inp_type: torch._C.TensorType):
         inp_type.sizes(),
         dtype=inp_type.dtype(),
         device=inp_type.device())
+'''
+
+def make_tensor_from_type(inp_type: torch._C.TensorType):
+    size = inp_type.sizes()
+    stride = inp_type.strides()
+    device = inp_type.device()
+    dtype = inp_type.dtype()
+    return torch.empty_strided(size=size, stride=stride, device=device, dtype=dtype)
 
 
 def load_graph_and_inputs(ir: str) -> Tuple[Any, List[Any]]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #853

Re-ran with & without this extra line, and the results are very different. I think scripted results from previous runs are probably being cached and reused without using this.