### PR TITLE
fix a printout bug; remove default memory monitoring

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -49,11 +49,6 @@ class ModelAnalyzer:
         self.gpu_record_aggregator = RecordAggregator()
         self.export_csv_name = ''
 
-    def add_mem_throughput_metrics(self):
-        # Note that this is from the perspective of the GPU, 
-        # so copying data from device to host (DtoH) / host to device (HtoD) would be reflected in the below two metrics.
-        self.gpu_metrics.append(GPUPCIERX)
-        self.gpu_metrics.append(GPUPCIETX)
 
     def set_export_csv_name(self, export_csv_name=''):
         self.export_csv_name = export_csv_name

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -137,6 +137,8 @@ class ModelAnalyzer:
                         tmp_line = "%s, " % (record_type.tag + '(%)')
                     elif record_type.tag.startswith('gpu_pice'):
                         tmp_line = "%s, " % (record_type.tag + '(bytes)')
+                    else:
+                        tmp_line = "%s, " % record_type.tag
                     fout.write(tmp_line)
                 fout.write("duration(ms), ")
                 if GPUPCIERX in self.gpu_metrics:

--- a/run.py
+++ b/run.py
@@ -67,7 +67,6 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
         model_analyzer = ModelAnalyzer()
         if export_dcgm_metrics_file:
             model_analyzer.set_export_csv_name(export_dcgm_metrics_file)
-            model_analyzer.add_mem_throughput_metrics()
         model_analyzer.start_monitor()
     if stress:
         cur_time = time.time_ns()
@@ -208,7 +207,7 @@ if __name__ == "__main__":
     parser.add_argument("--bs", type=int, help="Specify batch size to the test.")
     parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result.")
     parser.add_argument("--export-dcgm-metrics", action="store_true",
-                        help="Export all GPU FP32 unit active ratio, CPU-GPU memory traffic, and CPU-GPU memory throughput records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
+                        help="Export all GPU FP32 unit active ratio records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
     parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
     args, extra_args = parser.parse_known_args()
 


### PR DESCRIPTION
When adding more metrics rather than FP32Active and PCIERX/TX, the final output head will be duplicated `gpu_fp32active`. It is caused by missing else-branch to catch the other metrics.

Since we get more clear understanding of PCIERX/TX metrics, I think they are not so attractive and it's better to remove them from default configurations.