### PR TITLE
Add required example_args argument to prepare_fx and prepare_qat_fx

### DIFF
--- a/test.py
+++ b/test.py
@@ -120,6 +120,10 @@ def _load_tests():
         devices.append('cuda')
 
     for path in _list_model_paths():
+        # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
+        # api, enable after PyTorch 1.13 release
+        if "quantized" in path:
+            continue
         for device in devices:
             _load_test(path, device)
 

--- a/test_bench.py
+++ b/test_bench.py
@@ -51,6 +51,10 @@ class TestBenchNetwork:
             if skip_by_metadata(test="train", device=device, jit=(compiler == 'jit'), \
                                 extra_args=[], metadata=get_metadata_from_yaml(model_path)):
                 raise NotImplementedError("Test skipped by its metadata.")
+            # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
+            # api, enable after PyTorch 1.13 release
+            if "quantized" in model_path:
+                return
             task = ModelTask(model_path)
             if not task.model_details.exists:
                 return  # Model is not supported.
@@ -67,6 +71,10 @@ class TestBenchNetwork:
             if skip_by_metadata(test="eval", device=device, jit=(compiler == 'jit'), \
                                 extra_args=[], metadata=get_metadata_from_yaml(model_path)):
                 raise NotImplementedError("Test skipped by its metadata.")
+            # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
+            # api, enable after PyTorch 1.13 release
+            if "quantized" in model_path:
+                return
             task = ModelTask(model_path)
             if not task.model_details.exists:
                 return  # Model is not supported.

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}
         self.model.train()
-        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
+        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict, self.example_inputs)
 
     def train(self, niter=3):
         optimizer = optim.Adam(self.model.parameters())

--- a/torchbenchmark/models/resnet50_quantized_qat/__init__.py
+++ b/torchbenchmark/models/resnet50_quantized_qat/__init__.py
@@ -32,7 +32,7 @@ class Model(BenchmarkModel):
     def prep_qat_train(self):
         qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('fbgemm')}
         self.model.train()
-        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict)
+        self.model = quantize_fx.prepare_qat_fx(self.model, qconfig_dict, self.example_inputs)
 
     def get_module(self):
         return self.model, self.example_inputs


### PR DESCRIPTION
Summary:
FX Graph Mode Quantization needs to know whether an fx node is a floating point Tensor before it can decide whether to
insert observer/fake_quantize module or not, since we only insert observer/fake_quantize module for floating point Tensors.
Currently we have some hacks to support this by defining some rules like NON_OBSERVABLE_ARG_DICT (https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/utils.py#L496), but this approach is fragile and we do not plan to maintain it long term in the pytorch code base.

As we discussed in the design review, we'd need to ask users to provide sample args and sample keyword args
so that we can infer the type in a more robust way. This PR starts with changing the prepare_fx and prepare_qat_fx api to require user to either provide
example arguments thrugh example_inputs, Note this api doesn't support kwargs, kwargs can make https://github.com/pytorch/pytorch/pull/76496#discussion_r861230047 (comment) simpler, but
it will be rare, and even then we can still workaround with positional arguments, also torch.jit.trace(https://pytorch.org/docs/stable/generated/torch.jit.trace.html) and ShapeProp: https://github.com/pytorch/pytorch/blob/master/torch/fx/passes/shape_prop.py#L140 just have single positional args, we'll just use a single example_inputs argument for now.

If needed, we can extend the api with an optional example_kwargs. e.g. in case when there are a lot of arguments for forward and it makes more sense to
pass the arguments by keyword

BC-breaking Note:
Before:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict)

After:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 224, 224),))

Reviewed By: vkuzo, andrewor14

Differential Revision: D35984526

