### PR TITLE
Fix eval batch size on Nvidia A100 40GB

### DIFF
--- a/run.py
+++ b/run.py
@@ -220,13 +220,13 @@ if __name__ == "__main__":
     if not Model:
         print(f"Unable to find model matching {args.model}.")
         exit(-1)
-    print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode.")
     # build the model and get the chosen test method
     if args.flops:
         extra_args.append("--flops")
         extra_args.append(args.flops)
 
     m = Model(device=args.device, test=args.test, jit=(args.mode == "jit"), batch_size=args.bs, extra_args=extra_args)
+    print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode with input batch size {m.batch_size}.")
 
     test = m.invoke
     model_flops = None

--- a/scripts/update_device_batch_size.py
+++ b/scripts/update_device_batch_size.py
@@ -1,0 +1,44 @@
+import argparse
+import pathlib
+import yaml
+
+CORE_MODEL_PATH = pathlib.Path(__file__).parent.parent.absolute().joinpath("torchbenchmark", "models")
+
+def get_model_list():
+    models = list(map(lambda x: x.name, filter(lambda x: x.is_dir(), CORE_MODEL_PATH.iterdir())))
+    return models
+
+def check_csv_file(csv_file, known_models):
+    optimial_bsizes = {}
+    with open(csv_file, "r") as cf:
+        opt_csv = cf.readlines()
+    for line in opt_csv:
+        model, bsize = line.split(",")
+        bsize = int(bsize)
+        if not bsize == 0:
+            optimial_bsizes[model] = bsize
+        assert model in known_models, f"Model {model} is not covered in TorchBench core model list."
+    return optimial_bsizes
+
+def update_model_optimal_bsizes(device, new_bsize, known_models):
+    # get the metadata of exist model
+    for model in new_bsize:
+        metadata_path = CORE_MODEL_PATH.joinpath(model).joinpath("metadata.yaml")
+        with open(metadata_path, "r") as mp:
+            metadata = yaml.safe_load(mp)
+        if not "devices" in metadata or device not in metadata["devices"]:
+            metadata["devices"] = {}
+            metadata["devices"][device] = {}
+            metadata["devices"][device]["eval_batch_size"] = new_bsize[model]
+        with open(metadata_path, "w") as mp:
+            yaml.safe_dump(metadata, mp)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", required=True, type=str, help="Name of the device")
+    parser.add_argument("--optimal-bsize-csv", required=True, type=str, help="Optimal Batchsize CSV file")
+    args = parser.parse_args()
+
+    known_models = get_model_list()
+    new_bsize = check_csv_file(args.optimal_bsize_csv, known_models)
+    update_model_optimal_bsizes(args.device, new_bsize, known_models)

--- a/torchbenchmark/models/BERT_pytorch/metadata.yaml
+++ b/torchbenchmark/models/BERT_pytorch/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/BERT_pytorch/metadata.yaml
+++ b/torchbenchmark/models/BERT_pytorch/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 256
+    eval_batch_size: 32
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/LearningToPaint/metadata.yaml
+++ b/torchbenchmark/models/LearningToPaint/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4096
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: true
 train_deterministic: false
-not_implemented:
-  # Model LearningToPaint doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/LearningToPaint/metadata.yaml
+++ b/torchbenchmark/models/LearningToPaint/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 4096
+    eval_batch_size: 256
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/Super_SloMo/metadata.yaml
+++ b/torchbenchmark/models/Super_SloMo/metadata.yaml
@@ -1,11 +1,12 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
+not_implemented:
+- device: cpu
+- device: cuda
+  test: eval
 train_benchmark: false
 train_deterministic: true
-not_implemented:
-  # Disabled due to excessively slow runtime - see GH Issue #100
-  - device: cpu
-  # Disabled eval test due to insufficient GPU memory size on CI
-  - device: cuda
-    test: eval

--- a/torchbenchmark/models/Super_SloMo/metadata.yaml
+++ b/torchbenchmark/models/Super_SloMo/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true

