### PR TITLE
Add pplbench beanmachine model

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -375,6 +375,12 @@ class ModelTask(base_task.TaskBase):
         try:
             input_iter, _size = model.gen_inputs()
             next_inputs = next(input_iter)
+
+            # In case of pplbench, next_inputs is a tuple
+            if isinstance(next_inputs, tuple):
+                module(*next_inputs)
+                return
+
             for input in next_inputs:
                 if isinstance(input, dict):
                     # Huggingface models pass **kwargs as arguments, not *args

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -376,11 +376,6 @@ class ModelTask(base_task.TaskBase):
             input_iter, _size = model.gen_inputs()
             next_inputs = next(input_iter)
 
-            # In case of pplbench, next_inputs is a tuple
-            if isinstance(next_inputs, tuple):
-                module(*next_inputs)
-                return
-
             for input in next_inputs:
                 if isinstance(input, dict):
                     # Huggingface models pass **kwargs as arguments, not *args

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -75,7 +75,8 @@ class Model(BenchmarkModel):
             result = []
             while True:
                 for _i in range(num_batches):
-                    result.append(self.example_inputs)
+                    train_data, test_data = self.model.model.generate_data(seed=int(time.time()), n=500000, k=500)
+                    result.append((train_data, test_data))
                 yield result
         return (_gen_inputs(), None)
 

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -9,6 +9,7 @@ from typing import Tuple, Generator, Optional
 from pplbench.ppls.beanmachine import robust_regression
 from pplbench.models.robust_regression import RobustRegression
 from pplbench.ppls.beanmachine.inference import MCMC
+import beanmachine.ppl as bm
 
 class Pplbench(torch.nn.Module):
     def __init__(self, test):
@@ -41,7 +42,8 @@ class Pplbench(torch.nn.Module):
         if training:
             # Run bayesian inference (training) on given data
             # Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
-            samples = self.infer_obj.infer(data=train_data, iterations=1500, num_warmup=0, seed=random.randint(1, int(1e7)))
+            # num_warmp should be >= iterations/2 . Because of a bug, with the default algorithm, only 0 works.
+            self.samples = self.infer_obj.infer(data=train_data, iterations=1500, num_warmup=0, seed=random.randint(1, int(1e7)))
         else:
             # Evaluate the model with test data and compute the posterior probabilities
             out = self.model.evaluate_posterior_predictive(self.samples, test_data)

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -21,7 +21,7 @@ class Pplbench(torch.nn.Module):
         if test == "eval":
             # Increased number of samples (n) and number of features(k) to increase computation for eval
             # Default values Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
-            self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()), n= 1000000, k=1000)
+            self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()), n=500000, k=500)
         else:
             self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()))
 

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -34,6 +34,7 @@ class Pplbench(torch.nn.Module):
         if not training:
             # Run bayesian inference (training) on given data for 1 iteration
             # We need the object of type MonteCarloSamples for the evaluation step
+            # @Todo Can we create samples object without using infer function?
             samples = self.infer_obj.infer(data=train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)))
 
             # Evaluate the model with test data and compute the posterior probabilities

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -10,6 +10,31 @@ from pplbench.ppls.beanmachine import robust_regression
 from pplbench.models.robust_regression import RobustRegression
 from pplbench.ppls.beanmachine.inference import MCMC
 
+class Pplbench(torch.nn.Module):
+    def __init__(self):
+        super(Pplbench, self).__init__()
+
+        # Instantiate model
+        self.model = RobustRegression()
+
+        # Get data for evaluating model
+        self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()))
+
+        # Create inference object with training data
+        self.infer_obj = MCMC(robust_regression.RobustRegression,
+                              self.train_data.attrs)
+        self.infer_obj.compile()
+
+    def forward(self, train_data, test_data):
+
+        # Run inference on given data
+        samples = self.infer_obj.infer(data=train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)))
+
+        # Evaluate the model with test data
+        out = self.model.evaluate_posterior_predictive(samples, test_data)
+
+        return torch.Tensor(out)
+
 class Model(BenchmarkModel):
     task = OTHER.OTHER_TASKS
     DEFAULT_EVAL_BSIZE = 1
@@ -21,17 +46,9 @@ class Model(BenchmarkModel):
             raise NotImplementedError("The eval test only supports CPU.")
 
         # Instantiate model
