### PR TITLE
Add distributed to userbenchmark

### DIFF
--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -3,7 +3,7 @@ import submitit
 from torchbenchmark.util.distributed.submit import parse_args, get_init_file, TrainerWrapper
 
 def run(args: List[str]):
-    args = parse_args()
+    args = parse_args(args)
 
     # Note that the folder will depend on the job_id, to easily track experiments
     executor = submitit.AutoExecutor(folder=args.job_dir, slurm_max_num_timeout=3000)

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -26,8 +26,7 @@ def run(args: List[str]):
     args.output_dir = args.job_dir
 
     job = executor.submit(TrainerWrapper(args))
-    # print ID of the Slurm job
-    print(job.job_id)
 
     # waits for completion and returns output
-    print(job.results())
+    result = job.results()
+    print(result)

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -8,9 +8,10 @@ BM_NAME = "distributed"
 
 def gen_metrics_from_result(result):
     assert isinstance(result, List), "The result of submitit should be a list."
-    metrics = []
-    for result_id, key in enumerate(result):
-        metrics[f"{result_id}-{key}"] = result[key]
+    metrics = {}
+    for result_id, r in enumerate(result):
+        for metric_name in r:
+            metrics[f"{result_id}-{metric_name}"] = r[metric_name]
     return metrics
 
 def run(args: List[str]):

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -1,6 +1,17 @@
 from typing import List
 import submitit
+import torch
 from torchbenchmark.util.distributed.submit import parse_args, get_init_file, TrainerWrapper
+from ..utils import dump_output
+
+BM_NAME = "distributed"
+
+def gen_metrics_from_result(result):
+    assert isinstance(result, List), "The result of submitit should be a list."
+    metrics = []
+    for result_id, key in enumerate(result):
+        metrics[f"{result_id}-{key}"] = result[key]
+    return metrics
 
 def run(args: List[str]):
     args = parse_args(args)
@@ -29,4 +40,10 @@ def run(args: List[str]):
 
     # waits for completion and returns output
     result = job.results()
-    print(result)
+    # dump the output file
+    output = {
+        "name": BM_NAME,
+        "environ": {"pytorch_git_version": torch.version.git_version},
+        "metrics": gen_metrics_from_result(result),
+    }
+    dump_output(BM_NAME, output)

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -1,0 +1,33 @@
+from typing import List
+import submitit
+from torchbenchmark.util.distributed.submit import parse_args, get_init_file, TrainerWrapper
+
+def run(args: List[str]):
+    args = parse_args()
+
+    # Note that the folder will depend on the job_id, to easily track experiments
+    executor = submitit.AutoExecutor(folder=args.job_dir, slurm_max_num_timeout=3000)
+
+    executor.update_parameters(
+        gpus_per_node=args.ngpus,
+        # one task per GPU
+        tasks_per_node=args.ngpus,
+        cpus_per_task=10,
+        nodes=args.nodes,
+        timeout_min=args.timeout,
+        # Below are cluster dependent parameters
+        slurm_partition=args.partition,
+        slurm_signal_delay_s=120,
+    )
+
+    executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=1000)
+
+    args.dist_url = get_init_file(args).as_uri()
+    args.output_dir = args.job_dir
+
+    job = executor.submit(TrainerWrapper(args))
+    # print ID of the Slurm job
+    print(job.job_id)
+
+    # waits for completion and returns output
+    print(job.results())

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -45,6 +45,7 @@ def run(args: List[str]):
     output = {
         "name": BM_NAME,
         "environ": {"pytorch_git_version": torch.version.git_version},
+        "args": vars(args),
         "metrics": gen_metrics_from_result(result),
     }
     dump_output(BM_NAME, output)

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -1,5 +1,5 @@
 import os
