### PR TITLE
Fix DLRM batch size argument to be mini_batch_size

### DIFF
--- a/torchbenchmark/models/dlrm/__init__.py
+++ b/torchbenchmark/models/dlrm/__init__.py
@@ -38,8 +38,8 @@ from torchbenchmark.tasks import RECOMMENDATION
 
 class Model(BenchmarkModel):
     task = RECOMMENDATION.RECOMMENDATION
-    DEFAULT_TRAIN_BSIZE = 1000
-    DEFAULT_EVAL_BSIZE = 1000
+    DEFAULT_TRAIN_BSIZE = 2048
+    DEFAULT_EVAL_BSIZE = 2048
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
@@ -51,8 +51,8 @@ class Model(BenchmarkModel):
         arch_mlp_bot = "512-512-64"
         arch_mlp_top = "1024-1024-1024-1"
         data_generation = "random"
-        mini_batch_size = 2048
-        num_batches = self.batch_size
+        mini_batch_size = self.batch_size
+        num_batches = 1
         num_indicies_per_lookup = 100
 
         self.opt = Namespace(**{

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -126,6 +126,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             # its DEFAULT_TRAIN_BSIZE or DEFAULT_EVAL_BSIZE will still be None
             if not self.batch_size:
                 raise NotImplementedError(f"Test {self.test} is not implemented.")
+        else:
+            self.batch_size = batch_size
         # Check if specified batch size is supported by the model
         if hasattr(self, "ALLOW_CUSTOMIZE_BSIZE") and (not getattr(self, "ALLOW_CUSTOMIZE_BSIZE")):
             if self.test == "train" and (not self.batch_size == self.DEFAULT_TRAIN_BSIZE):


### PR DESCRIPTION
Using num_batches was not changing the batch size properly from a high level script.
Changing batch_size to modify mini_batch_size will now change the actual batch size
in the DLRM architecture.

Here is the default batch_size (2048), took 9 ms:
```
$ python run.py dlrm -d cuda -m eager --profile -t train
Running train method from dlrm on cuda in eager mode with input batch size 2048.
Collecting CUDA activity.
STAGE:2022-08-03 17:03:39 92135:92135 ActivityProfilerController.cpp:294] Completed Stage: Warm Up
STAGE:2022-08-03 17:03:39 92135:92135 ActivityProfilerController.cpp:300] Completed Stage: Collection
STAGE:2022-08-03 17:03:40 92135:92135 output_json.cpp:417] Completed Stage: Post Processing
STAGE:2022-08-03 17:03:40 92135:92135 ActivityProfilerController.cpp:294] Completed Stage: Warm Up
STAGE:2022-08-03 17:03:40 92135:92135 ActivityProfilerController.cpp:300] Completed Stage: Collection
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    cudaDeviceSynchronize       100.00%       7.000us       100.00%       7.000us       7.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 7.000us

Saved TensorBoard Profiler traces to ./logs.
```
![image](https://user-images.githubusercontent.com/17602366/182669173-65bccdda-238f-441f-acfc-f3a8a03079ae.png)


Here is the batch size set to 4096, took 16ms:
```
$ python run.py dlrm -d cuda -m eager --profile -t train --bs 4096
Running train method from dlrm on cuda in eager mode with input batch size 4096.
Collecting CUDA activity.
STAGE:2022-08-03 17:05:42 92704:92704 ActivityProfilerController.cpp:294] Completed Stage: Warm Up
STAGE:2022-08-03 17:05:42 92704:92704 ActivityProfilerController.cpp:300] Completed Stage: Collection
STAGE:2022-08-03 17:05:42 92704:92704 output_json.cpp:417] Completed Stage: Post Processing
STAGE:2022-08-03 17:05:42 92704:92704 ActivityProfilerController.cpp:294] Completed Stage: Warm Up
STAGE:2022-08-03 17:05:42 92704:92704 ActivityProfilerController.cpp:300] Completed Stage: Collection
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    cudaDeviceSynchronize       100.00%       8.000us       100.00%       8.000us       8.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 8.000us

Saved TensorBoard Profiler traces to ./logs.
```
![image](https://user-images.githubusercontent.com/17602366/182668585-768f2a75-1312-4407-853e-f0d102a39ab1.png)
