### PR TITLE
shorten output format

### DIFF
--- a/.github/scripts/bmutils/summarize.py
+++ b/.github/scripts/bmutils/summarize.py
@@ -81,12 +81,12 @@ def find_result_by_header(r, header, base_arg):
             return "N/A"
     elif tp == "latency":
         if is_ok(r[args]):
-            return r[args]["results"]["latency_ms"]
+            return round(r[args]["results"]["latency_ms"], 3)
         else:
             return r[args]["status"]
     elif tp == "speedup":
         if is_ok(r[base_arg]) and is_ok(r[args]):
-            return round(r[base_arg]["results"]["latency_ms"] / r[args]["results"]["latency_ms"], 2)
+            return round(r[base_arg]["results"]["latency_ms"] / r[args]["results"]["latency_ms"], 3)
         else:
             return "N/A"
     else:

--- a/.github/scripts/bmutils/summarize.py
+++ b/.github/scripts/bmutils/summarize.py
@@ -86,7 +86,7 @@ def find_result_by_header(r, header, base_arg):
             return r[args]["status"]
     elif tp == "speedup":
         if is_ok(r[base_arg]) and is_ok(r[args]):
-            return r[base_arg]["results"]["latency_ms"] / r[args]["results"]["latency_ms"]
+            return round(r[base_arg]["results"]["latency_ms"] / r[args]["results"]["latency_ms"], 2)
         else:
             return "N/A"
     else:

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -106,7 +106,6 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         num_batches = task.get_model_attribute("NUM_BATCHES")
         if num_batches:
             result.results["latency_ms"] = result.results["latency_ms"] / num_batches
-        result.results["latency_ms"] = round(result.results["latency_ms"], 3)
         # if the model provides eager eval result, save it for cosine similarity
         correctness = task.get_model_attribute(correctness_name)
         if correctness is not None:

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -106,6 +106,7 @@ def _run_model_test(model_path: pathlib.Path, test: str, device: str, jit: bool,
         num_batches = task.get_model_attribute("NUM_BATCHES")
         if num_batches:
             result.results["latency_ms"] = result.results["latency_ms"] / num_batches
+        result.results["latency_ms"] = round(result.results["latency_ms"], 3)
         # if the model provides eager eval result, save it for cosine similarity
         correctness = task.get_model_attribute(correctness_name)
         if correctness is not None:


### PR DESCRIPTION
Currently, the output results are too long when three or more backends run together. So we can shorten this output format.