-        self.model = RobustRegression()
+        self.model = Pplbench()
 
-        # Get data for evaluating model
-        self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()))
-
-        # Create inference object with training data
-        self.infer_obj = MCMC(robust_regression.RobustRegression,
-                    self.train_data.attrs)
-        self.infer_obj.compile()
-
-        self.example_inputs = self.test_data
+        self.example_inputs = (self.model.train_data, self.model.test_data)
 
     def get_module(self):
         return self.model, self.example_inputs
@@ -42,12 +59,5 @@ class Model(BenchmarkModel):
     def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
 
-        # Run inference on given data
-        samples = self.infer_obj.infer(data=self.train_data, iterations=1, num_warmup=0,
-                                  seed=random.randint(1, int(1e7)))
-
-        # Evaluate the model with test data
-        out = model.evaluate_posterior_predictive(
-                samples, self.test_data
-            )
-        return (torch.Tensor(out), )
+        out = model(*example_inputs)
+        return (out, )

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -62,6 +62,8 @@ class Model(BenchmarkModel):
         if device != "cpu":
             raise NotImplementedError("The {} test only supports CPU.".format(test))
 
+        self.test = test
+
         # Instantiate model
         self.model = Pplbench(test)
 
@@ -75,7 +77,10 @@ class Model(BenchmarkModel):
             result = []
             while True:
                 for _i in range(num_batches):
-                    train_data, test_data = self.model.model.generate_data(seed=int(time.time()), n=500000, k=500)
+                    if self.test == "train":
+                        train_data, test_data = self.model.model.generate_data(seed=int(time.time()))
+                    else:
+                        train_data, test_data = self.model.model.generate_data(seed=int(time.time()), n=500000, k=500)
                     result.append((train_data, test_data))
                 yield result
         return (_gen_inputs(), None)

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -28,7 +28,7 @@ class Pplbench(torch.nn.Module):
     def forward(self, train_data, test_data):
 
         # Run inference on given data
-        samples = self.infer_obj.infer(data=train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)))
+        samples = self.infer_obj.infer(data=train_data, iterations=1500, num_warmup=0, seed=random.randint(1, int(1e7)))
 
         # Evaluate the model with test data
         out = self.model.evaluate_posterior_predictive(samples, test_data)
@@ -37,7 +37,10 @@ class Pplbench(torch.nn.Module):
 
 class Model(BenchmarkModel):
     task = OTHER.OTHER_TASKS
+
+    # Batch size is not adjustable in the model
     DEFAULT_EVAL_BSIZE = 1
+    ALLOW_CUSTOMIZE_BSIZE = False
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -35,15 +35,16 @@ class Pplbench(torch.nn.Module):
             # Run bayesian inference (training) on given data for 1 iteration
             # We need the object of type MonteCarloSamples for the evaluation step
             # @Todo Can we create samples object without using infer function?
-            self.samples = self.infer_obj.infer(data=self.train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)))
+            self.samples = self.infer_obj.infer(data=self.train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)),
+                                                algorithm="GlobalNoUTurnSampler")
 
     def forward(self, train_data, test_data, training=False):
 
         if training:
             # Run bayesian inference (training) on given data
             # Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
-            # num_warmp should be >= iterations/2 . Because of a bug, with the default algorithm, only 0 works.
-            self.samples = self.infer_obj.infer(data=train_data, iterations=1500, num_warmup=0, seed=random.randint(1, int(1e7)))
+            self.samples = self.infer_obj.infer(data=train_data, iterations=500, num_warmup=250, seed=random.randint(1, int(1e7)),
+                                                algorithm="GlobalNoUTurnSampler")
         else:
             # Evaluate the model with test data and compute the posterior probabilities
             out = self.model.evaluate_posterior_predictive(self.samples, test_data)

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -4,7 +4,7 @@ import torch
 
 from ...util.model import BenchmarkModel
 from torchbenchmark.tasks import OTHER
-from typing import Tuple
+from typing import Tuple, Generator, Optional
 
 from pplbench.ppls.beanmachine import robust_regression
 from pplbench.models.robust_regression import RobustRegression
@@ -69,6 +69,12 @@ class Model(BenchmarkModel):
 
     def get_module(self):
         return self.model, self.example_inputs