--- a/torchbenchmark/models/alexnet/metadata.yaml
+++ b/torchbenchmark/models/alexnet/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8192
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/alexnet/metadata.yaml
+++ b/torchbenchmark/models/alexnet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8192
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/dcgan/metadata.yaml
+++ b/torchbenchmark/models/dcgan/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 32768
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/dcgan/metadata.yaml
+++ b/torchbenchmark/models/dcgan/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 32768
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/demucs/metadata.yaml
+++ b/torchbenchmark/models/demucs/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 64
+    eval_batch_size: 32
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/demucs/metadata.yaml
+++ b/torchbenchmark/models/demucs/metadata.yaml
@@ -1,15 +1,15 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 64
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+  test: train
+- device: cuda
+  test: train
+- device: cuda
+  test: eval
 train_benchmark: true
 train_deterministic: false
-not_implemented:
-  # Disable CPU training because it is too slow (> 1min)
-  - test: train
-    device: cpu
-  # Disable GPU training because it causes CUDA OOM on T4
-  - test: train
-    device: cuda
-  # Disable GPU inference because it causes CUDA OOM on T4
-  - test: eval
-    device: cuda

--- a/torchbenchmark/models/densenet121/metadata.yaml
+++ b/torchbenchmark/models/densenet121/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 256
+    eval_batch_size: 64
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/densenet121/metadata.yaml
+++ b/torchbenchmark/models/densenet121/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cuda
+- device: cpu
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # CUDA disabled due to CUDA out of memory on CI GPU
-  - device: cuda
-  # CPU disabled due to out of memory on CI CPU
-  - device: cpu

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 4
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 4
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 32
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 32
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fcos_r_50_fpn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 2
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 4
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # disable CPU tests because it is too slow
-  - device: cpu
-  # detectron2_maskrcnn doesn't support torchscript (JIT)
-  - jit: true

--- a/torchbenchmark/models/dlrm/metadata.yaml
+++ b/torchbenchmark/models/dlrm/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: true
-not_implemented:
-  # dlrm model doesn't support jit
-  - jit: true

--- a/torchbenchmark/models/fambench_xlmr/metadata.yaml
+++ b/torchbenchmark/models/fambench_xlmr/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 64
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/fambench_xlmr/metadata.yaml
+++ b/torchbenchmark/models/fambench_xlmr/metadata.yaml
@@ -1,9 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cuda
+  test: train
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # Disable CUDA train test because of insufficient GPU memory on CI machine
-  - test: train
-    device: cuda

--- a/torchbenchmark/models/fastNLP_Bert/metadata.yaml
+++ b/torchbenchmark/models/fastNLP_Bert/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 128
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true

--- a/torchbenchmark/models/fastNLP_Bert/metadata.yaml
+++ b/torchbenchmark/models/fastNLP_Bert/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: true
-not_implemented:
-  # FastNLP-Bert model does not support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Albert/metadata.yaml
+++ b/torchbenchmark/models/hf_Albert/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 128
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_Albert/metadata.yaml
+++ b/torchbenchmark/models/hf_Albert/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_Albert model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Bart/metadata.yaml
+++ b/torchbenchmark/models/hf_Bart/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 64
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_Bart/metadata.yaml
+++ b/torchbenchmark/models/hf_Bart/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 64
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_Bart model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Bert/metadata.yaml
+++ b/torchbenchmark/models/hf_Bert/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_Bert model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Bert/metadata.yaml
+++ b/torchbenchmark/models/hf_Bert/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 128
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_BigBird/metadata.yaml
+++ b/torchbenchmark/models/hf_BigBird/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_BigBird/metadata.yaml
+++ b/torchbenchmark/models/hf_BigBird/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_BigBird model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_DistilBert/metadata.yaml
+++ b/torchbenchmark/models/hf_DistilBert/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 128
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_DistilBert/metadata.yaml
+++ b/torchbenchmark/models/hf_DistilBert/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_DistilBert model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_GPT2/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 32
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_GPT2 model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_GPT2/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 32
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_Longformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Longformer/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_Longformer model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Longformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Longformer/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_Reformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Reformer/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 32
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_Reformer model doesn't support JIT
-  - jit: true

