### PR TITLE
Improve correctness algorithm

### DIFF
--- a/run.py
+++ b/run.py
@@ -183,4 +183,4 @@ if __name__ == "__main__":
     else:
         run_one_step(test, model_flops=model_flops)
     if hasattr(m, 'correctness'):
-        print('{:<20} {:>20}'.format("Correctness:", "%.15f" % m.correctness), sep='')
+        print('{:<20} {:>20}'.format("Correctness: ", m.correctness), sep='')

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -68,7 +68,7 @@ def torch_allclose(eager_output: Tuple['torch.Tensor'], output: Tuple['torch.Ten
     # sanity checks
     assert len(eager_output) == len(output), "Correctness check requires two inputs have the same length"
     for i in range(len(eager_output)):
-        if not torch.allclose(eager_output[i], output[i], atol=threshold, rtol=threshold):
+        if not torch.allclose(eager_output[i].float(), output[i].float(), atol=threshold, rtol=threshold):
             return False
     return True
 

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -50,7 +50,7 @@ def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel') -> Optio
 
 def correctness_check(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
     assert model.test=="eval", "We only support correctness check for inference."
-    assert hasattr(model, 'stableness'), "Need stableness result to check correctness."
+    assert hasattr(model, 'eager_output'), "Need stableness result to check correctness."
     if not model.eager_output:
         return "Unstable"
     for _i in range(CORRECTNESS_CHECK_ROUNDS):

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -7,7 +7,7 @@ from typing import ContextManager, Optional, List, Tuple, Generator
 from torchbenchmark.util.backends.torchdynamo import parse_torchdynamo_args, apply_torchdynamo_args
 from torchbenchmark.util.extra_args import enable_opt_args, parse_opt_args, apply_opt_args, \
                                            parse_decoration_args, apply_decoration_args
-from torchbenchmark.util.env_check import set_random_seed, correctness_check
+from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check
 
 class PostInitProcessor(type):
     def __call__(cls, *args, **kwargs):
@@ -90,19 +90,17 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         self.need_correctness_check = True if self.dynamo else enable_opt_args(self.opt_args)
         # currently, only check correctness under CUDA+inference, and `need_correctness_check` is True
         if self.device == "cuda" and self.test == "eval" and self.need_correctness_check:
-            self.eager_output = self.invoke()
-        # apply decoration and optimization args
+            self.stableness = stableness_check(self)
+        # apply decoration args
         apply_decoration_args(self, self.dargs)
+        # apply optimization args
         if self.dynamo:
             apply_torchdynamo_args(self, self.opt_args, self.dargs.precision)
         else:
             apply_opt_args(self, self.opt_args)
         # if test is eval, check correctness
         if self.device == "cuda" and self.test == "eval" and self.need_correctness_check:
-            self.output = self.invoke()
-            self.correctness = correctness_check(self.eager_output, self.output)
-            del self.eager_output
-            del self.output
+            self.correctness = correctness_check(self)
             torch.cuda.empty_cache()
 
     def add_context(self, context_fn):

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -90,7 +90,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         self.need_correctness_check = True if self.dynamo else enable_opt_args(self.opt_args)
         # currently, only check correctness under CUDA+inference, and `need_correctness_check` is True
         if self.device == "cuda" and self.test == "eval" and self.need_correctness_check:
-            self.stableness = stableness_check(self)
+            self.eager_output = stableness_check(self)
         # apply decoration args
         apply_decoration_args(self, self.dargs)
         # apply optimization args


### PR DESCRIPTION
This PR improves the correctness algorithm by:
1. run 10 iterations and only pass the test when all of them pass
2. add a stableness test, if the model doesn't output stable results, do not run the correctness test
3. use the `torch.allclose()` to perform the correctness test, except for fx2trt+fp16, which keeps using cosine similarity
