### PR TITLE
fix explanations for PCIERX/PCIETX

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -50,6 +50,8 @@ class ModelAnalyzer:
         self.export_csv_name = ''
 
     def add_mem_throughput_metrics(self):
+        # Note that this is from the perspective of the GPU, 
+        # so copying data from device to host (DtoH) / host to device (HtoD) would be reflected in the below two metrics.
         self.gpu_metrics.append(GPUPCIERX)
         self.gpu_metrics.append(GPUPCIETX)
 
@@ -138,9 +140,9 @@ class ModelAnalyzer:
                     fout.write(tmp_line)
                 fout.write("duration(ms), ")
                 if GPUPCIERX in self.gpu_metrics:
-                    fout.write("read_throughput(GB/s), ")
+                    fout.write("HtoD_throughput(GB/s), ")
                 if GPUPCIETX in self.gpu_metrics:
-                    fout.write("write_throughput(GB/s), ")
+                    fout.write("DtoH_throughput(GB/s), ")
                 timestamps = list(timestamps)
                 timestamps.sort()
                 timestamp_start = timestamps[0]

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -37,6 +37,7 @@ class DCGMMonitor(Monitor):
     """
 
     # Mapping between the DCGM Fields and Model Analyzer Records
+    # For more explainations, please refer to https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html
     model_analyzer_to_dcgm_field = {
         GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
         GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,

--- a/components/model_analyzer/readme.md
+++ b/components/model_analyzer/readme.md
@@ -1,0 +1,51 @@
+# How to enable TorchBench Analyzer in pytorch/benchmark?
+TorchBench Analyzer has been merged to the main branch after Jun 1, 2022 .
+
+To enable its FLOPS computation capability, you have to add
+```bash
+--flops dcgm
+```
+to the argument list when you run run.py.
+
+The last part in the final output of pytorch/benchmark looks like the following.
+```bash
+GPU Time:             12.097 milliseconds
+CPU Total Wall Time:  12.137 milliseconds
+FLOPS:               1.9684 TFLOPs per second
+```
+To enable its detailed GPU metric records export capability, you have to add
+```bash
+--flops dcgm --export-dcgm-metrics
+```
+to the argument list when you run run.py. The metrics will be output to [model_name]_all_metrics.csv automatically.
+
+
+# How to integrate TorchBench Analyzer into your project?
+The following code snippet shows the basic usage of TorchBench Analyzer. TorchBench Analyzer is integrated into pytorch/benchmark. If you want to use it to test your own function, the only thing you need to do is copy the whole folder pytorch/benchmark/components/model_analyzer to your project and code like the following.
+
+```python
+from model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
+
+def work():
+    # A simple mm test 
+    import torch
+    n=4096
+    x = torch.ones((n, n), dtype=torch.float32, device="cuda")
+    y = torch.ones((n, n),dtype=torch.float32, device="cuda")
+
+    # configure model analyzer
+    model_analyzer = ModelAnalyzer()
+    model_analyzer.start_monitor()
+
+    # run your own code
+    for i in range(200):
+        if i % 100 == 0:
+            print(i)
+        torch.mm(x, y)
+    
+    # stop and aggregate the profiling results
+    model_analyzer.stop_monitor()
+    model_analyzer.aggregate()
+    tflops = model_analyzer.calculate_flops()
+    print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
+```

--- a/components/model_analyzer/tb_dcgm_types/gpu_pcie_rx.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_pcie_rx.py
@@ -5,7 +5,8 @@ from .gpu_record import GPURecord
 @total_ordering
 class GPUPCIERX(GPURecord):
     """
-    GPU PCIe RX Bytes record. It is supposed to be memory read traffic.
+    GPU PCIe RX Bytes record. The number of bytes of active PCIe rx (read) data including both header and payload.
+    Note that this is from the perspective of the GPU, so copying data from host to device (HtoD) would be reflected in this metric.
     """
 
     tag = "gpu_picerx"

--- a/components/model_analyzer/tb_dcgm_types/gpu_pcie_tx.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_pcie_tx.py
@@ -5,7 +5,8 @@ from .gpu_record import GPURecord
 @total_ordering
 class GPUPCIETX(GPURecord):
     """
-    GPU PCIe TX Bytes record. It is supposed to be memory write traffic.
+    GPU PCIe TX Bytes record. The number of bytes of active PCIe tx (transmit) data including both header and payload.
+    Note that this is from the perspective of the GPU, so copying data from device to host (DtoH) would be reflected in this metric.
     """
 
     tag = "gpu_picetx"

--- a/components/model_analyzer/test.py
+++ b/components/model_analyzer/test.py
@@ -2,7 +2,7 @@
 This is a test file for TorchBenchAnalyzer
 """
 
-from .TorchBenchAnalyzer import ModelAnalyzer
+from model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
 
 def work():
     # A simple mm test 
@@ -24,7 +24,8 @@ def work():
     # stop and aggregate the profiling results
     model_analyzer.stop_monitor()
     model_analyzer.aggregate()
-    model_analyzer.print_flops()
+    tflops = model_analyzer.calculate_flops()
+    print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     parser.add_argument("--bs", type=int, help="Specify batch size to the test.")
     parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result.")
     parser.add_argument("--export-dcgm-metrics", action="store_true",
-                        help="Export all GPU FP32 unit active ratio, memory traffic, and memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
+                        help="Export all GPU FP32 unit active ratio, CPU-GPU memory traffic, and CPU-GPU memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
     parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
     args, extra_args = parser.parse_known_args()
 


### PR DESCRIPTION
The previous explanations of `dcgm_fields.DCGM_FI_PROF_PCIE_TX_BYTES` and `dcgm_fields.DCGM_FI_PROF_PCIE_RX_BYTES` are wrong. Those two metrics refer CPU-GPU interactive memory traffic. 

This PR also update the example code and add a readme file for TorchBench model analyzer.