### PR TITLE
Pin the version of dill for attention_is_all_you_need_pytorch

### DIFF
--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
@@ -1,4 +1,4 @@
-dill
+dill==0.3.5
 tqdm
 iopath
 numpy

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
@@ -1,4 +1,4 @@
-dill==0.3.5
+dill==0.3.4
 tqdm
 iopath
 numpy


### PR DESCRIPTION
`attention_is_all_you_need_pytorch` requires dill == 0.3.4, newer dill version will have the following error:
```
ModuleNotFoundError: No module named 'dill._shims'
```

Fix another API change of `prepare_qat_fx` API (https://github.com/pytorch/pytorch/pull/77608)