--- a/torchbenchmark/models/hf_Reformer/metadata.yaml
+++ b/torchbenchmark/models/hf_Reformer/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 32
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_T5/metadata.yaml
+++ b/torchbenchmark/models/hf_T5/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/hf_T5/metadata.yaml
+++ b/torchbenchmark/models/hf_T5/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
+- test: train
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # hf_T5 model doesn't support JIT
-  - jit: true
-  # disable train test because of CI infra capacity issue
-  - test: train

--- a/torchbenchmark/models/mnasnet1_0/metadata.yaml
+++ b/torchbenchmark/models/mnasnet1_0/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 512
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/mnasnet1_0/metadata.yaml
+++ b/torchbenchmark/models/mnasnet1_0/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 512
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/mobilenet_v2/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/mobilenet_v2/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 256
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 512
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 512
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/moco/metadata.yaml
+++ b/torchbenchmark/models/moco/metadata.yaml
@@ -1,8 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
+- device: cpu
 train_benchmark: true
 train_deterministic: false
-not_implemented:
-  - jit: true
-  - device: cpu

--- a/torchbenchmark/models/moco/metadata.yaml
+++ b/torchbenchmark/models/moco/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 128
+    eval_batch_size: 64
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
+++ b/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
@@ -1,7 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8192
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  - jit: true

--- a/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
+++ b/torchbenchmark/models/nvidia_deeprecommender/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8192
+    eval_batch_size: 512
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/opacus_cifar10/metadata.yaml
+++ b/torchbenchmark/models/opacus_cifar10/metadata.yaml
@@ -1,7 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8192
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  - jit: true

--- a/torchbenchmark/models/opacus_cifar10/metadata.yaml
+++ b/torchbenchmark/models/opacus_cifar10/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8192
+    eval_batch_size: 512
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16777216
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_equation_of_state/metadata.yaml
@@ -1,6 +1,3 @@
-devices:
-  NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16777216
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 67108864
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/metadata.yaml
@@ -1,6 +1,3 @@
-devices:
-  NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 67108864
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/pytorch_unet/metadata.yaml
+++ b/torchbenchmark/models/pytorch_unet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true

--- a/torchbenchmark/models/pytorch_unet/metadata.yaml
+++ b/torchbenchmark/models/pytorch_unet/metadata.yaml
@@ -1,8 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
 eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
+not_implemented:
+- jit: true
+  test: eval
 train_benchmark: false
 train_deterministic: true
-not_implemented:
-  - jit: true
-    test: eval

--- a/torchbenchmark/models/resnet18/metadata.yaml
+++ b/torchbenchmark/models/resnet18/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/resnet18/metadata.yaml
+++ b/torchbenchmark/models/resnet18/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/resnet50/metadata.yaml
+++ b/torchbenchmark/models/resnet50/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 256
+    eval_batch_size: 64
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/resnet50/metadata.yaml
+++ b/torchbenchmark/models/resnet50/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/resnext50_32x4d/metadata.yaml
+++ b/torchbenchmark/models/resnext50_32x4d/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 256
+    eval_batch_size: 64
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/resnext50_32x4d/metadata.yaml
+++ b/torchbenchmark/models/resnext50_32x4d/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/speech_transformer/metadata.yaml
+++ b/torchbenchmark/models/speech_transformer/metadata.yaml
@@ -1,8 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
+- device: cpu
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  - jit: true
-  - device: cpu

--- a/torchbenchmark/models/squeezenet1_1/metadata.yaml
+++ b/torchbenchmark/models/squeezenet1_1/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/squeezenet1_1/metadata.yaml
+++ b/torchbenchmark/models/squeezenet1_1/metadata.yaml
@@ -1,7 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- test: train
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  - test: train

