### PR TITLE
fix help message of test_bench.py

### DIFF
--- a/test_bench.py
+++ b/test_bench.py
@@ -2,7 +2,7 @@
 Runs hub models in benchmark mode using pytest-benchmark. Run setup separately first.
 
 Usage:
-  python test.py --setup_only
+  python install.py
   pytest test_bench.py
 
 See pytest-benchmark help (pytest test_bench.py -h) for additional options


### PR DESCRIPTION
README.md was edited by #133 but help message of test_bench.py is still saying `python test.py --setup_only`. 

Fixed it.