### PR TITLE
Make it easier to add more backends

### DIFF
--- a/torchbenchmark/util/backends/__init__.py
+++ b/torchbenchmark/util/backends/__init__.py
@@ -1,0 +1,37 @@
+"""
+Utils for managing backends
+"""
+import functools
+
+BACKENDS = dict()
+
+def create_backend(fn):
+    @functools.wraps(fn)
+    def inner(model: 'torchbenchmark.util.model.BenchmarkModel', **kwargs):
+        if model is None:
+            return None
+
+        try:
+            fn(model, **kwargs)
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            print(f"{fn.__name__} error: {e}")
+            return None
+
+    BACKENDS[fn.__name__] = inner
+    return inner
+
+def list_backends():
+    """
+    Return valid strings that can be passed to:
+        @torchdynamo.optimize(<backend>)
+        def foo(...):
+           ....
+    """
+    return sorted(BACKENDS.keys())
+
+# register the backends
+from .jit import torchscript
+
+__all__ = [list_backends, create_backend ]

--- a/torchbenchmark/util/backends/__init__.py
+++ b/torchbenchmark/util/backends/__init__.py
@@ -17,7 +17,7 @@ def create_backend(fn):
             raise
         except Exception as e:
             print(f"{fn.__name__} error: {e}")
-            return None
+            raise
 
     BACKENDS[fn.__name__] = inner
     return inner

--- a/torchbenchmark/util/backends/jit.py
+++ b/torchbenchmark/util/backends/jit.py
@@ -24,8 +24,6 @@ def torchscript(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args:
         module = torch.jit._script_pdt(module, example_inputs=[example_inputs, ])
     else:
         module = torch.jit.script(module, example_inputs=[example_inputs, ])
-    print(backend_args)
-    print(args)
     if model.test == "eval" and not args.no_ofi:
         module = torch.jit.optimize_for_inference(module)
     model.set_module(module)

--- a/torchbenchmark/util/backends/jit.py
+++ b/torchbenchmark/util/backends/jit.py
@@ -13,17 +13,17 @@ def parse_torchscript_args(args) -> argparse.Namespace:
 
 @create_backend
 def torchscript(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: List[str]):
-    # customized jit callback function
     model.jit = True
     args = parse_torchscript_args(backend_args)
+    # customized jit callback function
     if hasattr(model, 'jit_callback'):
         model.jit_callback()
-        return
-    module, example_inputs = model.get_module()
-    if hasattr(torch.jit, '_script_pdt'):
-        module = torch.jit._script_pdt(module, example_inputs=[example_inputs, ])
     else:
-        module = torch.jit.script(module, example_inputs=[example_inputs, ])
+        module, example_inputs = model.get_module()
+        if hasattr(torch.jit, '_script_pdt'):
+            module = torch.jit._script_pdt(module, example_inputs=[example_inputs, ])
+        else:
+            module = torch.jit.script(module, example_inputs=[example_inputs, ])
     if model.test == "eval" and not args.no_ofi:
         module = torch.jit.optimize_for_inference(module)
     model.set_module(module)

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -1,7 +1,8 @@
 import argparse
 from typing import List, Optional, Tuple
+from torchbenchmark.util.backends import list_backends, BACKENDS
+
 from torchbenchmark.util.backends.fx2trt import enable_fx2trt
-from torchbenchmark.util.backends.jit import enable_jit
 from torchbenchmark.util.backends.torch_trt import enable_torchtrt
 
 def check_correctness_p(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: argparse.Namespace) -> bool:
@@ -104,12 +105,14 @@ def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dar
 # Dispatch arguments based on model type
 def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=list_backends(), help="enable backends")
     parser.add_argument("--fx2trt", action='store_true', help="enable fx2trt")
     parser.add_argument("--fuser", type=str, default="", choices=["fuser0", "fuser1", "fuser2"], help="enable fuser")
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     parser.add_argument("--flops", choices=["model", "dcgm"], help="Return the flops result")
-    args = parser.parse_args(opt_args)
-    args.jit = model.jit
+    args, extra_args = parser.parse_known_args(opt_args)
+    if model.jit:
+        args.backend = "torchscript"
     if model.device == "cpu" and args.fuser:
         raise NotImplementedError("Fuser only works with GPU.")
     if not (model.device == "cuda" and model.test == "eval"):
