### PR TITLE
Fix slow tests on CPU

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -76,7 +76,7 @@ class Model(BenchmarkModel):
 
     def __init__(self, test, device, batch_size=None, jit=False, extra_args=[]):
         if device == "cpu":
-            self.DEFAULT_EVAL_BSIZE = self.DEFAULT_EVAL_BSIZE / 8
+            self.DEFAULT_EVAL_BSIZE = max(1, int(self.DEFAULT_EVAL_BSIZE / 8))
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         debug_print = False
         root = str(Path(__file__).parent)

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -75,6 +75,8 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 16
 
     def __init__(self, test, device, batch_size=None, jit=False, extra_args=[]):
+        if device == "cpu":
+            self.DEFAULT_EVAL_BSIZE = self.DEFAULT_EVAL_BSIZE / 8
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         debug_print = False
         root = str(Path(__file__).parent)

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -42,7 +42,7 @@ class Model(BenchmarkModel):
         # reduce the eval batch size when running on CPU
         # see: https://github.com/pytorch/benchmark/issues/895
         if device == "cpu":
-            self.DEFAULT_EVAL_BSIZE = 1
+            self.DEFAULT_EVAL_BSIZE = max(1, int(self.DEFAULT_EVAL_BSIZE / 8))
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
         self.parser = get_parser()

--- a/torchbenchmark/models/demucs/__init__.py
+++ b/torchbenchmark/models/demucs/__init__.py
@@ -39,6 +39,10 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 8
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]) -> None:
+        # reduce the eval batch size when running on CPU
+        # see: https://github.com/pytorch/benchmark/issues/895
+        if device == "cpu":
+            self.DEFAULT_EVAL_BSIZE = 1
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
         self.parser = get_parser()

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -87,9 +87,9 @@ class Model(BenchmarkModel):
             self.data = data_bundle.get_dataset('dev')
 
         example_inputs = DataSetIter(dataset=self.data,
-                                          batch_size=self.batch_size,
-                                          sampler=None,
-                                          num_workers=self.num_workers, drop_last=False)
+                                     batch_size=self.batch_size,
+                                     sampler=None,
+                                     num_workers=self.num_workers, drop_last=False)
         self.example_inputs = self._prefetch(example_inputs)
 
     def get_module(self):

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -50,6 +50,10 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 4
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        # reduce the eval batch size when running on CPU
+        # see: https://github.com/pytorch/benchmark/issues/895
+        if device == "cpu":
+            self.DEFAULT_EVAL_BSIZE = 1
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
         self.model = torchvision.models.detection.maskrcnn_resnet50_fpn(pretrained=True).to(self.device)

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -22,6 +22,8 @@ cpu_input_slice = {
     'hf_BigBird': 5,
     'hf_Longformer': 8,
     'hf_T5': 4,
+    'hf_GPT2': 4,
+    'hf_Reformer': 2,
 }
 
 class ArgsToKwargsWrapper(torch.nn.Module):


### PR DESCRIPTION
Partly address https://github.com/pytorch/benchmark/issues/895. Fix the slow cpu models https://github.com/pytorch/torchdynamo/blob/main/benchmarks/torchbench.py#L110. 

For some slow models, like fastNLP_Bert, we are already using batch size 1. In this case:
- if the input data is from real data set (e.g. fastNLP_Bert input is from CMRC2018, vision_maskrcnn is from COCO 2017), we do nothing
- if the input data is randomly generated, we reduce the size of inputs (e.g. hf_* models)

We will continue address this problem in a follow-up PR, where we will reduce CPU batch size to around 1/8 of GPU batch size.