+
+    def gen_inputs(self, num_batches=1) -> Tuple[Generator, Optional[int]]:
+        def _gen_inputs():
+            while True:
+                yield self.example_inputs
+        return (_gen_inputs(), None)
 
     def train(self, niter=1):
         model, example_inputs = self.get_module()

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -72,8 +72,11 @@ class Model(BenchmarkModel):
 
     def gen_inputs(self, num_batches=1) -> Tuple[Generator, Optional[int]]:
         def _gen_inputs():
+            result = []
             while True:
-                yield self.example_inputs
+                for _i in range(num_batches):
+                    result.append(self.example_inputs)
+                yield result
         return (_gen_inputs(), None)
 
     def train(self, niter=1):

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -1,0 +1,54 @@
+import time
+import random
+import torch
+
+from ...util.model import BenchmarkModel
+from torchbenchmark.tasks import OTHER
+from typing import Tuple
+
+from pplbench.ppls.beanmachine import robust_regression
+from pplbench.models.robust_regression import RobustRegression
+from pplbench.ppls.beanmachine.inference import MCMC
+
+
+class Model(BenchmarkModel):
+    task = OTHER.OTHER_TASKS
+    DEFAULT_EVAL_BSIZE = 1
+
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+
+        if test == "eval" and device != "cpu":
+            raise NotImplementedError("The eval test only supports CPU.")
+
+        # Instantiate model
+        self.model = RobustRegression()
+
+        # Get data for evaluating model
+        self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()))
+
+        # Create inference object with training data
+        self.infer_obj = MCMC(robust_regression.RobustRegression,
+                    self.train_data.attrs)
+        self.infer_obj.compile()
+
+        self.example_inputs = self.test_data
+
+    def get_module(self):
+        return self.model, self.example_inputs
+
+    def train(self, niter=1):
+        raise NotImplementedError("Training not supported")
+
+    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+        model, example_inputs = self.get_module()
+
+        # Run inference on given data
+        samples = self.infer_obj.infer(data=self.train_data, iterations=1, num_warmup=0,
+                                  seed=random.randint(1, int(1e7)))
+
+        # Evaluate the model with test data
+        out = model.evaluate_posterior_predictive(
+                samples, self.test_data
+            )
+        return (out, )

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -10,7 +10,6 @@ from pplbench.ppls.beanmachine import robust_regression
 from pplbench.models.robust_regression import RobustRegression
 from pplbench.ppls.beanmachine.inference import MCMC
 
-
 class Model(BenchmarkModel):
     task = OTHER.OTHER_TASKS
     DEFAULT_EVAL_BSIZE = 1
@@ -51,4 +50,4 @@ class Model(BenchmarkModel):
         out = model.evaluate_posterior_predictive(
                 samples, self.test_data
             )
-        return (out, )
+        return (torch.Tensor(out), )

--- a/torchbenchmark/models/pplbench_beanmachine/install.py
+++ b/torchbenchmark/models/pplbench_beanmachine/install.py
@@ -1,0 +1,8 @@
+import sys
+import subprocess
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()

--- a/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
+++ b/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
@@ -4,3 +4,5 @@ eval_nograd: true
 optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
+not_implemented:
+    - jit: true

--- a/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
+++ b/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
@@ -2,5 +2,5 @@ eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
 optimized_for_inference: false
-train_benchmark: true
+train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
+++ b/torchbenchmark/models/pplbench_beanmachine/metadata.yaml
@@ -1,0 +1,6 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+optimized_for_inference: false
+train_benchmark: true
+train_deterministic: false

--- a/torchbenchmark/models/pplbench_beanmachine/requirements.txt
+++ b/torchbenchmark/models/pplbench_beanmachine/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/facebookresearch/pplbench.git#egg=pplbench[ppls]


### PR DESCRIPTION
Code for integrating beanchmachine pplbench with torchbench

**Outputs:**

_python run.py pplbench_beanmachine -d cpu -t eval_

Running eval method from pplbench_beanmachine on cpu in eager mode.
CPU Total Wall Time:  98.262 milliseconds

 _python run.py pplbench_beanmachine -d cpu -t train_

Running train method from pplbench_beanmachine on cpu in eager mode.
CPU Total Wall Time: 16629.886 milliseconds