@@ -117,20 +120,19 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
             raise NotImplementedError("TensorRT only works for CUDA inference tests.")
     if is_torchvision_model(model):
         args.cudagraph = False
-    return args
+    return args, extra_args
 
-def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):
+def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace, extra_args: List[str]):
+    if args.backend:
+        backend = BACKENDS[args.backend]
+        args_dict = vars(args).copy()
+        args_dict['--extra-args'] = extra_args
+        # transform the model using the specified backend
+        backend(model, kwargs=args_dict)
+        return
     if args.fuser:
         import torch
         model.add_context(lambda: torch.jit.fuser(args.fuser))
-    if args.jit:
-        # model can handle jit code themselves through the 'jit_callback' callback function
-        if hasattr(model, 'jit_callback'):
-            model.jit_callback()
-        else:
-            # if model doesn't have customized jit code, use the default jit script code
-            module, exmaple_inputs = model.get_module()
-            model.set_module(enable_jit(model=module, example_inputs=exmaple_inputs, test=model.test))
     if args.fx2trt:
         if args.jit:
             raise NotImplementedError("fx2trt with JIT is not available.")

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -125,11 +125,10 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
 def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace, extra_args: List[str]):
     if args.backend:
         backend = BACKENDS[args.backend]
-        args_dict = vars(args).copy()
-        args_dict['--extra-args'] = extra_args
         # transform the model using the specified backend
-        backend(model, kwargs=args_dict)
+        backend(model, backend_args=extra_args)
         return
+    assert not extra_args, f"Exptected no unknown args at this point, found {extra_args}"
     if args.fuser:
         import torch
         model.add_context(lambda: torch.jit.fuser(args.fuser))

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -89,7 +89,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.opt_args = parse_torchdynamo_args(self, opt_args)
         else:
             self.dynamo = False
-            self.opt_args = parse_opt_args(self, opt_args)
+            self.opt_args, self.extra_args = parse_opt_args(self, opt_args)
         should_check_correctness = check_correctness_p(self, self.opt_args)
         if should_check_correctness:
             self.eager_output = stableness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY, rounds=1)
@@ -100,7 +100,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             from torchbenchmark.util.backends.torchdynamo import apply_torchdynamo_args
             apply_torchdynamo_args(self, self.opt_args, self.dargs.precision)
         else:
-            apply_opt_args(self, self.opt_args)
+            apply_opt_args(self, self.opt_args, self.extra_args)
         if should_check_correctness:
             # tensorrt or fp16 is known to generate less-accurate results
             # in this case, use more relaxed cosine similarity instead of torch.allclose


### PR DESCRIPTION
This PR makes it easier to add more backends. Fixes https://github.com/pytorch/benchmark/issues/1046
To add a new backend:
 
1. create a file, say `jit.py`, in https://github.com/pytorch/benchmark/tree/main/torchbenchmark/util/backends.
2. In the file, create a function, say `def torchsript(model, backend_args)`, to transform the model using your backend, or add run contexts to it.
3. In https://github.com/pytorch/benchmark/blob/5a857e97721019eb0aa622976a8ac378cd4f2fbb/torchbenchmark/util/backends/__init__.py#L35, register your backend with import, e.g., `from .jit import torchscript`.

You can now try your own backend with your own backend:
`python run.py <model-name> --backend <backend-name> <backend-options`, for example:
```
$ python run.py resnet50 --backend torchscript
CPU Total Wall Time: 667.329 milliseconds
Correctness:                         True
$ python run.py resnet50 --backend torchscript --no-ofi
CPU Total Wall Time: 1633.694 milliseconds
Correctness:                         True
```