--- a/torchbenchmark/models/tacotron2/metadata.yaml
+++ b/torchbenchmark/models/tacotron2/metadata.yaml
@@ -1,12 +1,12 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cuda
+- device: cpu
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # Disable CUDA test because of insufficient GPU memory on CI machine
-  - device: cuda
-  # CPU is not supported
-  - device: cpu
-  # JIT is not supported
-  - jit: true

--- a/torchbenchmark/models/timm_efficientdet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientdet/metadata.yaml
@@ -1,10 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16384
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cuda
+- device: cpu
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # Disable CUDA test because of insufficient GPU memory on CI machine
-  - device: cuda
-  # CPU is not supported
-  - device: cpu

--- a/torchbenchmark/models/timm_efficientdet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientdet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 16384
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_efficientnet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientnet/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_efficientnet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientnet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -1,9 +1,11 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- evice: cuda
+  test: train
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # Disable CUDA train test because of insufficient GPU memory on CI machine
-  - test: train
-    evice: cuda

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_regnet/metadata.yaml
+++ b/torchbenchmark/models/timm_regnet/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 32
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_resnest/metadata.yaml
+++ b/torchbenchmark/models/timm_resnest/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 2048
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_resnest/metadata.yaml
+++ b/torchbenchmark/models/timm_resnest/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 2048
+    eval_batch_size: 256
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_vision_transformer/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_vision_transformer/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_vovnet/metadata.yaml
+++ b/torchbenchmark/models/timm_vovnet/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1024
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/timm_vovnet/metadata.yaml
+++ b/torchbenchmark/models/timm_vovnet/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 1024
+    eval_batch_size: 128
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/tts_angular/metadata.yaml
+++ b/torchbenchmark/models/tts_angular/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8192
+    eval_batch_size: 512
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/tts_angular/metadata.yaml
+++ b/torchbenchmark/models/tts_angular/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 8192
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: true
 train_deterministic: false
-not_implemented:
-  # tts-angular model does not support JIT
-  - jit: true

--- a/torchbenchmark/models/vgg16/metadata.yaml
+++ b/torchbenchmark/models/vgg16/metadata.yaml
@@ -1,3 +1,6 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 512
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/vgg16/metadata.yaml
+++ b/torchbenchmark/models/vgg16/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 512
+    eval_batch_size: 8
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/models/vision_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/vision_maskrcnn/metadata.yaml
@@ -1,8 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- jit: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  # JIT is not supported by this model
-  - jit: true

--- a/torchbenchmark/models/yolov3/metadata.yaml
+++ b/torchbenchmark/models/yolov3/metadata.yaml
@@ -1,11 +1,12 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 64
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
+not_implemented:
+- device: cpu
+  test: train
+- jit: true
 train_benchmark: true
 train_deterministic: false
-not_implemented:
-  # Disabled due to excessively slow runtime - see GH Issue #100
-  - test: train
-    device: cpu
-  # yolov3 model doesn't support scripting
-  - jit: True

--- a/torchbenchmark/models/yolov3/metadata.yaml
+++ b/torchbenchmark/models/yolov3/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 64
+    eval_batch_size: 8
 eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -64,7 +64,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             f"Test must be 'train' or 'eval', but get {self.test}. Please submit a bug report."
         self.device = device
         self.jit = jit
-        self.batch_size = self.determine_batch_size(batch_size)
+        self.determine_batch_size(batch_size)
         self.extra_args = extra_args
         # contexts to run in the test function
         self.run_contexts = []

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -3,7 +3,10 @@ import torch
 from contextlib import contextmanager, ExitStack
 import warnings
 import inspect
+import yaml
+from pathlib import Path
 from typing import ContextManager, Optional, List, Tuple, Generator
+from torchbenchmark import REPO_PATH
 from torchbenchmark.util.extra_args import check_correctness_p, parse_opt_args, apply_opt_args, \
                                            parse_decoration_args, apply_decoration_args
 from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check
