### PR TITLE
Increase the default batch size of alexnet

### DIFF
--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -6,7 +6,7 @@ class Model(TorchVisionModel):
     # Train batch size: use the smallest example batch of 128 (assuming only 1 worker)
     # Source: https://arxiv.org/pdf/1404.5997.pdf
     DEFAULT_TRAIN_BSIZE = 128
-    DEFAULT_EVAL_BSIZE = 16
+    DEFAULT_EVAL_BSIZE = 128
 
     def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
         super().__init__(model_name="alexnet", test=test, device=device, jit=jit,


### PR DESCRIPTION
The default batch size for alexnet is too small and is not a proper workload for GPU. Some performance issues (e.g., https://github.com/pytorch/pytorch/issues/76970) only affects small batch size inputs and I believe they are insignificant in real settings.
This PR increases the default batch size for alexnet on GPU.

Although this PR will also increase CPU batch size, we are working on a PR that uses separate batch sizes for different devices, which will use small batch size for CPU, and large batch size for GPU.