### PR TITLE
reorganize imports to make model_analyzer more independent.

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -1,24 +1,24 @@
 
 from typing import OrderedDict
-from components.model_analyzer.dcgm.dcgm_monitor import DCGMMonitor
-from components.model_analyzer.tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
-from components.model_analyzer.tb_dcgm_types.gpu_device_factory import GPUDeviceFactory
-from components.model_analyzer.dcgm import dcgm_fields
-from components.model_analyzer.dcgm.dcgm_structs import DCGMError
-from components.model_analyzer.tb_dcgm_types.gpu_tensoractive import GPUTensorActive
-from components.model_analyzer.tb_dcgm_types.gpu_utilization import GPUUtilization
-from components.model_analyzer.tb_dcgm_types.gpu_power_usage import GPUPowerUsage
-from components.model_analyzer.tb_dcgm_types.gpu_free_memory import GPUFreeMemory
-from components.model_analyzer.tb_dcgm_types.gpu_used_memory import GPUUsedMemory
-from components.model_analyzer.tb_dcgm_types.gpu_fp32active import GPUFP32Active
-from components.model_analyzer.tb_dcgm_types.gpu_dram_active import GPUDRAMActive
-from components.model_analyzer.tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
-from components.model_analyzer.tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
-from components.model_analyzer.tb_dcgm_types.record import RecordType
-from components.model_analyzer.tb_dcgm_types.record_aggregator import RecordAggregator
-from components.model_analyzer.tb_dcgm_types.tb_logger import set_logger, LOGGER_NAME
-from components.model_analyzer.tb_dcgm_types.config import *
-from components.model_analyzer.tb_dcgm_types.config import DEFAULT_MONITORING_INTERVAL
+from .dcgm.dcgm_monitor import DCGMMonitor
+from .tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
+from .tb_dcgm_types.gpu_device_factory import GPUDeviceFactory
+from .dcgm import dcgm_fields
+from .dcgm.dcgm_structs import DCGMError
+from .tb_dcgm_types.gpu_tensoractive import GPUTensorActive
+from .tb_dcgm_types.gpu_utilization import GPUUtilization
+from .tb_dcgm_types.gpu_power_usage import GPUPowerUsage
+from .tb_dcgm_types.gpu_free_memory import GPUFreeMemory
+from .tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from .tb_dcgm_types.gpu_fp32active import GPUFP32Active
+from .tb_dcgm_types.gpu_dram_active import GPUDRAMActive
+from .tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
+from .tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
+from .tb_dcgm_types.record import RecordType
+from .tb_dcgm_types.record_aggregator import RecordAggregator
+from .tb_dcgm_types.tb_logger import set_logger, LOGGER_NAME
+from .tb_dcgm_types.config import *
+from .tb_dcgm_types.config import DEFAULT_MONITORING_INTERVAL
 
 import logging
 logger = logging.getLogger(LOGGER_NAME)
@@ -38,8 +38,8 @@ class ModelAnalyzer:
         # the final metric results. Its format is {GPU_UUID: {GPUUtilization: }}
         # Example:
         # {'GPU-4177e846-1274-84e3-dcde': 
-        #   {<class 'components.model_analyzer.tb_dcgm_types.gpu_fp32active.GPUFP32Active'>: 
-        #      <components.model_analyzer.tb_dcgm_types.gpu_fp32active.GPUFP32Active object at 0x7f14bbae2280>
+        #   {<class '.tb_dcgm_types.gpu_fp32active.GPUFP32Active'>: 
+        #      <.tb_dcgm_types.gpu_fp32active.GPUFP32Active object at 0x7f14bbae2280>
         #   }
         #  }
         self.gpu_metric_value = {}

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 from .monitor import Monitor
-from components.model_analyzer.tb_dcgm_types.gpu_free_memory import GPUFreeMemory
-from components.model_analyzer.tb_dcgm_types.gpu_tensoractive import GPUTensorActive
-from components.model_analyzer.tb_dcgm_types.gpu_used_memory import GPUUsedMemory
-from components.model_analyzer.tb_dcgm_types.gpu_utilization import GPUUtilization
-from components.model_analyzer.tb_dcgm_types.gpu_power_usage import GPUPowerUsage
-from components.model_analyzer.tb_dcgm_types.gpu_fp32active import GPUFP32Active
-from components.model_analyzer.tb_dcgm_types.gpu_dram_active import GPUDRAMActive
-from components.model_analyzer.tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
-from components.model_analyzer.tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
-from components.model_analyzer.tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
+from ..tb_dcgm_types.gpu_free_memory import GPUFreeMemory
+from ..tb_dcgm_types.gpu_tensoractive import GPUTensorActive
+from ..tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from ..tb_dcgm_types.gpu_utilization import GPUUtilization
+from ..tb_dcgm_types.gpu_power_usage import GPUPowerUsage
+from ..tb_dcgm_types.gpu_fp32active import GPUFP32Active
+from ..tb_dcgm_types.gpu_dram_active import GPUDRAMActive
+from ..tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
+from ..tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
+from ..tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
 
 
 from . import dcgm_agent

--- a/components/model_analyzer/dcgm/monitor.py
+++ b/components/model_analyzer/dcgm/monitor.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from multiprocessing.pool import ThreadPool
 import time
 
-from components.model_analyzer.tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
+from ..tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
 
 
 

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -15,8 +15,8 @@
 # Logging
 LOGGER_NAME = "model_analyzer_logger"
 from .gpu_device import GPUDevice
-import components.model_analyzer.dcgm.dcgm_agent as dcgm_agent
-import components.model_analyzer.dcgm.dcgm_structs as structs
+from  ..dcgm import dcgm_agent as dcgm_agent
+from ..dcgm import dcgm_structs as structs
 from .da_exceptions import TorchBenchAnalyzerException
 
 import numba.cuda


### PR DESCRIPTION
From now, the model analyzer could be copied and imported more independently and easily.

To integrate model_analyzer to your own project, you can copy the folder https://github.com/pytorch/benchmark/tree/main/components/model_analyzer to your project, and follow the example below.

```python
from .model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
# create an instance
model_analyzer = ModelAnalyzer()
model_analyzer.set_export_csv_name("all_records.csv")
# FLOPS related gpu metric is enabled by default while others not
model_analyzer.add_mem_throughput_metrics()

# DCGM will be connected after this function
model_analyzer.start_monitor()
# your own code to profile
run_app()
# stop and aggregate the profiling results
model_analyzer.stop_monitor()
model_analyzer.aggregate()
model_analyzer.export_all_records_to_csv()
tflops = model_analyzer.calculate_flops()
print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
```