### PR TITLE
Pin the omegaconf package version for xlmr

### DIFF
--- a/torchbenchmark/models/fambench_dlrm/metadata.yaml
+++ b/torchbenchmark/models/fambench_dlrm/metadata.yaml
@@ -4,3 +4,6 @@ eval_nograd: true
 optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
+not_implemented:
+  # CUDA disabled due to CUDA out of memory on CI GPU
+  - device: cuda

--- a/torchbenchmark/models/fambench_xlmr/requirements.txt
+++ b/torchbenchmark/models/fambench_xlmr/requirements.txt
@@ -1,6 +1,7 @@
 sacrebleu
 bitarray
-omegaconf
+# fairseq v0.11.0 requires omegaconf==2.1.1
+omegaconf==2.1.1
 hydra-core
 sentencepiece
 xformers


### PR DESCRIPTION
In https://github.com/pytorch/benchmark/pull/902 we pinned the fairseq version to 0.11.0, which requires an older omegaconf package version. The recent update of omegaconf (2.2.1) breaks the backward compatibility.