### PR TITLE
Fix demucs jit error with type annotation

### DIFF
--- a/torchbenchmark/models/demucs/demucs/model.py
+++ b/torchbenchmark/models/demucs/demucs/model.py
@@ -6,6 +6,7 @@
 
 import math
 
+import torch
 import torch as th
 from torch import Tensor, nn
 
@@ -21,7 +22,7 @@ class BLSTM(nn.Module):
         self.lstm.flatten_parameters()
         self.linear = nn.Linear(2 * dim, dim)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
         x = x.permute(2, 0, 1)
         x = self.lstm(x)[0]
         x = self.linear(x)

--- a/torchbenchmark/models/fambench_xlmr/metadata.yaml
+++ b/torchbenchmark/models/fambench_xlmr/metadata.yaml
@@ -4,3 +4,7 @@ eval_nograd: true
 optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
+not_implemented:
+  # Disable CUDA train test because of insufficient GPU memory on CI machine
+  - test: train
+    device: cuda

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/metadata.yaml
@@ -4,3 +4,7 @@ eval_nograd: true
 optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
+not_implemented:
+  # Disable CUDA train test because of insufficient GPU memory on CI machine
+  - test: train
+    device: cuda

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -4,3 +4,7 @@ eval_nograd: true
 optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false
+not_implemented:
+  # Disable CUDA train test because of insufficient GPU memory on CI machine
+  - test: train
+    evice: cuda


### PR DESCRIPTION
Demucs jit test failed with error "Unknown type name 'torch.Tensor'" (https://app.circleci.com/pipelines/github/pytorch/benchmark/4092/workflows/4d99d970-de28-41f0-bab9-0f0ece1f9aa9/jobs/4209).
This can be fixed by importing the torch library and adding a type annotation to the code.

After upgrading to cudnn 8.3.2, the GPU memory usage of some tests seems increase and cause OOM on the CI box which uses T4. So we have to disable them as well.