### PR TITLE
Fix fp16 precision and cos sim correctness

### DIFF
--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -102,7 +102,9 @@ def cos_similarity(eager_output: Tuple['torch.Tensor'], output: Tuple['torch.Ten
         t1 = eager_output[i]
         t2 = output[i]
         cos = torch.nn.CosineSimilarity(dim=0, eps=1e-4)
-        # need to call float() because fp16 tensor may overflow when calculating cosine similarity
-        result *= cos(t1.flatten().float(), t2.flatten().float())
+        # deal with special case: both t1 and t2 are zeros
+        if not (torch.count_nonzero(t1) == 0 and torch.count_nonzero(t2) == 0):
+            # need to call float() because fp16 tensor may overflow when calculating cosine similarity
+            result *= cos(t1.flatten().float(), t2.flatten().float())
     assert list(result.size())==[], "The result of cosine similarity must be a scalar."
     return float(result)

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -100,11 +100,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             apply_opt_args(self, self.opt_args)
         # if test is eval, check correctness
         if self.device == "cuda" and self.test == "eval" and self.need_correctness_check:
-            # if fx2trt is used (either with or without dynamo), use cosine similarity
-            # instead of torch.allclose, because fp16+TensorRT is loose on accuracy
-            if self.dargs.precision == "fp16" and self.dynamo and self.opt_args.torchdynamo == "fx2trt":
-                self.correctness = correctness_check(self, cos_sim=True)
-            elif self.dargs.precision == "fp16" and (not self.dynamo) and self.opt_args.fx2trt:
+            # if fp16 is used, use cosine similarity instead of torch.allclose
+            # because cosine similarity is more relaxed
+            if self.dargs.precision == "fp16":
                 self.correctness = correctness_check(self, cos_sim=True)
             else:
                 self.correctness = correctness_check(self, cos_sim=False)


### PR DESCRIPTION
Currently we are using fp32 as the baseline for all correctness tests.
When using `torch.allclose()` to compare the result between fp32 and torchdynamo eager+fp16, the test returns "incorrect"; on the other hand, using cosine similarity, it returns "correct".

Here is an overview of the results:

|               | torch.allclose() | cosine similarity |
|---------------|------------------|-------------------|
| fp32 baseline vs. torchdynamo-eager-fp16 | *incorrect*        | correct           |
| fp16 baseline vs. torchdynamo-eager-fp16 | correct          | correct           |

Therefore, we are using cosine similarity for all fp16 correctness tests.

Note that this is not a problem of torchdynamo - using `torch.allclose()` to compare fp32 baseline and fp16 result without torchdynamo, the result is also `incorrect`. 