### PR TITLE
Support probing the best batch size for inference tests

### DIFF
--- a/run_sweep.py
+++ b/run_sweep.py
@@ -152,8 +152,8 @@ if __name__ == "__main__":
         else:
             r = _run_model_test(model_path, test, device, args.jit, batch_size=args.bs, extra_args=extra_args)
         results.append(r)
-    results = list(map(lambda x: dataclasses.asdict(x), results))
-    parent_dir = pathlib.Path(args.output).parent
-    parent_dir.mkdir(exist_ok=True, parents=True)
-    with open(args.output, "w") as outfile:
-        json.dump(results, outfile, indent=4)
+        results_to_export = list(map(lambda x: dataclasses.asdict(x), results))
+        parent_dir = pathlib.Path(args.output).parent
+        parent_dir.mkdir(exist_ok=True, parents=True)
+        with open(args.output, "w") as outfile:
+            json.dump(results_to_export, outfile, indent=4)

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -147,6 +147,9 @@ if __name__ == "__main__":
     for element in itertools.product(*[args.models, args.tests, args.devices]):
         model_path, test, device = element
         if args.proper_bs:
+            if test != 'eval':
+                print("Error: Only batch size of eval test is tunable.")
+                sys.exit(1)
             from scripts.proper_bs import _run_model_test_proper_bs
             r = _run_model_test_proper_bs(model_path, test, device, args.jit, batch_size=args.bs, extra_args=extra_args)
         else:

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -140,12 +140,17 @@ if __name__ == "__main__":
     parser.add_argument("-b", "--bs", type=int, help="Specify batch size.")
     parser.add_argument("--jit", action='store_true', help="Turn on torchscript.")
     parser.add_argument("-o", "--output", type=str, default="tb-output.json", help="The default output json file.")
+    parser.add_argument("--proper-bs", action='store_true', help="Find the best batch_size for current devices.")
     args, extra_args = parser.parse_known_args()
     args.models = _list_model_paths(args.models)
     results = []
     for element in itertools.product(*[args.models, args.tests, args.devices]):
         model_path, test, device = element
