### PR TITLE
Add Dev Infra nightly test

### DIFF
--- a/.github/workflows/devinfra-nightly.yml
+++ b/.github/workflows/devinfra-nightly.yml
@@ -2,16 +2,16 @@ name: TorchBench V3 Dev Infra nightly benchmarking
 on:
   workflow_dispatch:
 jobs:
-  # CUDA 11.3 nightly test
+  # CUDA 11.6 nightly test
   benchmark-cu113:
     env:
       TORCHBENCH_VER: "v3"
       PYTHON_VER: "3.8"
-      CUDA_VER: "11.3"
-      MAGMA_VERSION: "magma-cuda113"
+      CUDA_VER: "11.6"
+      MAGMA_VERSION: "magma-cuda116"
       CONDA_ENV_NAME:  "torchbench-v3-devinfra-nightly-ci"
       UB_NAME: "devinfra-nightly"
-      CUDA_VERSION: "cu113"
+      CUDA_VERSION: "cu116"
       IS_GHA: 1
       AWS_DEFAULT_REGION: us-east-1
       BUILD_ENVIRONMENT: benchmark-nightly

--- a/.github/workflows/devinfra-nightly.yml
+++ b/.github/workflows/devinfra-nightly.yml
@@ -1,4 +1,4 @@
-name: TorchBench V3 nightly
+name: TorchBench V3 Dev Infra nightly benchmarking
 on:
   workflow_dispatch:
 jobs:
@@ -9,8 +9,8 @@ jobs:
       PYTHON_VER: "3.8"
       CUDA_VER: "11.3"
       MAGMA_VERSION: "magma-cuda113"
-      CONDA_ENV_NAME:  "torchbench-v3-nightly-ci"
-      OUTPUT_DIR: ".torchbench/v3-nightly-ci"
+      CONDA_ENV_NAME:  "torchbench-v3-devinfra-nightly-ci"
+      UB_NAME: "devinfra-nightly"
       CUDA_VERSION: "cu113"
       IS_GHA: 1
       AWS_DEFAULT_REGION: us-east-1
@@ -50,12 +50,12 @@ jobs:
       - name: Run benchmark
         run: |
           . activate "${CONDA_ENV_NAME}"
-          python run_benchmark.py devinfra-nightly
+          python run_benchmark.py "${UB_NAME}"
       - name: Copy artifact
         run: |
           . activate "${CONDA_ENV_NAME}"
           mkdir -p benchmark-output
