### PR TITLE
Pin numpy version and mkl libraries

### DIFF
--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -16,6 +16,7 @@ jobs:
       PYTHON_VERSION: "3.8"
       MAGMA_VERSION: "magma-cuda113"
       CUDA_VERSION: "11.3"
+      MKL_VERSION: "2021.2.0"
       NUMPY_VERSION: "1.21.2"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
@@ -33,7 +34,7 @@ jobs:
           # See: https://github.com/pytorch/pytorch/issues/74985
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython tqdm
-          conda install -y mkl mkl-include
+          conda install -y mkl="${MKL_VERSION}" mkl-include
           conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Bisection
         run: |

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -33,7 +33,7 @@ jobs:
           . activate "$BISECT_CONDA_ENV"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VER}"  mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}" \
+          conda install -y numpy="${NUMPY_VERSION}"  mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}" \
                            requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           conda install -y -c pytorch "${MAGMA_VERSION}"

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -16,6 +16,7 @@ jobs:
       PYTHON_VERSION: "3.8"
       MAGMA_VERSION: "magma-cuda113"
       CUDA_VERSION: "11.3"
+      NUMPY_VERSION: "1.21.2"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
     timeout-minutes: 2880 # 48 hours
@@ -30,11 +31,10 @@ jobs:
           . activate "$BISECT_CONDA_ENV"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
+          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython tqdm
+          conda install -y mkl mkl-include
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616
-          conda install -y ffmpeg=4.4.1
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -28,6 +28,7 @@ jobs:
           ref: v1.0
       - name: Create conda environment
         run: |
+          set -x
           conda create -y -n "$BISECT_CONDA_ENV" python="${PYTHON_VERSION}"
           . activate "$BISECT_CONDA_ENV"
           # pytorch doesn't support cmake>3.22

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -33,9 +33,9 @@ jobs:
           . activate "$BISECT_CONDA_ENV"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml setuptools cmake=3.22 cffi \
-                           typing_extensions future six dataclasses tabulate gitpython tqdm
-          conda install -y mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}"
+          conda install -y numpy="${NUMPY_VER}"  mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}" \
+                           requests ninja pyyaml setuptools cmake=3.22 cffi \
+                           typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Bisection
         run: |

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -34,7 +34,7 @@ jobs:
           # See: https://github.com/pytorch/pytorch/issues/74985
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython tqdm
-          conda install -y mkl="${MKL_VERSION}" mkl-include
+          conda install -y mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}"
           conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Bisection
         run: |

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -32,7 +32,7 @@ jobs:
           . activate "$BISECT_CONDA_ENV"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
+          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython tqdm
           conda install -y mkl="${MKL_VERSION}" mkl-include
           conda install -y -c pytorch "${MAGMA_VERSION}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -28,6 +28,7 @@ jobs:
           ref: v2.0
       - name: Create conda environment
         run: |
+          set -x
           conda create -y -n "${BISECT_CONDA_ENV}" python="${PYTHON_VER}"
           . activate "${BISECT_CONDA_ENV}"
           # pytorch doesn't support cmake>3.22
@@ -38,8 +39,6 @@ jobs:
           conda install -y mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}"
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
-          # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616
-          conda install -y ffmpeg=4.4.1
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -16,6 +16,7 @@ jobs:
       PYTHON_VER: "3.8"
       CUDA_VER: "11.3"
       NUMPY_VER: "1.21.2"
+      MKL_VER: "2021.2.0"
       MAGMA_VERSION: "magma-cuda113"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
@@ -34,7 +35,7 @@ jobs:
           conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install mkl
-          conda install -y mkl mkl-include
+          conda install -y mkl="${MKL_VERSION}" mkl-include
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
           # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -32,7 +32,7 @@ jobs:
           . activate "${BISECT_CONDA_ENV}"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
+          conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install mkl
           conda install -y mkl="${MKL_VERSION}" mkl-include

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -33,10 +33,9 @@ jobs:
           . activate "${BISECT_CONDA_ENV}"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml setuptools cmake=3.22 cffi \
+          conda install -y numpy="${NUMPY_VER}"  mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}" \
+                           requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
-          # Install mkl
-          conda install -y mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}"
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Bisection

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -17,7 +17,7 @@ jobs:
       CUDA_VER: "11.3"
       NUMPY_VER: "1.21.2"
       MKL_VER: "2021.2.0"
-      MAGMA_VERSION: "magma-cuda113"
+      MAGMA_VER: "magma-cuda113"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
     timeout-minutes: 2880 # 48 hours
@@ -33,11 +33,11 @@ jobs:
           . activate "${BISECT_CONDA_ENV}"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy="${NUMPY_VER}"  mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}" \
+          conda install -y numpy="${NUMPY_VER}"  mkl="${MKL_VER}" mkl-include="${MKL_VER}" \
                            requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install magma
-          conda install -y -c pytorch "${MAGMA_VERSION}"
+          conda install -y -c pytorch "${MAGMA_VER}"
       - name: Bisection
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -35,7 +35,7 @@ jobs:
           conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
           # Install mkl
-          conda install -y mkl="${MKL_VERSION}" mkl-include
+          conda install -y mkl="${MKL_VERSION}" mkl-include="${MKL_VERSION}"
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
           # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -15,6 +15,7 @@ jobs:
       BISECT_BRANCH: "v2.0"
       PYTHON_VER: "3.8"
       CUDA_VER: "11.3"
+      NUMPY_VER: "1.21.2"
       MAGMA_VERSION: "magma-cuda113"
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, bm-runner]
@@ -30,8 +31,10 @@ jobs:
           . activate "${BISECT_CONDA_ENV}"
           # pytorch doesn't support cmake>3.22
           # See: https://github.com/pytorch/pytorch/issues/74985
-          conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
+          conda install -y numpy="${NUMPY_VER}" requests ninja pyyaml mkl mkl-include setuptools cmake=3.22 cffi \
                            typing_extensions future six dataclasses tabulate gitpython git-lfs tqdm
+          # Install mkl
+          conda install -y mkl mkl-include
           # Install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
           # Pin ffmpeg version to 4.4.1. See: https://github.com/pytorch/vision/issues/5616


### PR DESCRIPTION
Tacotron2 and tts_angular requires librosa, which requires numpy <= 1.21. Torchtext fails to build upon newer mkl libraries.
This PR pins these two libraries to older version.

We should use conda environment file to manage the dependency packages in the future.