### PR TITLE
Use sync-free cuda event timing in benchmark

### DIFF
--- a/run_sweep.py
+++ b/run_sweep.py
@@ -38,7 +38,7 @@ def run_one_step(func, device: str, nwarmup=WARMUP_ROUNDS, num_iter=20) -> Tuple
             t0 = time.time_ns()
             func()
             t1 = time.time_ns()
-        result_summary.append((t1 - t0) / NANOSECONDS_PER_MILLISECONDS)
+            result_summary.append((t1 - t0) / NANOSECONDS_PER_MILLISECONDS)
     
     if device != 'cuda':
         # return wall_latency

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -336,7 +336,6 @@ class ModelTask(base_task.TaskBase):
     def invoke(self) -> None:
         self.worker.run("""
             model.invoke()
-            maybe_sync()
         """)
 
     def set_eval(self) -> None:


### PR DESCRIPTION
This PR uses sync-free cuda event timing as suggested in https://github.com/pytorch/torchdynamo/issues/425#issuecomment-1163378442

See also https://github.com/pytorch/torchdynamo/issues/425