### PR TITLE
Add more GPU metrics to DCGM monitor

### DIFF
--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -19,6 +19,9 @@ from components.model_analyzer.tb_dcgm_types.gpu_used_memory import GPUUsedMemor
 from components.model_analyzer.tb_dcgm_types.gpu_utilization import GPUUtilization
 from components.model_analyzer.tb_dcgm_types.gpu_power_usage import GPUPowerUsage
 from components.model_analyzer.tb_dcgm_types.gpu_fp32active import GPUFP32Active
+from components.model_analyzer.tb_dcgm_types.gpu_dram_active import GPUDRAMActive
+from components.model_analyzer.tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
+from components.model_analyzer.tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
 from components.model_analyzer.tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
 
 
@@ -40,8 +43,10 @@ class DCGMMonitor(Monitor):
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL,
         GPUPowerUsage: dcgm_fields.DCGM_FI_DEV_POWER_USAGE,
         GPUFP32Active: dcgm_fields.DCGM_FI_PROF_PIPE_FP32_ACTIVE,
-        GPUTensorActive: dcgm_fields.DCGM_FI_PROF_PIPE_TENSOR_ACTIVE
-# @Yueming todo: add more metrics here.
+        GPUTensorActive: dcgm_fields.DCGM_FI_PROF_PIPE_TENSOR_ACTIVE,
+        GPUDRAMActive: dcgm_fields.DCGM_FI_PROF_DRAM_ACTIVE,
+        GPUPCIERX: dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES,
+        GPUPCIETX: dcgm_fields.DCGM_FI_PROF_PCIE_TX_BYTES,
     }
 
     def __init__(self, gpus, frequency, metrics, dcgmPath=None):

--- a/components/model_analyzer/tb_dcgm_types/gpu_dram_active.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_dram_active.py
@@ -1,0 +1,93 @@
+from functools import total_ordering
+from .gpu_record import GPURecord
+
+
+@total_ordering
+class GPUDRAMActive(GPURecord):
+    """
+    GPU DRAM active record
+    """
+
+    tag = "gpu_dramactive"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the GPU metrtic
+        device_uuid : str
+            The  GPU device uuid this metric is associated
+            with.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        """
+        The function that is used to aggregate
+        this type of record
+        """
+
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Average " if aggregation_tag else "") + "GPU FP32 Active (%)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if
+        this record is less than
+        the other
+        """
+
+        return self.value() < other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return GPUDRAMActive(device_uuid=None,
+                              value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return GPUDRAMActive(device_uuid=None,
+                              value=(self.value() - other.value()))

--- a/components/model_analyzer/tb_dcgm_types/gpu_pcie_rx.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_pcie_rx.py
@@ -1,0 +1,93 @@
+from functools import total_ordering
+from .gpu_record import GPURecord
+
+
+@total_ordering
+class GPUPCIERX(GPURecord):
+    """
+    GPU PCIe RX Bytes record. It is supposed to be memory read traffic.
+    """
+
+    tag = "gpu_picerx"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the GPU metrtic
+        device_uuid : str
+            The  GPU device uuid this metric is associated
+            with.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        """
+        The function that is used to aggregate
+        this type of record
+        """
+
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Average " if aggregation_tag else "") + "GPU FP32 Active (%)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if
+        this record is less than
+        the other
+        """
+
+        return self.value() < other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return GPUPCIERX(device_uuid=None,
+                              value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return GPUPCIERX(device_uuid=None,
+                              value=(self.value() - other.value()))

--- a/components/model_analyzer/tb_dcgm_types/gpu_pcie_tx.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_pcie_tx.py
@@ -1,0 +1,93 @@
+from functools import total_ordering
+from .gpu_record import GPURecord
+
+
+@total_ordering
+class GPUPCIETX(GPURecord):
+    """
+    GPU PCIe TX Bytes record. It is supposed to be memory write traffic.
+    """
+
+    tag = "gpu_picetx"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the GPU metrtic
+        device_uuid : str
+            The  GPU device uuid this metric is associated
+            with.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def aggregation_function():
+        """
+        The function that is used to aggregate
+        this type of record
+        """
+
+        def average(seq):
+            return sum(seq[1:], start=seq[0]) / len(seq)
+
+        return average
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Average " if aggregation_tag else "") + "GPU FP32 Active (%)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if
+        this record is less than
+        the other
+        """
+
+        return self.value() < other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return GPUPCIETX(device_uuid=None,
+                              value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return GPUPCIETX(device_uuid=None,
+                              value=(self.value() - other.value()))

--- a/components/model_analyzer/tb_dcgm_types/record_aggregator.py
+++ b/components/model_analyzer/tb_dcgm_types/record_aggregator.py
@@ -172,6 +172,28 @@ class RecordAggregator:
                     aggregated_result[record_type]
         return groupby_result
 
+    def groupby_wo_aggregate(self, record_types, groupby_criterion):
+        """
+        Similar to groupby(). But this function will return raw grouped records rather aggrated record.
+        """
+
+        field_values = {
+            record_type: set([
+                groupby_criterion(record)
+                for record in self._records[record_type]
+            ]) for record_type in record_types
+        }
+        groupby_result = defaultdict(list)
+        for record_type in record_types:
+            groupby_result[record_type] = defaultdict(list)
+            for field_value in field_values[record_type]:
+                temp_records_aggregator = self.filter_records(
+                    record_types=[record_type],
+                    filters=[lambda r: groupby_criterion(r) == field_value ])
+                groupby_result[record_type][field_value] = temp_records_aggregator.get_records()
+        return groupby_result
+
+
     def record_types(self):
         """
         Returns

--- a/run.py
+++ b/run.py
@@ -224,7 +224,8 @@ if __name__ == "__main__":
             print("You have to specifiy --flops dcgm accompany with --export-dcgm-metrics")
             exit(-1)
         export_dcgm_metrics_file = "%s_all_metrics.csv" % args.model
-
+    else:
+        export_dcgm_metrics_file = False
     if args.profile:
         profile_one_step(test)
     elif args.cudastreams:

--- a/run.py
+++ b/run.py
@@ -231,10 +231,6 @@ if __name__ == "__main__":
     elif args.cudastreams:
         run_one_step_with_cudastreams(test, 10)
     else:
-<<<<<<< HEAD
-        run_one_step(test, model_flops=model_flops, model=m, export_all_records=args.export_all_records)
-=======
-        run_one_step(test, model_flops=model_flops, export_dcgm_metrics_file=export_dcgm_metrics_file)
->>>>>>> update parser argument
+        run_one_step(test, model_flops=model_flops, model=m, export_dcgm_metrics_file=export_dcgm_metrics_file)
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", m.correctness), sep='')

--- a/run.py
+++ b/run.py
@@ -54,7 +54,7 @@ def run_one_step_with_cudastreams(func, streamcount):
         print('{:<20} {:>20}'.format("GPU Time:", "%.3f milliseconds" % start_event.elapsed_time(end_event)), sep='')
 
 
-def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_all_records=False):
+def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_dcgm_metrics_file=False):
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
         func()