-import datetime
+from datetime import datetime
 import time
 import json
 from pathlib import Path

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -1,0 +1,14 @@
+import os
+import datetime
+import time
+import json
+from pathlib import Path
+
+def dump_output(bm_name, output):
+    current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    target_dir = current_dir.parent.joinpath(".userbenchmark", bm_name)
+    target_dir.mkdir(exist_ok=True, parents=True)
+    fname = "metrics-{}.json".format(datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S"))
+    full_fname = os.path.join(target_dir, fname)
+    with open(full_fname, 'w') as f:
+        json.dump(output, f, indent=4)


### PR DESCRIPTION
Test to run on AWS Cluster (8xA100 GPU):
```
python run_benchmark.py distributed --ngpus 8 --partition train --job_dir $PWD/.userbenchmark/distributed/logs
```

Output metrics json file:
```
{
    "name": "distributed",
    "environ": {
        "pytorch_git_version": "367ce697da444978ab49ed7426c1ffee57d1e88b"
    },
    "args": {
        "ngpus": 8,
        "nodes": 1,
        "timeout": 1440,
        "profiler": false,
        "partition": "train",
        "job_dir": "/data/home/xzhao9/benchmark/.userbenchmark/distributed/logs",
        "model": "torchbenchmark.e2e_models.hf_bert.Model",
        "trainer": "torchbenchmark.util.distributed.ddp.DDPTrainer",
        "dist_url": "file:///data/home/xzhao9/benchmark/.userbenchmark/distributed/logs/300741a6a31248b5af287dad433b9200_init",
        "output_dir": "/data/home/xzhao9/benchmark/.userbenchmark/distributed/logs"
    },
    "metrics": {
        "0-fwd_mean": 18.587260818481447,
        "0-fwd_stdev": 1.249975396652668,
        "0-bwd_mean": 22.979004859924316,
        "0-bwd_stdev": 0.17279135941652868,
        "0-opt_mean": 17.845138931274413,
        "0-opt_stdev": 0.10701804960748133,
        "1-fwd_mean": 14.643673610687255,
        "1-fwd_stdev": 0.12621190012201905,
        "1-bwd_mean": 31.684182357788085,
        "1-bwd_stdev": 1.6110578055095222,
        "1-opt_mean": 12.702611064910888,
        "1-opt_stdev": 0.11127842204111327,
        "2-fwd_mean": 13.7170880317688,
        "2-fwd_stdev": 0.3072370404256818,
        "2-bwd_mean": 33.75406379699707,
        "2-bwd_stdev": 1.2665815412703216,
        "2-opt_mean": 11.773264026641845,
        "2-opt_stdev": 0.08454682507453214,
        "3-fwd_mean": 13.955654430389405,
        "3-fwd_stdev": 0.28808249829358984,
        "3-bwd_mean": 33.470188522338866,
        "3-bwd_stdev": 1.2093597218183398,
        "3-opt_mean": 11.838454341888427,
        "3-opt_stdev": 0.13043112330328627,
        "4-fwd_mean": 14.69996166229248,
        "4-fwd_stdev": 2.096843783502309,
        "4-bwd_mean": 33.06722240447998,
        "4-bwd_stdev": 2.384150208768099,
        "4-opt_mean": 11.545113658905029,
        "4-opt_stdev": 0.17722284388649193,
        "5-fwd_mean": 14.81980791091919,
        "5-fwd_stdev": 0.1175716373064526,
        "5-bwd_mean": 32.68328037261963,
        "5-bwd_stdev": 1.3603798665482199,
        "5-opt_mean": 11.662390422821044,
        "5-opt_stdev": 0.06255000873065251,
        "6-fwd_mean": 14.148975849151611,
        "6-fwd_stdev": 0.10553216426892825,
        "6-bwd_mean": 33.048796844482425,
        "6-bwd_stdev": 1.3651520012370102,
        "6-opt_mean": 12.033942317962646,
        "6-opt_stdev": 0.039871346805974116,
        "7-fwd_mean": 14.514809608459473,
        "7-fwd_stdev": 0.7432848123236139,
        "7-bwd_mean": 31.55668125152588,
        "7-bwd_stdev": 1.5674374937909337,
        "7-opt_mean": 13.237116622924805,
        "7-opt_stdev": 1.2275919701313986
    }
}
```

This metrics output can be used to update the internal performance metrics dashboard to track performance.