@@ -55,23 +58,13 @@ class BenchmarkModel(metaclass=PostInitProcessor):
     See [Adding Models](#../models/ADDING_MODELS.md)
     """
     def __init__(self, test: str, device: str, jit: bool=False, batch_size: Optional[int]=None, extra_args: List[str]=[]):
+        self.metadata = self.load_metadata()
         self.test = test
-        assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but get {self.test}. Please submit a bug report."
+        assert self.test == "train" or self.test == "eval", \
+            f"Test must be 'train' or 'eval', but get {self.test}. Please submit a bug report."
         self.device = device
         self.jit = jit
-        self.batch_size = batch_size
-        if not self.batch_size:
-            self.batch_size = self.DEFAULT_TRAIN_BSIZE if test == "train" else self.DEFAULT_EVAL_BSIZE
-            # If the model doesn't implement test or eval test
-            # its DEFAULT_TRAIN_BSIZE or DEFAULT_EVAL_BSIZE will still be None
-            if not self.batch_size:
-                raise NotImplementedError(f"Test {test} is not implemented.")
-        # Check if customizing batch size is supported
-        if hasattr(self, "ALLOW_CUSTOMIZE_BSIZE") and (not getattr(self, "ALLOW_CUSTOMIZE_BSIZE")):
-            if test == "train" and (not self.batch_size == self.DEFAULT_TRAIN_BSIZE):
-                raise NotImplementedError("Model doesn't support customizing batch size.")
-            elif test == "eval" and (not self.batch_size == self.DEFAULT_EVAL_BSIZE):
-                raise NotImplementedError("Model doesn't support customizing batch size.")
+        self.batch_size = self.determine_batch_size(batch_size)
         self.extra_args = extra_args
         # contexts to run in the test function
         self.run_contexts = []
@@ -117,6 +110,35 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.set_module(apply_trainer(module, self.dargs.distributed))
         if self.test == "cuda":
             torch.cuda.empty_cache()
+
+    def determine_batch_size(self, batch_size=None):
+        # batch size priority for eval tests: not ALLOW_CUSTOMIZE_BSIZE > user specified > device specified > default
+        # batch size priority for train tests: not ALLOW_CUSTOMIZE_BSIZE > user specified > default
+        if not batch_size:
+            self.batch_size = self.DEFAULT_TRAIN_BSIZE if self.test == "train" else self.DEFAULT_EVAL_BSIZE
+            # use the device suggestion on CUDA inference tests
+            if self.test == "eval" and self.device == "cuda":
+                current_device_name = torch.cuda.get_device_name()
+                assert current_device_name, f"torch.cuda.get_device_name() returns None when device is set to cuda, please double check."
+                if "devices" in self.metadata and current_device_name in self.metadata["devices"]:
+                    self.batch_size = self.metadata["devices"][current_device_name]["eval_batch_size"]
+            # If the model doesn't implement test or eval test
+            # its DEFAULT_TRAIN_BSIZE or DEFAULT_EVAL_BSIZE will still be None
+            if not self.batch_size:
+                raise NotImplementedError(f"Test {self.test} is not implemented.")
+        # Check if specified batch size is supported by the model
+        if hasattr(self, "ALLOW_CUSTOMIZE_BSIZE") and (not getattr(self, "ALLOW_CUSTOMIZE_BSIZE")):
+            if self.test == "train" and (not self.batch_size == self.DEFAULT_TRAIN_BSIZE):
+                raise NotImplementedError("Model doesn't support customizing batch size.")
+            elif self.test == "eval" and (not self.batch_size == self.DEFAULT_EVAL_BSIZE):
+                raise NotImplementedError("Model doesn't support customizing batch size.")
+
+    def load_metadata(self):
+        relative_path = self.__class__.__module__.split(".")
+        metadata_loc = Path(REPO_PATH).joinpath(*relative_path).joinpath("metadata.yaml")
+        with open(metadata_loc, "r") as mf:
+            metadata = yaml.safe_load(mf)
+        return metadata
 
     def add_context(self, context_fn):
         ctx = context_fn()


### PR DESCRIPTION
Use `torch.cuda.device_name()` to specify the eval batch size on GPU devices.