### PR TITLE
Add Dockerfile for building torchbench docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# base Dockerfile: PyTorch nightly docker
+# ghcr.io/pytorch:pytorch-nightly
+FROM ghcr.io/pytorch/pytorch-nightly:latest
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+# setup conda by default
+RUN /opt/conda/bin/conda clean -tipsy && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc
+
+RUN apt-get update
+RUN apt-get install -y git git-lfs jq
+
+RUN git clone https://github.com/pytorch/benchmark /workspace/benchmark
+# Clone conda env
+RUN conda create --name torchbench --clone base && \
+    echo "conda activate torchbench" >> ${HOME}/.bashrc
+
+# Run the setup
+RUN pushd /workspace/benchmark; python install.py
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,11 +11,15 @@ RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
 RUN apt-get update
 RUN apt-get install -y git git-lfs jq
 
+RUN git clone https://github.com/pytorch/functorch /workspace/functorch
+RUN git clone https://github.com/pytorch/torchdynamo /workspace/torchdynamo
 RUN git clone https://github.com/pytorch/benchmark /workspace/benchmark
+
 # Clone conda env
 RUN conda create --name torchbench --clone base && \
     echo "conda activate torchbench" >> ${HOME}/.bashrc
 
 # Run the setup
+RUN cd /workspace/functorch; python setup.py develop
+RUN cd /workspace/torchdynamo; python setup.py develop
 RUN cd /workspace/benchmark; python install.py
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,6 @@ RUN conda create --name torchbench --clone base && \
     echo "conda activate torchbench" >> ${HOME}/.bashrc
 
 # Run the setup
+RUN cd /workspace/benchmark; python install.py
 RUN cd /workspace/functorch; python setup.py develop
 RUN cd /workspace/torchdynamo; python setup.py develop
-RUN cd /workspace/benchmark; python install.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,7 @@ FROM ghcr.io/pytorch/pytorch-nightly:latest
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # setup conda by default
-RUN /opt/conda/bin/conda clean -tipsy && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc
 
 RUN apt-get update
@@ -18,5 +17,5 @@ RUN conda create --name torchbench --clone base && \
     echo "conda activate torchbench" >> ${HOME}/.bashrc
 
 # Run the setup
-RUN pushd /workspace/benchmark; python install.py
+RUN cd /workspace/benchmark; python install.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
-# base Dockerfile: PyTorch nightly docker
+# default base image: PyTorch nightly docker
 # ghcr.io/pytorch:pytorch-nightly
-FROM ghcr.io/pytorch/pytorch-nightly:latest
+ARG BASE_IMAGE=ghcr.io/pytorch/pytorch-nightly:latest
+FROM ${BASE_IMAGE}
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
@@ -19,6 +20,8 @@ RUN git clone https://github.com/pytorch/benchmark /workspace/benchmark
 RUN conda create --name torchbench --clone base && \
     echo "conda activate torchbench" >> ${HOME}/.bashrc
 
+# Uninstall domain packages if they pre-exist
+RUN pip uninstall -y functorch torchdynamo
 # Run the setup
 RUN cd /workspace/benchmark; python install.py
 RUN cd /workspace/functorch; python setup.py develop


### PR DESCRIPTION
@xwang233 
Build torchbench docker based on pytorch nightly docker.

Environment:
- python 3.8
- cuda 11.3
- pytorch latest nightly

This docker supports nvidia gpu passthrough, but users need to make sure their docker daemon is running with nvidia runtime.
It also bundles torchdynamo and functorch. We will add bundling to Torch-TensorRT and TensorRT later.

The command to build:
```
$ docker pull ghcr.io/pytorch/pytorch-nightly:latest
$ pushd docker
$ docker build . -t pytorch/benchmark:latest
```

The command to run:
```
$ docker run -it  --gpus all pytorch/benchmark:latest /bin/bash
(torchbench) root@5e76c95cb424:/workspace/benchmark#  cd /workspace/benchmark
(torchbench) root@5e76c95cb424:/workspace/benchmark# python run.py resnet18 -d cuda
Running eval method from resnet18 on cuda in eager mode.
GPU Time:              4.578 milliseconds
CPU Total Wall Time:   4.613 milliseconds
```
 
Fixes https://github.com/pytorch/benchmark/issues/984