-          cp .userbenchmark/devinfra-nightly/* benchmark-output/
+          cp -r .userbenchmark/"${UB_NAME}"/* benchmark-output/
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -1,0 +1,1 @@
+name: TorchBench V3 nightly

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -1,1 +1,63 @@
 name: TorchBench V3 nightly
+on:
+  workflow_dispatch:
+jobs:
+  # CUDA 11.3 nightly test
+  benchmark-cu113:
+    env:
+      TORCHBENCH_VER: "v3"
+      PYTHON_VER: "3.8"
+      CUDA_VER: "11.3"
+      MAGMA_VERSION: "magma-cuda113"
+      CONDA_ENV_NAME:  "torchbench-v3-nightly-ci"
+      OUTPUT_DIR: ".torchbench/v3-nightly-ci"
+      CUDA_VERSION: "cu113"
+      IS_GHA: 1
+      AWS_DEFAULT_REGION: us-east-1
+      BUILD_ENVIRONMENT: benchmark-nightly
+    runs-on: [ linux.4xlarge.nvidia.gpu ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: v2.0
+      - name: Create conda env
+        run: |
+          conda create -y -q --name "${CONDA_ENV_NAME}" python=${{ env.PYTHON_VER }}
+      - name: Install PyTorch nightly
+        run: |
+          . activate "${CONDA_ENV_NAME}"
+          # Install dependencies
+          pip install requests bs4 argparse gitpython boto3
+          # Check if nightly builds are available
+          NIGHTLIES=$(python torchbenchmark/util/torch_nightly.py --packages torch)
+          # If failed, the script will generate empty result
+          if [ -z $NIGHTLIES ]; then
+              echo "Torch nightly build failed. Cancel the workflow."
+              exit 1
+          fi
+          # install git-lfs
+          conda install -y git-lfs
+          # install magma
+          conda install -y -c pytorch "${MAGMA_VERSION}"
+          # Install PyTorch nightly from pip
+          pip install --pre torch torchtext torchvision \
+          -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
+      - name: Install other TorchBench dependencies
+        run: |
+          . activate "${CONDA_ENV_NAME}"
+          python install.py
+      - name: Run benchmark
+        run: |
+          . activate "${CONDA_ENV_NAME}"
+          python run_benchmark.py devinfra-nightly
+      - name: Copy artifact
+        run: |
+          . activate "${CONDA_ENV_NAME}"
+          mkdir -p benchmark-output
+          cp .userbenchmark/devinfra-nightly/* benchmark-output/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmark-output/

--- a/configs/devinfra/cpu.yaml
+++ b/configs/devinfra/cpu.yaml
@@ -1,0 +1,7 @@
+device:
+  - "cpu"
+test:
+  - "train"
+  - "eval"
+args:
+  - ""

--- a/configs/devinfra/cuda.yaml
+++ b/configs/devinfra/cuda.yaml
@@ -1,0 +1,7 @@
+device:
+  - "cuda"
+test:
+  - "train"
+  - "eval"
+args:
+  - ""

--- a/userbenchmark/devinfra-nightly/__init__.py
+++ b/userbenchmark/devinfra-nightly/__init__.py
@@ -1,8 +1,33 @@
 """
-Run Dev Infra nightly performance regression testing.
+Run Dev Infra nightly benchmarking.
 """
+import subprocess
+import argparse
 
 from typing import List
+from ..utils import REPO_PATH, get_output_dir
+
+BM_NAME = "devinfra-nightly"
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="devinfra/cuda", help="The name of the config to run.")
+    parser.add_argument("--repeat", type=int, default=1, help="Number of times to repeat the benchmark.")
+    parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
+    return parser.parse_args(args)
+
+def run_benchmark(config, logdir, iter, dryrun=True):
+    run_config_script = REPO_PATH.joinpath(".github", "scripts", "run-config.py")
+    run_command = [str(run_config_script), "-c", config, "-b", str(REPO_PATH), "-o", str(logdir)]
+    print(f"Iter {iter}: running {run_command}")
+    if not dryrun:
+        subprocess.check_call(run_command, shell=True)
 
 def run(args: List[str]):
-    pass
+    args = parse_args(args)
+    output_dir = get_output_dir(BM_NAME)
+    logdir = output_dir.joinpath("logs")
+    for iter in range(args.repeat):
+        if args.repeat != 1:
+            logdir = logdir.joinpath(f"iter-{iter}")
+        run_benchmark(args.config, logdir, iter=iter, dryrun=args.dryrun)

--- a/userbenchmark/devinfra-nightly/__init__.py
+++ b/userbenchmark/devinfra-nightly/__init__.py
@@ -1,0 +1,8 @@
+"""
+Run Dev Infra nightly performance regression testing.
+"""
+
+from typing import List
+
+def run(args: List[str]):
+    pass

--- a/userbenchmark/devinfra-nightly/gen_config.py
+++ b/userbenchmark/devinfra-nightly/gen_config.py
@@ -1,0 +1,3 @@
+"""
+Generate a config file given an existing benchmark output json.
+"""

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -5,6 +5,8 @@ import json
 import torch
 from pathlib import Path
 
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
+
 def get_output_json(bm_name, metrics):
     return {
         "name": bm_name,


### PR DESCRIPTION
This PR adds the Dev Infra nightly test on  linux.4xlarge.nvidia.gpu to determine the set of tests to run on TorchBench V3.
Related to https://github.com/pytorch/builder/issues/1098