@@ -65,8 +65,8 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
         dcgm_enabled = True
         from components.model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
         model_analyzer = ModelAnalyzer()
-        if export_all_records:
-            model_analyzer.set_export_csv_name(export_all_records)
+        if export_dcgm_metrics_file:
+            model_analyzer.set_export_csv_name(export_dcgm_metrics_file)
             model_analyzer.add_mem_throughput_metrics()
         model_analyzer.start_monitor()
 
@@ -119,7 +119,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
         if dcgm_enabled:
             model_analyzer.aggregate()
             tflops = model_analyzer.calculate_flops()
-            if export_all_records:
+            if export_dcgm_metrics_file:
                 model_analyzer.export_all_records_to_csv()
         else:
             flops, batch_size = model_flops
@@ -187,8 +187,8 @@ if __name__ == "__main__":
                         help="Utilization test using increasing number of cuda streams.")
     parser.add_argument("--bs", type=int, help="Specify batch size to the test.")
     parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result.")
-    parser.add_argument("--export-all-records", type=str, action="store",
-                        help="Export all GPU FP32 unit active ratio, memory traffic, and memory throughput records to a csv file. The default csv file name is all_records.csv, and it could be specified by this option.")
+    parser.add_argument("--export-dcgm-metrics", action="store_true",
+                        help="Export all GPU FP32 unit active ratio, memory traffic, and memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
     args, extra_args = parser.parse_known_args()
 
     if args.cudastreams and not args.device == "cuda":
@@ -219,12 +219,21 @@ if __name__ == "__main__":
             from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
             if check_dcgm():
                 model_flops = 'dcgm'
-            
+    if args.export_dcgm_metrics:
+        if not args.flops:
+            print("You have to specifiy --flops dcgm accompany with --export-dcgm-metrics")
+            exit(-1)
+        export_dcgm_metrics_file = "%s_all_metrics.csv" % args.model
+
     if args.profile:
         profile_one_step(test)
     elif args.cudastreams:
         run_one_step_with_cudastreams(test, 10)
     else:
+<<<<<<< HEAD
         run_one_step(test, model_flops=model_flops, model=m, export_all_records=args.export_all_records)
+=======
+        run_one_step(test, model_flops=model_flops, export_dcgm_metrics_file=export_dcgm_metrics_file)
+>>>>>>> update parser argument
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", m.correctness), sep='')


### PR DESCRIPTION
## New GPU metrics
add support for the following GPU metrics,

- GPUDRAMActive: The ratio of cycles the device memory interface is active sending or receiving data.
- GPUPCIETX: The number of bytes of active PCIe tx (transmit) data including both header and payload. It is supposed to be device memory write traffic.
- GPUPCIERX: The number of bytes of active PCIe rx (read) data including both header and payload. It is supposed to be device memory read traffic.
## Export all records to csv file ordered by timestamp
Add a new argument `--export-dcgm-metrics` to export all GPU FP32 unit active ratio, memory traffic, and memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.


The final csv file could be be like the following.


timestamp(ms) | gpu_fp32active(%) | gpu_picerx(bytes) | gpu_picetx(bytes) | duration(ms) | read_throughput(GB/s) | write_throughput(GB/s)
-- | -- | -- | -- | -- | -- | --
0 | 0 | 17241379 | 155172413 | 0 |   |  
0.23 | 0 | 3164139 | 9492419 | 0.23 | 12.81 | 38.44
2.6 | 0 | 1131301 | 2036343 | 2.37 | 0.44 | 0.8
3.82 | 0 | 4206098 | 4588471 | 1.22 | 3.22 | 3.51

- `timestamp(ms)` is the timestamp for a record.
- `gpu_fp32active(%)` is the ratio of FP32 unit active cycles during this record
- `gpu_pcierx(bytes)` is how many bytes read from device memory
- `gpu_pcietx(bytes)` is how many bytes write to device memory
-  `duration(ms)` is how long this record monitors
- `read_throughput(GB/s)` is derived by `gpu_pcierx(bytes)` / `duration` *1000/1024/1024/1024
- `write_throughput(GB/s)` is derived by `gpu_pcietx(bytes)` / `duration` *1000/1024/1024/1024

We could easily generate a line chart by opening this file with google sheet or excel. 