### PR TITLE
Disable eval test in pplbench_beanmachine

### DIFF
--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -20,6 +20,9 @@ class Pplbench(torch.nn.Module):
 
         # Get data for inference & evaluating model
         if test == "eval":
+            # The evaluation step doesn't use PyTorch code because it needs to handle
+            # various probabilistic programming languages. See GitHub issue #898
+            raise NotImplementedError("PPLBench Beanmachine eval test doesn't use PyTorch and is disabled - see GH issue #898.")
             # Increased number of samples (n) and number of features(k) to increase computation for eval
             # Default values Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
             self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()), n=500000, k=500)

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -17,9 +17,10 @@ class Pplbench(torch.nn.Module):
 
         # Instantiate model
         self.model = RobustRegression()
+        self.test = test
 
         # Get data for inference & evaluating model
-        if test == "eval":
+        if self.test == "eval":
             # Increased number of samples (n) and number of features(k) to increase computation for eval
             # Default values Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
             self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()), n=500000, k=500)
@@ -31,16 +32,16 @@ class Pplbench(torch.nn.Module):
                               self.train_data.attrs)
         self.infer_obj.compile()
 
-        if test == "eval":
+        if self.test == "eval":
             # Run bayesian inference (training) on given data for 1 iteration
             # We need the object of type MonteCarloSamples for the evaluation step
             # @Todo Can we create samples object without using infer function?
             self.samples = self.infer_obj.infer(data=self.train_data, iterations=1, num_warmup=0, seed=random.randint(1, int(1e7)),
                                                 algorithm="GlobalNoUTurnSampler")
 
-    def forward(self, train_data, test_data, training=False):
+    def forward(self, train_data, test_data):
 
-        if training:
+        if self.test == "train":
             # Run bayesian inference (training) on given data
             # Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
             self.samples = self.infer_obj.infer(data=train_data, iterations=500, num_warmup=250, seed=random.randint(1, int(1e7)),
@@ -96,7 +97,7 @@ class Model(BenchmarkModel):
     def train(self, niter=1):
         model, example_inputs = self.get_module()
 
-        _ = model(*example_inputs, training=True)
+        _ = model(*example_inputs)
 
     def eval(self, niter=1) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()

--- a/torchbenchmark/models/pplbench_beanmachine/__init__.py
+++ b/torchbenchmark/models/pplbench_beanmachine/__init__.py
@@ -20,9 +20,6 @@ class Pplbench(torch.nn.Module):
 
         # Get data for inference & evaluating model
         if test == "eval":
-            # The evaluation step doesn't use PyTorch code because it needs to handle
-            # various probabilistic programming languages. See GitHub issue #898
-            raise NotImplementedError("PPLBench Beanmachine eval test doesn't use PyTorch and is disabled - see GH issue #898.")
             # Increased number of samples (n) and number of features(k) to increase computation for eval
             # Default values Reference: https://github.com/facebookresearch/pplbench/blob/main/examples/robust_regression.json
             self.train_data, self.test_data = self.model.generate_data(seed=int(time.time()), n=500000, k=500)
@@ -64,6 +61,11 @@ class Model(BenchmarkModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+
+        if self.test == "eval":
+            # The evaluation step doesn't use PyTorch code because it needs to handle
+            # various probabilistic programming languages. See GitHub issue #898
+            raise NotImplementedError("PPLBench Beanmachine eval test doesn't use PyTorch and is disabled - see GH issue #898.")
 
         if device != "cpu":
             raise NotImplementedError("The {} test only supports CPU.".format(test))


### PR DESCRIPTION
Disable eval test in pplbench_beanmachine, but keeps the train test.
The eval code is shared among various frameworks, so it doesn't use PyTorch.
Fixes https://github.com/pytorch/benchmark/issues/898