### PR TITLE
Add amp+train support and channels_last support to timm models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest
 pytest-benchmark
 requests
 tabulate
-timm == 0.4.12
+git+https://github.com/rwightman/pytorch-image-models.git@6d4665b
 # huggingface fx2trt support requires transformers == 4.12.1
 transformers == 4.12.1
 MonkeyType

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -71,6 +71,8 @@ def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', ext
     return (dargs, opt_args)
 
 def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dargs: argparse.Namespace):
+    if dargs.channels_last:
+        model.enable_channels_last()
     if dargs.precision == "fp16":
         model.enable_fp16_half()
     elif dargs.precision == "amp":
@@ -82,8 +84,6 @@ def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dar
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
     elif not dargs.precision == "fp32":
         assert False, f"Get an invalid precision option: {dargs.precision}. Please report a bug."
-    if dargs.channels_last:
-        model.enable_channels_last()
 
 # Dispatch arguments based on model type
 def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -47,7 +47,8 @@ def check_precision(model: 'torchbenchmark.util.model.BenchmarkModel', precision
 
 def check_memory_layout(model: 'torchbenchmark.util.model.BenchmakModel', channels_last: bool) -> bool:
     if channels_last:
-        return hasattr(model, 'enable_memory_layout')
+        return hasattr(model, 'enable_channels_last')
+    return True
 
 def get_precision_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> str:
     if hasattr(model, "DEFAULT_EVAL_CUDA_PRECISION") and model.test == 'eval' and model.device == 'cuda':
@@ -59,7 +60,7 @@ def get_precision_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> 
 def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> Tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser()
     parser.add_argument("--precision", choices=["fp32", "fp16", "amp"], default=get_precision_default(model), help="choose precisions from: fp32, fp16, or amp")
-    parser.add_argument("--channels-last", actions='store_true', help="enable channels-last memory layout")
+    parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
     dargs, opt_args = parser.parse_known_args(extra_args)
     if not check_precision(model, dargs.precision):
         raise NotImplementedError(f"precision value: {dargs.precision}, fp16 or amp precision is only supported on CUDA inference tests, "

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -90,6 +90,7 @@ class TimmModel(BenchmarkModel):
 
     def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
         with torch.no_grad():
-            for _ in range(niter):
-                out = self._step_eval()
+            with self.amp_context():
+                for _ in range(niter):
+                    out = self._step_eval()
         return (out, )


### PR DESCRIPTION
This PR adds amp precision support to timm train tests.
It also adds channels-last option to both train and eval tests.

Test plan:
```
$ python run.py timm_nfnet -t train -d cuda --precision amp
Running train method from timm_nfnet on cuda in eager mode.
GPU Time:            256.267 milliseconds
CPU Total Wall Time: 256.305 milliseconds
```

```
$ python run.py timm_nfnet -t train -d cuda --precision amp --channels-last
Running train method from timm_nfnet on cuda in eager mode.
GPU Time:            234.359 milliseconds
CPU Total Wall Time: 234.450 milliseconds
```