### PR TITLE
Add `--stress` option to `run.py`

### DIFF
--- a/run.py
+++ b/run.py
@@ -72,7 +72,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
     if stress != 0:
         cur_time = time.time_ns()
         start_time = cur_time
-        target_time = stress * 60 * 1e9 + start_time
+        target_time = stress * 1e9 + start_time
         num_iter = -1
         last_time = start_time
     _i = 0
@@ -106,10 +106,11 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
             result_summary.append([(t1 - t0) / 1_000_000])
         if stress != 0:
             cur_time = time.time_ns()
-            if (cur_time - last_time) >= 60 * 1e9:
-                est = (target_time - cur_time) / 60 / 1e9
+            # print out the status every 10s.
+            if (cur_time - last_time) >= 10 * 1e9:
+                est = (target_time - cur_time) / 1e9
                 print('{:<20} {:>20}'.format("Passed Iterations:", "%d" % _i))
-                print('{:<20} {:>20}'.format("Estimated Rest Time:", "%d minutes" % int(est)))
+                print('{:<20} {:>20}'.format("Estimated Rest Time:", "%d seconds" % int(est)))
                 last_time = cur_time
         _i += 1
     if dcgm_enabled:
@@ -203,7 +204,7 @@ if __name__ == "__main__":
     parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result.")
     parser.add_argument("--export-dcgm-metrics", action="store_true",
                         help="Export all GPU FP32 unit active ratio, memory traffic, and memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
-    parser.add_argument("--stress", type=float, default=0, help="Specify execution time (minutes) to stress devices.")
+    parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
     args, extra_args = parser.parse_known_args()
 
     if args.cudastreams and not args.device == "cuda":

--- a/run.py
+++ b/run.py
@@ -69,14 +69,14 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
             model_analyzer.set_export_csv_name(export_dcgm_metrics_file)
             model_analyzer.add_mem_throughput_metrics()
         model_analyzer.start_monitor()
-    if stress != 0:
+    if stress:
         cur_time = time.time_ns()
         start_time = cur_time
         target_time = stress * 1e9 + start_time
         num_iter = -1
         last_time = start_time
     _i = 0
-    while ( num_iter != -1 and _i < num_iter ) or ( stress != 0 and cur_time < target_time ) :
+    while (not stress and _i < num_iter ) or (stress and cur_time < target_time ) :
         if args.device == "cuda":
             torch.cuda.synchronize()
             start_event = torch.cuda.Event(enable_timing=True)
@@ -104,7 +104,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
             func()
             t1 = time.time_ns()
             result_summary.append([(t1 - t0) / 1_000_000])
-        if stress != 0:
+        if stress:
             cur_time = time.time_ns()
             # print out the status every 10s.
             if (cur_time - last_time) >= 10 * 1e9:


### PR DESCRIPTION
Add `--stress <seconds>` option to `run.py`. Users can specify a number of minutes to stress devices. 

Related to Issue https://github.com/pytorch/benchmark/issues/904