### PR TITLE
Remove optimized_for_inference

### DIFF
--- a/gen_summary_metadata.py
+++ b/gen_summary_metadata.py
@@ -20,7 +20,6 @@ _DEFAULT_METADATA_ = {
     'eval_benchmark': True,
     'eval_deterministic': False,
     'eval_nograd': True,
-    'optimized_for_inference': False,
     # 'origin': None,
     # 'train_dtype': 'float32',
     # 'eval_dtype': 'float32',
@@ -106,8 +105,6 @@ def _maybe_override_extracted_details(args, extracted_details: List[Tuple[str, D
             ex_detail['eval_deterministic'] = args.eval_deterministic
         elif args.eval_nograd is not None:
             ex_detail['eval_nograd'] = args.eval_nograd
-        elif args.optimized_for_inference is not None:
-            ex_detail['optimized_for_inference'] = args.optimized_for_inference
 
 
 def _write_metadata_yaml_files(extracted_details: List[Tuple[str, Dict[str, Any]]]):
@@ -133,8 +130,6 @@ if __name__ == "__main__":
                         help="Whether to enable deterministic during eval.")
     parser.add_argument("--eval-nograd", default=None, type=_parser_helper,
                         help="Whether to enable no_grad during eval.")
-    parser.add_argument("--optimized-for-inference", default=None, type=_parser_helper,
-                        help="Whether to enable optimized_for_inference.")
     # parser.add_argument("--origin", default=None,
     #                     help="Location of benchmark's origin. Such as torchtext or torchvision.")
     # parser.add_argument("--train-dtype", default=None,

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -167,7 +167,6 @@ class ModelDetails:
     """
     path: str
     exists: bool
-    optimized_for_inference: bool
     _diagnostic_msg: str
 
     metadata: Dict[str, Any]
@@ -268,7 +267,6 @@ class ModelTask(base_task.TaskBase):
         return {
             "path": model_path,
             "exists": Model is not None,
-            "optimized_for_inference": hasattr(Model, "optimized_for_inference"),
             "_diagnostic_msg": diagnostic_msg,
             "metadata": {}
         }

--- a/torchbenchmark/models/BERT_pytorch/metadata.yaml
+++ b/torchbenchmark/models/BERT_pytorch/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/LearningToPaint/metadata.yaml
+++ b/torchbenchmark/models/LearningToPaint/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/Super_SloMo/metadata.yaml
+++ b/torchbenchmark/models/Super_SloMo/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/alexnet/metadata.yaml
+++ b/torchbenchmark/models/alexnet/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/__init__.py
@@ -29,7 +29,6 @@ torch.backends.cudnn.benchmark = False
 
 class Model(BenchmarkModel):
     task = NLP.TRANSLATION
-    optimized_for_inference = True
     # Original batch size 256, hardware platform unknown
     # Source: https://github.com/jadore801120/attention-is-all-you-need-pytorch/blob/132907dd272e2cc92e3c10e6c4e783a87ff8893d/README.md?plain=1#L83
     DEFAULT_TRAIN_BSIZE = 256

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/dcgan/metadata.yaml
+++ b/torchbenchmark/models/dcgan/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/demucs/metadata.yaml
+++ b/torchbenchmark/models/demucs/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/densenet121/metadata.yaml
+++ b/torchbenchmark/models/densenet121/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/dlrm/metadata.yaml
+++ b/torchbenchmark/models/dlrm/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/drq/metadata.yaml
+++ b/torchbenchmark/models/drq/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/fambench_dlrm/metadata.yaml
+++ b/torchbenchmark/models/fambench_dlrm/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/fambench_xlmr/metadata.yaml
+++ b/torchbenchmark/models/fambench_xlmr/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/fastNLP_Bert/metadata.yaml
+++ b/torchbenchmark/models/fastNLP_Bert/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/hf_Albert/metadata.yaml
+++ b/torchbenchmark/models/hf_Albert/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_Bart/metadata.yaml
+++ b/torchbenchmark/models/hf_Bart/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_Bert/metadata.yaml
+++ b/torchbenchmark/models/hf_Bert/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_BigBird/metadata.yaml
+++ b/torchbenchmark/models/hf_BigBird/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_DistilBert/metadata.yaml
+++ b/torchbenchmark/models/hf_DistilBert/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_GPT2/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_Longformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Longformer/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_Reformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Reformer/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/hf_T5/metadata.yaml
+++ b/torchbenchmark/models/hf_T5/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/maml/metadata.yaml
+++ b/torchbenchmark/models/maml/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/maml_omniglot/metadata.yaml
+++ b/torchbenchmark/models/maml_omniglot/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/mnasnet1_0/metadata.yaml
+++ b/torchbenchmark/models/mnasnet1_0/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/mobilenet_v2/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/mobilenet_v2_quantized_qat/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2_quantized_qat/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/moco/metadata.yaml
+++ b/torchbenchmark/models/moco/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
+++ b/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/opacus_cifar10/metadata.yaml
+++ b/torchbenchmark/models/opacus_cifar10/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/metadata.yaml
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/pytorch_stargan/__init__.py
+++ b/torchbenchmark/models/pytorch_stargan/__init__.py
@@ -21,7 +21,6 @@ def _prefetch(loader, size, collate_fn):
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.GENERATION
-    optimized_for_inference = True
 
     # Original train batch size: 16
     # Source: https://github.com/yunjey/stargan/blob/94dd002e93a2863d9b987a937b85925b80f7a19f/main.py#L73

--- a/torchbenchmark/models/pytorch_stargan/metadata.yaml
+++ b/torchbenchmark/models/pytorch_stargan/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/pytorch_struct/metadata.yaml
+++ b/torchbenchmark/models/pytorch_struct/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/pytorch_unet/metadata.yaml
+++ b/torchbenchmark/models/pytorch_unet/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: true
 not_implemented:

--- a/torchbenchmark/models/resnet18/metadata.yaml
+++ b/torchbenchmark/models/resnet18/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/resnet50/metadata.yaml
+++ b/torchbenchmark/models/resnet50/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/resnet50_quantized_qat/metadata.yaml
+++ b/torchbenchmark/models/resnet50_quantized_qat/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/resnext50_32x4d/metadata.yaml
+++ b/torchbenchmark/models/resnext50_32x4d/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/soft_actor_critic/metadata.yaml
+++ b/torchbenchmark/models/soft_actor_critic/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/speech_transformer/metadata.yaml
+++ b/torchbenchmark/models/speech_transformer/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/squeezenet1_1/metadata.yaml
+++ b/torchbenchmark/models/squeezenet1_1/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/tacotron2/metadata.yaml
+++ b/torchbenchmark/models/tacotron2/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/timm_efficientdet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientdet/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/timm_efficientnet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientnet/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/timm_regnet/metadata.yaml
+++ b/torchbenchmark/models/timm_regnet/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/timm_resnest/metadata.yaml
+++ b/torchbenchmark/models/timm_resnest/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/timm_vision_transformer/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/timm_vovnet/metadata.yaml
+++ b/torchbenchmark/models/timm_vovnet/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/tts_angular/metadata.yaml
+++ b/torchbenchmark/models/tts_angular/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/vgg16/metadata.yaml
+++ b/torchbenchmark/models/vgg16/metadata.yaml
@@ -1,6 +1,5 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -45,7 +45,6 @@ def _prefetch(loader, device):
 
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.DETECTION
-    optimized_for_inference = True
     DEFAULT_TRAIN_BSIZE = 4
     DEFAULT_EVAL_BSIZE = 4
 

--- a/torchbenchmark/models/vision_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/vision_maskrcnn/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: true
 train_benchmark: false
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/models/yolov3/metadata.yaml
+++ b/torchbenchmark/models/yolov3/metadata.yaml
@@ -1,7 +1,6 @@
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-optimized_for_inference: false
 train_benchmark: true
 train_deterministic: false
 not_implemented:

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -7,7 +7,6 @@ from .timm_config import TimmConfig
 from typing import Generator, Tuple, Optional
 
 class TimmModel(BenchmarkModel):
-    optimized_for_inference = True
     # To recognize this is a timm model
     TIMM_MODEL = True
     # These two variables should be defined by subclasses

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -6,7 +6,6 @@ from torchbenchmark.util.model import BenchmarkModel
 from typing import Tuple, Generator, Optional
 
 class TorchVisionModel(BenchmarkModel):
-    optimized_for_inference = True
     # To recognize this is a torchvision model
     TORCHVISION_MODEL = True
     # These two variables should be defined by subclasses

--- a/torchbenchmark/util/gen_torchvision_benchmarks.py
+++ b/torchbenchmark/util/gen_torchvision_benchmarks.py
@@ -25,7 +25,6 @@ from torchbenchmark.tasks import COMPUTER_VISION
 #######################################################
 class Model(BenchmarkModel):
     task = COMPUTER_VISION.CLASSIFICATION
-    optimized_for_inference = True
     def __init__(self, device=None, jit=False):
         super().__init__()
         self.device = device


### PR DESCRIPTION
Now we are enabling ofi for jit inference by default (https://github.com/pytorch/benchmark/blob/main/torchbenchmark/util/backends/jit.py#L4), so remove optimized_for_inference in metadata.