-        r = _run_model_test(model_path, test, device, args.jit, batch_size=args.bs, extra_args=extra_args)
+        if args.proper_bs:
+            from scripts.proper_bs import _run_model_test_proper_bs
+            r = _run_model_test_proper_bs(model_path, test, device, args.jit, batch_size=args.bs, extra_args=extra_args)
+        else:
+            r = _run_model_test(model_path, test, device, args.jit, batch_size=args.bs, extra_args=extra_args)
         results.append(r)
     results = list(map(lambda x: dataclasses.asdict(x), results))
     parent_dir = pathlib.Path(args.output).parent

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -19,6 +19,7 @@ def run_one_step_flops(func, device: str, nwarmup=WARMUP_ROUNDS, num_iter=10, fl
     if flops:
         model_analyzer = ModelAnalyzer()
         model_analyzer.start_monitor()
+        model_analyzer.set_monitoring_interval(0.01)
     for _i in range(num_iter):
         if device == "cuda":
             torch.cuda.synchronize()
@@ -54,7 +55,8 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
     error_message: Optional[str] = None
     result.results['details'] = []
     task = ModelTask(os.path.basename(model_path), timeout=WORKER_TIMEOUT)
-    for batch_size_exp in range(8):
+    MAX_EXP = 30
+    for batch_size_exp in range(MAX_EXP):
         batch_size = 2 ** batch_size_exp
         try:
             print(f"Batch Size {batch_size} ", end='')

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -63,6 +63,8 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
                 status = "NotExist"
                 return
             task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+            if task.get_model_attribute("ALLOW_CUSTOMIZE_BSIZE") == False:
+                raise ValueError(f"Model does not support tuning batch size")
             result.precision = task.get_model_attribute("dargs", "precision")
             # Check the batch size in the model matches the specified value
             if batch_size and (not task.get_model_attribute(bs_name) == batch_size):
@@ -82,6 +84,9 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
             error_message = str(e)
         except KeyboardInterrupt as e:
             status = "UserInterrupted"
+            error_message = str(e)
+        except ValueError as e:
+            status = "ValueError"
             error_message = str(e)
         except Exception as e:
             status = f"{type(e).__name__}"

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -54,7 +54,7 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
     error_message: Optional[str] = None
     result.results['details'] = []
     task = ModelTask(os.path.basename(model_path), timeout=WORKER_TIMEOUT)
-    for batch_size in range(1, 4):
+    for batch_size in range(1, 128):
         try:
             print(f"Batch Size {batch_size} ", end='')
             latency_ms_cur = 0

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -1,0 +1,100 @@
+import pathlib
+import torch
+from typing import Optional, List, Tuple
+from torchbenchmark import ModelTask
+import os
+import sys
+import time
+import numpy
+from components.model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
+from run_sweep import WORKER_TIMEOUT, WARMUP_ROUNDS, ModelTestResult, NANOSECONDS_PER_MILLISECONDS
+
+
+def run_one_step_flops(func, device: str, nwarmup=WARMUP_ROUNDS, num_iter=10, flops=True) -> Tuple[float, float, Optional[Tuple[torch.Tensor]]]:
+    "Run one step of the model, and return the latency in milliseconds."
+    # Warm-up `nwarmup` rounds
+    for _i in range(nwarmup):
+        func()
+    result_summary = []
+    if flops:
+        model_analyzer = ModelAnalyzer()
+        model_analyzer.start_monitor()
+    for _i in range(num_iter):
+        if device == "cuda":
+            torch.cuda.synchronize()
+            # Collect time_ns() instead of time() which does not provide better precision than 1
+            # second according to https://docs.python.org/3/library/time.html#time.time.
+            t0 = time.time_ns()
+            func()
+            torch.cuda.synchronize()  # Wait for the events to be recorded!
+            t1 = time.time_ns()
+        else:
+            t0 = time.time_ns()
+            func()
+            t1 = time.time_ns()
+        result_summary.append((t1 - t0) / NANOSECONDS_PER_MILLISECONDS)
+    if flops:
+        model_analyzer.stop_monitor()
+        model_analyzer.aggregate()
+        tflops = model_analyzer.calculate_flops()
+        
+    wall_latency = numpy.median(result_summary)
+    return (wall_latency, tflops)
+
+def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, jit: bool, batch_size: Optional[int], extra_args: List[str]) -> ModelTestResult:
+    assert test == "train" or test == "eval", f"Test must be either 'train' or 'eval', but get {test}."
+    result = ModelTestResult(name=model_path.name, test=test, device=device, extra_args=extra_args, batch_size=None, precision="fp32",
+                             status="OK", results={})
+
+    # Run the benchmark test in a separate process
+    print(f"Running model {model_path.name} ... ", flush=True)
+    status: str = "OK"
+    bs_name = "batch_size"
+    correctness_name = "correctness"
+    error_message: Optional[str] = None
+    result.results['details'] = []
+    task = ModelTask(os.path.basename(model_path), timeout=WORKER_TIMEOUT)
+    for batch_size in range(1, 4):
+        try:
+            print(f"Batch Size {batch_size} ", end='')
+            latency_ms_cur = 0
+            if not task.model_details.exists:
+                status = "NotExist"
+                return
+            task.make_model_instance(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+            result.precision = task.get_model_attribute("dargs", "precision")
+            # Check the batch size in the model matches the specified value
+            if batch_size and (not task.get_model_attribute(bs_name) == batch_size):
+                raise ValueError(f"User specify batch size {batch_size}, but model {result.name} runs with batch size {task.get_model_attribute(bs_name)}. Please report a bug.")
+            latency_ms_cur, tflops_cur = run_one_step_flops(task.invoke, device)
+            latency_ms_cur = latency_ms_cur / batch_size
+            result.results['details'].append({'batch_size': batch_size, "latency_ms": latency_ms_cur, "tflops": tflops_cur})
+            # if the model provides eager eval result, save it for cosine similarity
+            correctness = task.get_model_attribute(correctness_name)
+            if correctness is not None:
+                result.results[correctness_name] = correctness
+        except NotImplementedError as e:
+            status = "NotImplemented"
+            error_message = str(e)
+        except TypeError as e: # TypeError is raised when the model doesn't support variable batch sizes
+            status = "TypeError"
+            error_message = str(e)
+        except KeyboardInterrupt as e:
+            status = "UserInterrupted"
+            error_message = str(e)
+        except Exception as e:
+            status = f"{type(e).__name__}"
+            error_message = str(e)
+        finally:
+            print(f"[ {status} ]")
+            result.status = status
+            if error_message:
+                result.results["error_message"] = error_message
+            if status == "UserInterrupted":
+                sys.exit(1)
+            if status != 'OK':
+                return result
+    # find the best case
+    result.results['optimal_latency_bs'] = min(result.results['details'], key=lambda x:x['latency_ms'])['batch_size']
+    result.results['optimal_tflops_bs'] = max(result.results['details'], key=lambda x:x['tflops'])['batch_size']
+    return result

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -100,10 +100,8 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
                 sys.exit(1)
             if status != 'OK':
                 if result.results['details']:
-                    result.results['optimal_latency_bs'] = min(result.results['details'], key=lambda x:x['latency_ms'])['batch_size']
                     result.results['optimal_tflops_bs'] = max(result.results['details'], key=lambda x:x['tflops'])['batch_size']
                 return result
     # find the best case
-    result.results['optimal_latency_bs'] = min(result.results['details'], key=lambda x:x['latency_ms'])['batch_size']
     result.results['optimal_tflops_bs'] = max(result.results['details'], key=lambda x:x['tflops'])['batch_size']
     return result

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -54,7 +54,8 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
     error_message: Optional[str] = None
     result.results['details'] = []
     task = ModelTask(os.path.basename(model_path), timeout=WORKER_TIMEOUT)
-    for batch_size in range(1, 128):
+    for batch_size_exp in range(8):
+        batch_size = 2 ** batch_size_exp
         try:
             print(f"Batch Size {batch_size} ", end='')
             latency_ms_cur = 0

--- a/scripts/proper_bs.py
+++ b/scripts/proper_bs.py
@@ -99,6 +99,9 @@ def _run_model_test_proper_bs(model_path: pathlib.Path, test: str, device: str, 
             if status == "UserInterrupted":
                 sys.exit(1)
             if status != 'OK':
+                if result.results['details']:
+                    result.results['optimal_latency_bs'] = min(result.results['details'], key=lambda x:x['latency_ms'])['batch_size']
+                    result.results['optimal_tflops_bs'] = max(result.results['details'], key=lambda x:x['tflops'])['batch_size']
                 return result
     # find the best case
     result.results['optimal_latency_bs'] = min(result.results['details'], key=lambda x:x['latency_ms'])['batch_size']


### PR DESCRIPTION
Add proper_bs to find the best batch_size for current devices.

Users can specify `--proper_bs` for `run_sweep.py` to enable this feature. 

The final output file will contains details and optimal batch_size in the `results` section like the following.

```json
        "results": {
            "details": [
                {
                    "batch_size": 1,
                    "latency_ms": 49.924044499999994,
                    "tflops": 0.726485308717901
                },
                {
                    "batch_size": 2,
                    "latency_ms": 26.455478749999997,
                    "tflops": 1.4638535345863946
                },
                {
                    "batch_size": 3,
                    "latency_ms": 19.817013499999998,
                    "tflops": 1.8383686961789516
                }
            ],
            "optimal_latency_bs": 3,
            "optimal_tflops_bs": 3
        }
```


