### PR TITLE
Update correctness checking code for fx2trt

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -27,7 +27,6 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         model.add_context(functools.partial(torchdynamo.optimize, EXTRA_BACKENDS[args.torchdynamo]))
     elif args.torchdynamo == "fx2trt" and precision == "fp16":
         model.add_context(functools.partial(torchdynamo.optimize, torchdynamo.optimizations.backends.fx2trt_compiler_fp16))
-        args.trt = True
     else:
         model.add_context(functools.partial(torchdynamo.optimize, args.torchdynamo))
     torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -27,6 +27,7 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         model.add_context(functools.partial(torchdynamo.optimize, EXTRA_BACKENDS[args.torchdynamo]))
     elif args.torchdynamo == "fx2trt" and precision == "fp16":
         model.add_context(functools.partial(torchdynamo.optimize, torchdynamo.optimizations.backends.fx2trt_compiler_fp16))
+        args.trt = True
     else:
         model.add_context(functools.partial(torchdynamo.optimize, args.torchdynamo))
     torchdynamo.reset()

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -104,9 +104,11 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             apply_opt_args(self, self.opt_args)
         # if test is eval, check correctness
         if self.need_correctness_check:
-            # if fp16 is used, use cosine similarity instead of torch.allclose
-            # because cosine similarity is more relaxed
-            if self.dargs.precision == "fp16":
+            # tensorrt or fp16 is known to generate less-accurate results
+            # in this case, use more relaxed cosine similarity instead of torch.allclose
+            # for correctness testing
+            # see: https://github.com/pytorch/torchdynamo/pull/438
+            if self.dargs.precision == "fp16" or self.dynamo == "fx2trt" or self.opt_args.fx2trt:
                 self.correctness = correctness_check(self, cos_sim=True, deepcopy=self.DEEPCOPY)
             else:
                 self.correctness = correctness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY)


### PR DESCRIPTION
TensorRT generates less accurate results in both FP32 and FP16 precisions. Therefore, we are using more relaxed cosine-similarity to check accuracy.