### PR TITLE
[correctness check] added use_cosine_similarity as an extra argument

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -111,6 +111,7 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser.add_argument("--fuser", type=str, default="", choices=["fuser0", "fuser1", "fuser2"], help="enable fuser")
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
+    parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -112,7 +112,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             # in this case, use more relaxed cosine similarity instead of torch.allclose
             # for correctness testing
             # see: https://github.com/pytorch/torchdynamo/pull/438
-            if self.dargs.precision == "fp16" or (self.dynamo and self.opt_args.torchdynamo == "fx2trt") or (not self.dynamo and self.opt_args.fx2trt):
+            if self.dargs.precision == "fp16" or (self.dynamo and self.opt_args.torchdynamo == "fx2trt") or (not self.dynamo and self.opt_args.fx2trt) or self.opt_args.use_cosine_similarity:
                 self.correctness = correctness_check(self, cos_sim=True, deepcopy=self.DEEPCOPY)
             else:
                 # get tolerance of correctness check from os.environ


### PR DESCRIPTION
The default allclose() correctness check doesn't work for bfloat16
kernels due to precision differences between fp32 and bfloat16. For trt
kernels this is addressed by switching to cosine_similarity. Instead
of adding flags for every such runtime, this patch adds "use_consine_similarity"
as an extra argument for benchmark execution to explicitly use this correctness
check.