### PR TITLE
Migrate the workflow to use the new torch-tensorrt package

### DIFF
--- a/.github/scripts/torch-trt.patch
+++ b/.github/scripts/torch-trt.patch
@@ -109,13 +109,13 @@ index 2779e93c..f1c59825 100644
 -#)
 +new_local_repository(
 +    name = "libtorch",
-+    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch/__init__.py",
++    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch",
 +    build_file = "third_party/libtorch/BUILD"
 +)
 +
 +new_local_repository(
 +    name = "libtorch_pre_cxx11_abi",
-+    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch/__init__.py",
++    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch",
 +    build_file = "third_party/libtorch/BUILD"
 +)
 +

--- a/.github/scripts/torch-trt.patch
+++ b/.github/scripts/torch-trt.patch
@@ -1,0 +1,287 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 2779e93c..64533f26 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -73,25 +73,25 @@ http_archive(
+ # Either place them in the distdir directory in third_party and use the --distdir flag
+ # or modify the urls to "file:///<PATH TO TARBALL>/<TARBALL NAME>.tar.gz
+ 
+-http_archive(
+-    name = "cudnn",
+-    build_file = "@//third_party/cudnn/archive:BUILD",
+-    sha256 = "0e5d2df890b9967efa6619da421310d97323565a79f05a1a8cb9b7165baad0d7",
+-    strip_prefix = "cuda",
+-    urls = [
+-        "https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.2.4/11.4_20210831/cudnn-11.4-linux-x64-v8.2.4.15.tgz",
+-    ],
+-)
++# http_archive(
++#     name = "cudnn",
++#     build_file = "@//third_party/cudnn/archive:BUILD",
++#     sha256 = "0e5d2df890b9967efa6619da421310d97323565a79f05a1a8cb9b7165baad0d7",
++#     strip_prefix = "cuda",
++#     urls = [
++#         "https://developer.nvidia.com/compute/machine-learning/cudnn/secure/8.2.4/11.4_20210831/cudnn-11.4-linux-x64-v8.2.4.15.tgz",
++#     ],
++# )
+ 
+-http_archive(
+-    name = "tensorrt",
+-    build_file = "@//third_party/tensorrt/archive:BUILD",
+-    sha256 = "826180eaaecdf9a7e76116855b9f1f3400ea9b06e66b06a3f6a0747ba6f863ad",
+-    strip_prefix = "TensorRT-8.2.4.2",
+-    urls = [
+-        "https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.2.4/tars/tensorrt-8.2.4.2.linux.x86_64-gnu.cuda-11.4.cudnn8.2.tar.gz",
+-    ],
+-)
++# http_archive(
++#     name = "tensorrt",
++#     build_file = "@//third_party/tensorrt/archive:BUILD",
++#     sha256 = "826180eaaecdf9a7e76116855b9f1f3400ea9b06e66b06a3f6a0747ba6f863ad",
++#     strip_prefix = "TensorRT-8.2.4.2",
++#     urls = [
++#         "https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/8.2.4/tars/tensorrt-8.2.4.2.linux.x86_64-gnu.cuda-11.4.cudnn8.2.tar.gz",
++#     ],
++# )
+ 
+ ####################################################################################
+ # Locally installed dependencies (use in cases of custom dependencies or aarch64)
+@@ -116,17 +116,17 @@ http_archive(
+ #    build_file = "third_party/libtorch/BUILD"
+ #)
+ 
+-#new_local_repository(
+-#    name = "cudnn",
+-#    path = "/usr/",
+-#    build_file = "@//third_party/cudnn/local:BUILD"
+-#)
++new_local_repository(
++    name = "cudnn",
++    path = "/usr/local/cuda",
++    build_file = "@//third_party/cudnn/local:BUILD"
++)
+ 
+-#new_local_repository(
+-#   name = "tensorrt",
+-#   path = "/usr/",
+-#   build_file = "@//third_party/tensorrt/local:BUILD"
+-#)
++new_local_repository(
++   name = "tensorrt",
++   path = "/data/shared/TensorRT",
++   build_file = "@//third_party/tensorrt/local:BUILD"
++)
+ 
+ # #########################################################################
+ # # Testing Dependencies (optional - comment out on aarch64)
+diff --git a/py/setup.py b/py/setup.py
+index 890a0e1e..1501a97e 100644
+--- a/py/setup.py
++++ b/py/setup.py
+@@ -101,6 +101,7 @@ def build_libtorchtrt_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=F
+         cmd.append("--platforms=//toolchains:jetpack_4.6")
+         print("Jetpack version: 4.6")
+ 
++    cmd.append("--strategy=CppCompile=standalone")
+     print("building libtorchtrt")
+     status_code = subprocess.run(cmd).returncode
+ 
+diff --git a/third_party/cudnn/local/BUILD b/third_party/cudnn/local/BUILD
+index c2ef7c6f..2d98fab1 100644
+--- a/third_party/cudnn/local/BUILD
++++ b/third_party/cudnn/local/BUILD
+@@ -30,7 +30,7 @@ cc_import(
+     shared_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libcudnn.so",
+         ":windows": "bin/cudnn64_7.dll",  #Need to configure specific version for windows
+-        "//conditions:default": "lib/x86_64-linux-gnu/libcudnn.so",
++        "//conditions:default": "lib64/libcudnn.so",
+     }),
+     visibility = ["//visibility:private"],
+ )
+diff --git a/third_party/tensorrt/local/BUILD b/third_party/tensorrt/local/BUILD
+index 7b4fcc28..e3996bd3 100644
+--- a/third_party/tensorrt/local/BUILD
++++ b/third_party/tensorrt/local/BUILD
+@@ -41,21 +41,21 @@ cc_library(
+             ],
+         ),
+         "//conditions:default": [
+-            "include/x86_64-linux-gnu/NvUtils.h",
++            "include/NvUtils.h",
+         ] + glob(
+             [
+-                "include/x86_64-linux-gnu/NvInfer*.h",
++                "include/NvInfer*.h",
+             ],
+             exclude = [
+-                "include/x86_64-linux-gnu/NvInferPlugin.h",
+-                "include/x86_64-linux-gnu/NvInferPluginUtils.h",
++                "include/NvInferPlugin.h",
++                "include/NvInferPluginUtils.h",
+             ],
+         ),
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -65,7 +65,7 @@ cc_import(
+     static_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvinfer_static.a",
+         ":windows": "lib/nvinfer.lib",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvinfer_static.a",
++        "//conditions:default": "lib/libnvinfer_static.a",
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -75,7 +75,7 @@ cc_import(
+     shared_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvinfer.so",
+         ":windows": "lib/nvinfer.dll",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvinfer.so",
++        "//conditions:default": "lib/libnvinfer.so",
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -101,7 +101,7 @@ cc_import(
+     shared_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvparsers.so",
+         ":windows": "lib/nvparsers.dll",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvparsers.so",
++        "//conditions:default": "lib/libnvparsers.so",
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -124,17 +124,17 @@ cc_library(
+             "include/NvUffParser.h",
+         ],
+         "//conditions:default": [
+-            "include/x86_64-linux-gnu/NvCaffeParser.h",
+-            "include/x86_64-linux-gnu/NvOnnxParser.h",
+-            "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
+-            "include/x86_64-linux-gnu/NvOnnxConfig.h",
+-            "include/x86_64-linux-gnu/NvUffParser.h",
++            "include/NvCaffeParser.h",
++            "include/NvOnnxParser.h",
++            "include/NvOnnxParserRuntime.h",
++            "include/NvOnnxConfig.h",
++            "include/NvUffParser.h",
+         ],
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -156,7 +156,7 @@ cc_import(
+     shared_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvonnxparser.so",
+         ":windows": "lib/nvonnxparser.dll",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvonnxparser.so",
++        "//conditions:default": "lib/libnvonnxparser.so",
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -175,15 +175,15 @@ cc_library(
+             "include/NvOnnxConfig.h",
+         ],
+         "//conditions:default": [
+-            "include/x86_64-linux-gnu/NvOnnxParser.h",
+-            "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
+-            "include/x86_64-linux-gnu/NvOnnxConfig.h",
++            "include/NvOnnxParser.h",
++            "include/NvOnnxParserRuntime.h",
++            "include/NvOnnxConfig.h",
+         ],
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -203,9 +203,9 @@ cc_library(
+ cc_import(
+     name = "nvonnxparser_runtime_lib",
+     shared_library = select({
+-        ":aarch64_linux": "lib/x86_64-linux-gnu/libnvonnxparser_runtime.so",
++        ":aarch64_linux": "lib/libnvonnxparser_runtime.so",
+         ":windows": "lib/nvonnxparser_runtime.dll",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvonnxparser_runtime.so",
++        "//conditions:default": "lib/libnvonnxparser_runtime.so",
+     }),
+     visibility = ["//visibility:public"],
+ )
+@@ -220,13 +220,13 @@ cc_library(
+             "include/NvOnnxParserRuntime.h",
+         ],
+         "//conditions:default": [
+-            "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
++            "include/NvOnnxParserRuntime.h",
+         ],
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -248,7 +248,7 @@ cc_import(
+     shared_library = select({
+         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvcaffe_parsers.so",
+         ":windows": "lib/nvcaffe_parsers.dll",
+-        "//conditions:default": "lib/x86_64-linux-gnu/libnvcaffe_parsers.so",
++        "//conditions:default": "lib/libnvcaffe_parsers.so",
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -263,13 +263,13 @@ cc_library(
+             "include/NvCaffeParser.h",
+         ],
+         "//conditions:default": [
+-            "include/x86_64-linux-gnu/NvCaffeParser.h",
++            "include/NvCaffeParser.h",
+         ],
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     visibility = ["//visibility:private"],
+ )
+@@ -291,17 +291,17 @@ cc_library(
+     hdrs = select({
+         ":aarch64_linux": glob(["include/aarch64-linux-gnu/NvInferPlugin*.h"]),
+         ":windows": glob(["include/NvInferPlugin*.h"]),
+-        "//conditions:default": glob(["include/x86_64-linux-gnu/NvInferPlugin*.h"]),
++        "//conditions:default": glob(["include/NvInferPlugin*.h"]),
+     }),
+     srcs = select({
+-        ":aarch64_linux": ["lib/aarch64-linux-gnu/libnvinfer_plugin.so"],
++        ":aarch64_linux": ["lib/libnvinfer_plugin.so"],
+         ":windows": ["lib/nvinfer_plugin.dll"],
+-        "//conditions:default": ["lib/x86_64-linux-gnu/libnvinfer_plugin.so"],
++        "//conditions:default": ["lib/libnvinfer_plugin.so"],
+     }),
+     includes = select({
+         ":aarch64_linux": ["include/aarch64-linux-gnu/"],
+         ":windows": ["include/"],
+-        "//conditions:default": ["include/x86_64-linux-gnu/"],
++        "//conditions:default": ["include/"],
+     }),
+     deps = [
+         "nvinfer",

--- a/.github/scripts/torch-trt.patch
+++ b/.github/scripts/torch-trt.patch
@@ -1,8 +1,42 @@
 diff --git a/WORKSPACE b/WORKSPACE
-index 2779e93c..64533f26 100644
+index 2779e93c..f1c59825 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -73,25 +73,25 @@ http_archive(
+@@ -53,45 +53,45 @@ new_local_repository(
+ # Tarballs and fetched dependencies (default - use in cases when building from precompiled bin and tarballs)
+ #############################################################################################################
+ 
+-http_archive(
+-    name = "libtorch",
+-    build_file = "@//third_party/libtorch:BUILD",
+-    sha256 = "8d9e829ce9478db4f35bdb7943308cf02e8a2f58cf9bb10f742462c1d57bf287",
+-    strip_prefix = "libtorch",
+-    urls = ["https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu113.zip"],
+-)
++# http_archive(
++#     name = "libtorch",
++#     build_file = "@//third_party/libtorch:BUILD",
++#     sha256 = "8d9e829ce9478db4f35bdb7943308cf02e8a2f58cf9bb10f742462c1d57bf287",
++#     strip_prefix = "libtorch",
++#     urls = ["https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu113.zip"],
++# )
+ 
+-http_archive(
+-    name = "libtorch_pre_cxx11_abi",
+-    build_file = "@//third_party/libtorch:BUILD",
+-    sha256 = "90159ecce3ff451f3ef3f657493b6c7c96759c3b74bbd70c1695f2ea2f81e1ad",
+-    strip_prefix = "libtorch",
+-    urls = ["https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.11.0%2Bcu113.zip"],
+-)
++# http_archive(
++#     name = "libtorch_pre_cxx11_abi",
++#     build_file = "@//third_party/libtorch:BUILD",
++#     sha256 = "90159ecce3ff451f3ef3f657493b6c7c96759c3b74bbd70c1695f2ea2f81e1ad",
++#     strip_prefix = "libtorch",
++#     urls = ["https://download.pytorch.org/libtorch/cu113/libtorch-shared-with-deps-1.11.0%2Bcu113.zip"],
++# )
+ 
+ # Download these tarballs manually from the NVIDIA website
  # Either place them in the distdir directory in third_party and use the --distdir flag
  # or modify the urls to "file:///<PATH TO TARBALL>/<TARBALL NAME>.tar.gz
  
@@ -46,26 +80,51 @@ index 2779e93c..64533f26 100644
  
  ####################################################################################
  # Locally installed dependencies (use in cases of custom dependencies or aarch64)
-@@ -116,17 +116,17 @@ http_archive(
- #    build_file = "third_party/libtorch/BUILD"
- #)
+@@ -104,29 +104,29 @@ http_archive(
+ # x86_64 python distribution. If using NVIDIA's version just point to the root of the package
+ # for both versions here and do not use --config=pre-cxx11-abi
  
+-#new_local_repository(
+-#    name = "libtorch",
+-#    path = "/usr/local/lib/python3.6/dist-packages/torch",
+-#    build_file = "third_party/libtorch/BUILD"
+-#)
+-
+-#new_local_repository(
+-#    name = "libtorch_pre_cxx11_abi",
+-#    path = "/usr/local/lib/python3.6/dist-packages/torch",
+-#    build_file = "third_party/libtorch/BUILD"
+-#)
+-
 -#new_local_repository(
 -#    name = "cudnn",
 -#    path = "/usr/",
 -#    build_file = "@//third_party/cudnn/local:BUILD"
 -#)
-+new_local_repository(
-+    name = "cudnn",
-+    path = "/usr/local/cuda",
-+    build_file = "@//third_party/cudnn/local:BUILD"
-+)
- 
+-
 -#new_local_repository(
 -#   name = "tensorrt",
 -#   path = "/usr/",
 -#   build_file = "@//third_party/tensorrt/local:BUILD"
 -#)
++new_local_repository(
++    name = "libtorch",
++    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch/__init__.py",
++    build_file = "third_party/libtorch/BUILD"
++)
++
++new_local_repository(
++    name = "libtorch_pre_cxx11_abi",
++    path = "/home/xzhao9/miniconda3/envs/backends-ci/lib/python3.8/site-packages/torch/__init__.py",
++    build_file = "third_party/libtorch/BUILD"
++)
++
++new_local_repository(
++    name = "cudnn",
++    path = "/usr/local/cuda",
++    build_file = "@//third_party/cudnn/local:BUILD"
++)
++
 +new_local_repository(
 +   name = "tensorrt",
 +   path = "/data/shared/TensorRT",

--- a/.github/workflows/benchmark-config.yml
+++ b/.github/workflows/benchmark-config.yml
@@ -75,8 +75,12 @@ jobs:
       - name: Install torch-tensorrt, TorchDynamo, and functorch
         run: |
           . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          conda install -y bazel
           pushd torch-tensorrt
+          patch -p1 < ../benchmark/.github/scripts/torch-trt.patch
+          pushd py
           python setup.py install
+          popd
           popd
           pushd torchdynamo
           python setup.py develop

--- a/.github/workflows/benchmark-config.yml
+++ b/.github/workflows/benchmark-config.yml
@@ -82,9 +82,13 @@ jobs:
           python setup.py install
           popd
           popd
+          # test torch-tensorrt
+          python -c "import torch_tensorrt; from torch_tensorrt.fx.lower import lower_to_trt"
           pushd torchdynamo
           python setup.py develop
           popd
+          # test torchdynamo
+          python -c "import torchdynamo"
           pushd functorch
           python setup.py install
           popd

--- a/.github/workflows/benchmark-config.yml
+++ b/.github/workflows/benchmark-config.yml
@@ -23,17 +23,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: benchmark
-      - name: Checkout fx2trt
+      - name: Checkout pytorch/tensorrt
         uses: actions/checkout@v2
         with:
-          repository: pytorch/fx2trt
-          path: fx2trt
-          token: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
-      - name: Checkout Torch-TensorRT
-        uses: actions/checkout@v2
-        with:
-          repository: NVIDIA/Torch-TensorRT
-          path: torch-trt
+          repository: pytorch/TensorRT
+          path: torch-tensorrt
       - name: Checkout TorchDynamo
         uses: actions/checkout@v2
         with:
@@ -78,10 +72,10 @@ jobs:
             -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
           # make sure pytorch+cuda works
           python -c "import torch; torch.cuda.init()"
-      - name: Install fx2trt, TorchDynamo, and functorch
+      - name: Install torch-tensorrt, TorchDynamo, and functorch
         run: |
           . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
-          pushd fx2trt
+          pushd torch-tensorrt
           python setup.py install
           popd
           pushd torchdynamo


### PR DESCRIPTION
fx2trt has been merged to pytorch/TensorRT, and we are updating the workflow file to use pytorch/TensorRT.
We need to patch pytorch/TensorRT to make sure it builds against PyTorch nightly release.