### PR TITLE
Update the scribe category

### DIFF
--- a/scripts/userbenchmark/upload_scribe.py
+++ b/scripts/userbenchmark/upload_scribe.py
@@ -65,7 +65,7 @@ class TorchBenchUserbenchmarkUploader(ScribeUploader):
     SUBMISSION_GROUP_GUID = 'oss-ci-gcp-a100'
 
     def __init__(self):
-        super().__init__('perfpipe_pytorch_adhoc_benchmarks')
+        super().__init__('perfpipe_pytorch_user_benchmarks')
         self.schema = {
             'int': [
                 'time',                     # timestamp of upload


### PR DESCRIPTION
We are using the new scribe category `perfpipe_pytorch_user_benchmarks` to upload userbenchmark results to scribe.