### PR TITLE
Add T5 e2e_benchmark translation task with support for DDP 

### DIFF
--- a/torchbenchmark/e2e_models/hf_t5/__init__.py
+++ b/torchbenchmark/e2e_models/hf_t5/__init__.py
@@ -1,0 +1,392 @@
+from accelerate.utils.dataclasses import DeepSpeedPlugin
+import torch
+import math
+import os
+from pathlib import Path
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torchbenchmark.util.e2emodel import E2EBenchmarkModel
+from torchbenchmark.tasks import NLP
+from datasets import load_metric
+from accelerate import Accelerator
+from transformers import (
+    AutoConfig,
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
+    DataCollatorForSeq2Seq,
+    default_data_collator,
+    get_scheduler,
+    MBartTokenizer,
+    MBartTokenizerFast
+)
+from typing import Optional
+from torchbenchmark.util.framework.transformers.translation.dataset import prep_dataset, preprocess_dataset
+from torchbenchmark.util.framework.transformers.translation.args import parse_args, parse_torchbench_args
+
+# setup environment variable
+CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
+
+class Model(E2EBenchmarkModel):
+    task = NLP.TRANSLATION
+    DEFAULT_TRAIN_BSIZE: int = 32
+    DEFAULT_EVAL_BSIZE: int = 1
+
+    def __init__(self, test, batch_size=None, extra_args=[]):
+        super().__init__(test=test, batch_size=batch_size, extra_args=extra_args)
+        # TODO: currently only support 1 GPU device
+        self.device = "cuda"
+        self.device_num = 1
+        # Parse the extra arguments
+        self.tb_args = parse_torchbench_args(extra_args)
+        torch.manual_seed(1337)
+        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.benchmark = True
+
+        # Parameters
+        model_name = "t5-base"
+        dataset_name = "wmt16"
+        dataset_config_name = "ro-en"
+        source_lang = "en" 
+        target_lang = "ro" 
+        source_prefix = "translate English to Romanian: "
+        max_source_length = "1024"
+        max_target_length = "128"
+        learning_rate = "2e-5"
+        num_train_epochs = "1"
+        max_train_steps = "1000" # overrides num_train_epochs
+        # this benchmark runs on a single GPU
+        cuda_visible_devices = "0"
+        output_dir = os.path.join(CURRENT_DIR, ".output")
+        os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+        in_arg = ["--model_name_or_path", model_name, 
+                  "--dataset_name", dataset_name,
+                  "--dataset_config_name", dataset_config_name,
+                  "--source_lang", source_lang,
+                  "--target_lang", target_lang,
+                  "--source_prefix", source_prefix,
+                  "--max_source_length", max_source_length,
+                  "--max_target_length", max_target_length,
+                  "--per_device_train_batch_size", str(self.batch_size), 
+                  "--per_device_eval_batch_size", str(self.batch_size),
+                  "--learning_rate", learning_rate,
+                  "--num_train_epochs", num_train_epochs,
+                  "--max_train_steps", max_train_steps,
+                  "--output_dir", output_dir]
+        hf_args = parse_args(in_arg)
+
+        # ideally we don't modify the model code directly, but attaching deepspeed
+        # must be done before self.prep initialiazes accelerator.
+        if self.tb_args.distributed == "deepspeed":
+            zero_opt_cfg = {
+                "zero_optimization": {
+                    "stage": 1,
+                    "reduce_bucket_size": 2e8,
+                    "overlap_comm": True,
+                    "contiguous_gradients": False
+                }
+            }
+            hf_args.deepspeed_plugin = DeepSpeedPlugin()
+            hf_args.deepspeed_plugin.deepspeed_config.update(zero_opt_cfg)
+        elif self.tb_args.distributed == "ddp":
+            hf_args.apply_ddp = True
+        elif self.tb_args.distributed == "none":
+            hf_args.apply_ddp = False
+        else:
+            raise RuntimeError(f"Unsupported distributed scheme {self.tb_args.distributed} for model hf_t5")
+
+        # setup other members
+        self.prep(hf_args)
+        if test == "train":
+            self.num_examples = len(self.train_dataloader) * self.batch_size
+        elif test == "eval":
+            self.num_examples = len(self.eval_dataloader) * self.batch_size
+    
+    def prep(self, hf_args):
+        # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
+        # information sent is the one passed as arguments along with your Python/PyTorch versions.
+        # send_example_telemetry("run_translation_no_trainer", args) # comment out for simplicity
+
+        # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
+        # If we're using tracking, we also need to initialize it here and it will by default pick up all supported trackers
+        # in the environment
+        # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
+        if hasattr(hf_args, "deepspeed_plugin"):
+            # Note: self.tb_args.fp16 could be renamed to better clarify its meaning
+            assert self.tb_args.fp16=="amp", "deepspeed is only supported with bf16/amp enabled"
+            accelerator = Accelerator(deepspeed_plugin=hf_args.deepspeed_plugin, mixed_precision='bf16')
+        else:
+            accelerator = Accelerator(mixed_precision='fp16' if self.tb_args.fp16=='amp' else 'no')
+
+        # Handle the repository creation
+        if accelerator.is_main_process:
+            if hf_args.output_dir is not None:
+                os.makedirs(hf_args.output_dir, exist_ok=True)
+        accelerator.wait_for_everyone()
+
+        raw_datasets = prep_dataset(hf_args)
+
+        # Load pretrained model and tokenizer
+        #
+        # In distributed training, the .from_pretrained methods guarantee that only one local process can concurrently
+        # download model & vocab.
+        if hf_args.config_name:
+            config = AutoConfig.from_pretrained(hf_args.config_name)
+        elif hf_args.model_name_or_path:
+            config = AutoConfig.from_pretrained(hf_args.model_name_or_path)
+        # else: # TODO: comment out for simplicity, but probably want this.
+        #     config = CONFIG_MAPPING[hf_args.model_type]()
+        #     logger.warning("You are instantiating a new config instance from scratch.")
+
+        if hf_args.tokenizer_name:
+            tokenizer = AutoTokenizer.from_pretrained(hf_args.tokenizer_name, use_fast=not hf_args.use_slow_tokenizer)
+        elif hf_args.model_name_or_path:
+            tokenizer = AutoTokenizer.from_pretrained(hf_args.model_name_or_path, use_fast=not hf_args.use_slow_tokenizer)
+        else:
+            raise ValueError(
+                "You are instantiating a new tokenizer from scratch. This is not supported by this script."
+                "You can do it from another script, save it, and load it from here, using --tokenizer_name."
+            )
+
+        if hf_args.model_name_or_path:
+            model = AutoModelForSeq2SeqLM.from_pretrained(
+                hf_args.model_name_or_path,
+                from_tf=bool(".ckpt" in hf_args.model_name_or_path),
+                config=config,
+            )
+        else:
+            # logger.info("Training new model from scratch")
+            model = AutoModelForSeq2SeqLM.from_config(config)
+
+        model.resize_token_embeddings(len(tokenizer))
+
+        # Set decoder_start_token_id
+        if model.config.decoder_start_token_id is None and isinstance(tokenizer, (MBartTokenizer, MBartTokenizerFast)):
+            assert (
+                hf_args.target_lang is not None and hf_args.source_lang is not None
+            ), "mBart requires --target_lang and --source_lang"
+            if isinstance(tokenizer, MBartTokenizer):
+                model.config.decoder_start_token_id = tokenizer.lang_code_to_id[hf_args.target_lang]
+            else:
+                model.config.decoder_start_token_id = tokenizer.convert_tokens_to_ids(hf_args.target_lang)
+
+        if model.config.decoder_start_token_id is None:
+            raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")
+
+        # For translation we set the codes of our source and target languages (only useful for mBART, the others will
+        # ignore those attributes).
+        if isinstance(tokenizer, (MBartTokenizer, MBartTokenizerFast)):
+            if hf_args.source_lang is not None:
+                tokenizer.src_lang = hf_args.source_lang
+            if hf_args.target_lang is not None:
+                tokenizer.tgt_lang = hf_args.target_lang
+
+        prefix = hf_args.source_prefix if hf_args.source_prefix is not None else ""
+
+        train_dataset, eval_dataset = preprocess_dataset(hf_args, raw_datasets, tokenizer, prefix, accelerator)
+
+        # # Log a few random samples from the training set:
+        # for index in random.sample(range(len(train_dataset)), 3):
+        #     logger.info(f"Sample {index} of the training set: {train_dataset[index]}.")
+            
+        # DataLoaders creation:
+        label_pad_token_id = -100 if hf_args.ignore_pad_token_for_loss else tokenizer.pad_token_id
+        if hf_args.pad_to_max_length:
+            # If padding was already done ot max length, we use the default data collator that will just convert everything
+            # to tensors.
+            self.data_collator = default_data_collator
+        else:
+            # Otherwise, `DataCollatorWithPadding` will apply dynamic padding for us (by padding to the maximum length of
+            # the samples passed). When using mixed precision, we add `pad_to_multiple_of=8` to pad all tensors to multiple
+            # of 8s, which will enable the use of Tensor Cores on NVIDIA hardware with compute capability >= 7.5 (Volta).
+            self.data_collator = DataCollatorForSeq2Seq(
+                tokenizer,
+                model=model,
+                label_pad_token_id=label_pad_token_id,
+                pad_to_multiple_of=8 if accelerator.use_fp16 else None,
+            )
+
+        train_dataloader = DataLoader(
+            train_dataset, shuffle=True, collate_fn=self.data_collator, batch_size=hf_args.per_device_train_batch_size)
+        eval_dataloader = DataLoader(eval_dataset, collate_fn=self.data_collator, batch_size=hf_args.per_device_eval_batch_size)
+
+        # Optimizer
+        # Split weights in two groups, one with weight decay and the other not.
+        no_decay = ["bias", "LayerNorm.weight", "layer_norm.weight"]
+        optimizer_grouped_parameters = [
+            {
+                "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
+                "weight_decay": hf_args.weight_decay,
+            },
+            {
+                "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
+                "weight_decay": 0.0,
+            },
+        ]
+        optimizer = torch.optim.AdamW(optimizer_grouped_parameters, lr=hf_args.learning_rate)
+
+        # Scheduler and math around the number of training steps.
+        overrode_max_train_steps = False
+        num_update_steps_per_epoch = math.ceil(len(train_dataloader) / hf_args.gradient_accumulation_steps)
+        if hf_args.max_train_steps is None:
+            hf_args.max_train_steps = hf_args.num_train_epochs * num_update_steps_per_epoch
+            overrode_max_train_steps = True
+
+        lr_scheduler = get_scheduler(
+            name=hf_args.lr_scheduler_type,
+            optimizer=optimizer,
+            num_warmup_steps=hf_args.num_warmup_steps,
+            num_training_steps=hf_args.max_train_steps,
+        )
+
+        # Prepare everything with our `accelerator`.
+        model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
+            model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
+        )
+
+        # We need to recalculate our total training steps as the size of the training dataloader may have changed.
+        num_update_steps_per_epoch = math.ceil(len(train_dataloader) / hf_args.gradient_accumulation_steps)
+        if overrode_max_train_steps:
+            hf_args.max_train_steps = hf_args.num_train_epochs * num_update_steps_per_epoch
+        # Afterwards we recalculate our number of training epochs
+        hf_args.num_train_epochs = math.ceil(hf_args.max_train_steps / num_update_steps_per_epoch)
+        # TODO: not doing checkpointing
+        # # Figure out how many steps we should save the Accelerator states
+        # if hasattr(hf_args.checkpointing_steps, "isdigit"):
+        #     checkpointing_steps = hf_args.checkpointing_steps
+        #     if hf_args.checkpointing_steps.isdigit():
+        #         checkpointing_steps = int(hf_args.checkpointing_steps)
+        # else:
+        #     checkpointing_steps = None
+        
+        # TODO: commented out tracking
+        # # We need to initialize the trackers we use, and also store our configuration.
+        # # We initialize the trackers only on main process because `accelerator.log`
+        # # only logs on main process and we don't want empty logs/runs on other processes.
+        # if hf_args.with_tracking:
+        #     if accelerator.is_main_process:
+        #         experiment_config = vars(hf_args)
+        #         # TensorBoard cannot log Enums, need the raw value
+        #         experiment_config["lr_scheduler_type"] = experiment_config["lr_scheduler_type"].value
+        #         accelerator.init_trackers("translation_no_trainer", experiment_config)
+
+        # metric = evaluate.load("sacrebleu") # TODO bring this back, potentially w/o evaluate library?
+
+        # Setup class members
+        self.hf_args = hf_args
+        self.model = model
+        self.optimizer = optimizer
+        self.train_dataloader = train_dataloader
+        self.eval_dataloader = eval_dataloader
+        self.lr_scheduler = lr_scheduler
+        self.accelerator = accelerator
+
+        if hf_args.apply_ddp:
+            local_rank = int(os.getenv("LOCAL_RANK", -1))
+            self.model = DDP(
+                self.model,
+                device_ids=[local_rank],
+                # If buffer broadcast is necessary, specific optimizations might be
+                # necessary to optimize performance. Disable it by default.
+                broadcast_buffers=False,
+                # Set gradient as bucket view to avoid unnecessary copies
+                gradient_as_bucket_view=True,
+                # TODO: tune bucket_cap_mb
+                static_graph=True,
+            )
+
+    def train(self):
+        completed_steps = 0
+        for epoch in range(self.hf_args.num_train_epochs):
+            self.model.train()
+            for step, batch in enumerate(self.train_dataloader):
+                outputs = self.model(**batch)
+                loss = outputs.loss
+                loss = loss / self.hf_args.gradient_accumulation_steps
+                self.accelerator.backward(loss)
+                if step % self.hf_args.gradient_accumulation_steps == 0 or step == len(self.train_dataloader) - 1:
+                    self.optimizer.step()
+                    self.lr_scheduler.step()
+                    self.optimizer.zero_grad()
+                    completed_steps += 1
+                if completed_steps >= self.hf_args.max_train_steps:
+                    break
+        # self.eval2() # TODO: bring back eval
+
+    def eval(self) -> Optional[dict]:
+        self.model.eval()
+        for _step, batch in enumerate(self.eval_dataloader):
+            outputs = self.model(**batch)
+            predictions = outputs.logits.argmax(dim=-1) if not self.is_regression else outputs.logits.squeeze()
+            self.metric.add_batch(
+                    predictions=self.accelerator.gather(predictions),
+                    references=self.accelerator.gather(batch["labels"]),
+                )
+        eval_metric = self.metric.compute()
+        return eval_metric
+    
+    def eval2(self):
+        self.model.eval()
+
+        if args.val_max_target_length is None:
+            args.val_max_target_length = args.max_target_length
+
+        gen_kwargs = {
+            "max_length": args.val_max_target_length if args is not None else config.max_length,
+            "num_beams": args.num_beams,
+        }
+        samples_seen = 0
+        for step, batch in enumerate(self.eval_dataloader):
+            with torch.no_grad():
+                generated_tokens = self.accelerator.unwrap_model(self.model).generate(
+                    batch["input_ids"],
+                    attention_mask=batch["attention_mask"],
+                    **gen_kwargs,
+                )
+
+                generated_tokens = self.accelerator.pad_across_processes(
+                    generated_tokens, dim=1, pad_index=tokenizer.pad_token_id
+                )
+                labels = batch["labels"]
+                if not args.pad_to_max_length:
+                    # If we did not pad to max length, we need to pad the labels too
+                    labels = accelerator.pad_across_processes(batch["labels"], dim=1, pad_index=tokenizer.pad_token_id)
+
+                generated_tokens = self.accelerator.gather(generated_tokens).cpu().numpy()
+                labels = self.accelerator.gather(labels).cpu().numpy()
+
+                if args.ignore_pad_token_for_loss:
+                    # Replace -100 in the labels as we can't decode them.
+                    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+
+                decoded_preds = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)
+                decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+                decoded_preds, decoded_labels = postprocess_text(decoded_preds, decoded_labels)
+
+                # If we are in a multiprocess environment, the last batch has duplicates
+                if accelerator.num_processes > 1:
+                    if step == len(eval_dataloader) - 1:
+                        decoded_preds = decoded_preds[: len(eval_dataloader.dataset) - samples_seen]
+                        decoded_labels = decoded_labels[: len(eval_dataloader.dataset) - samples_seen]
+                    else:
+                        samples_seen += len(decoded_labels)
+
+                self.metric.add_batch(predictions=decoded_preds, references=decoded_labels)
+        eval_metric = self.metric.compute()
+        logger.info({"bleu": eval_metric["score"]})
+
+    def next_batch(self):
+        return next(iter(self.train_dataloader))
+
+    def run_forward(self, input):
+        """
+        compute model forward and return loss
+        """
+        return self.model(**input).loss
+
+    def run_backward(self, loss):
+        self.accelerator.backward(loss)
+
+    def run_optimizer_step(self):
+        self.optimizer.step()
+

--- a/torchbenchmark/e2e_models/hf_t5/install.py
+++ b/torchbenchmark/e2e_models/hf_t5/install.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()

--- a/torchbenchmark/e2e_models/hf_t5/requirements.txt
+++ b/torchbenchmark/e2e_models/hf_t5/requirements.txt
@@ -1,0 +1,6 @@
+accelerate
+datasets >= 1.8.0
+torch
+evaluate
+transformers
+numpy

--- a/torchbenchmark/util/framework/transformers/translation/args.py
+++ b/torchbenchmark/util/framework/transformers/translation/args.py
@@ -24,7 +24,7 @@ task_to_keys = {
 
 def parse_torchbench_args(extra_args):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--task_name", default="wmt16", choices=task_to_keys.keys(), help="Name of task to run") 
+    parser.add_argument("--task_name", default="wmt-en-ro", choices=task_to_keys.keys(), help="Name of task to run") 
     # do not validate in train by default
     parser.add_argument("--validate_in_train", action="store_true", help="Validate result in train")
     # use fp16 mixed precision by default

--- a/torchbenchmark/util/framework/transformers/translation/args.py
+++ b/torchbenchmark/util/framework/transformers/translation/args.py
@@ -1,0 +1,263 @@
+"""
+Hacked from https://github.com/huggingface/transformers/blob/main/examples/pytorch/translation/run_translation_no_trainer.py 
+# TODO: put the commit hash for the above link instead of main
+It runs HuggingFace transformer models translation on WMT16
+"""
+import argparse
+from transformers import SchedulerType
+
+task_to_keys = {
+    "wmt16": ("sentence", None),
+    "stas/wmt14-en-de-pre-processed": (), # TODO: fix this one
+}
+
+def parse_torchbench_args(extra_args):
+    parser = argparse.ArgumentParser()
+    # TODO: eventually allow task name to correspond to set of args for wmt16 eng->romanian for example
+    # parser.add_argument("--task_name", default="wmt16", choices=task_to_keys.keys(), help="Name of task to run") 
+    # do not validate in train by default
+    parser.add_argument("--validate_in_train", action="store_true", help="Validate result in train")
+    # use fp16 mixed precision by default
+    parser.add_argument("--fp16", default="amp", choices=["amp", "no"], help="Enable mixed precision")
+    parser.add_argument(
+        "--distributed", default="ddp", choices=["ddp", "fsdp", "deepspeed", "none"],
+        help="distributed training paradigm, by default using DDP"
+    )
+    tb_args = parser.parse_args(extra_args)
+    return tb_args
+
+def parse_args(in_args):
+    parser = argparse.ArgumentParser(description="Finetune a transformers model on a text classification task")
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default=None,
+        help="The name of the dataset to use (via the datasets library).",
+    )
+
+    parser.add_argument(
+        "--predict_with_generate",
+        type=bool,
+        default=True,
+        help="",
+    )
+    parser.add_argument(
+        "--dataset_config_name",
+        type=str,
+        default=None,
+        help="The configuration name of the dataset to use (via the datasets library).",
+    )
+    parser.add_argument(
+        "--train_file", type=str, default=None, help="A csv or a json file containing the training data."
+    )
+
+    parser.add_argument(
+        "--num_beams",
+        type=int,
+        default=None,
+        help=(
+            "Number of beams to use for evaluation. This argument will be "
+            "passed to ``model.generate``, which is used during ``evaluate`` and ``predict``."
+        ),
+    )
+
+    parser.add_argument(
+        "--max_source_length",
+        type=int,
+        default=1024,
+        help=(
+            "The maximum total input sequence length after "
+            "tokenization.Sequences longer than this will be truncated, sequences shorter will be padded."
+        ),
+    )
+    parser.add_argument(
+        "--max_target_length",
+        type=int,
+        default=128,
+        help=(
+            "The maximum total sequence length for target text after "
+            "tokenization. Sequences longer than this will be truncated, sequences shorter will be padded."
+            "during ``evaluate`` and ``predict``."
+        ),
+    )
+    parser.add_argument(
+        "--val_max_target_length",
+        type=int,
+        default=None,
+        help=(
+            "The maximum total sequence length for validation "
+            "target text after tokenization.Sequences longer than this will be truncated, sequences shorter will be "
+            "padded. Will default to `max_target_length`.This argument is also used to override the ``max_length`` "
+            "param of ``model.generate``, which is used during ``evaluate`` and ``predict``."
+        ),
+    )
+    parser.add_argument(
+        "--pad_to_max_length",
+        type=bool,
+        default=False,
+        help=(
+            "Whether to pad all samples to model maximum sentence "
+            "length. If False, will pad the samples dynamically when batching to the maximum length in the batch. More"
+            "efficient on GPU but very bad for TPU."
+        ),
+    )
+    parser.add_argument(
+        "--validation_file", type=str, default=None, help="A csv or a json file containing the validation data."
+    )
+    parser.add_argument(
+        "--ignore_pad_token_for_loss",
+        type=bool,
+        default=True,
+        help="Whether to ignore the tokens corresponding to padded labels in the loss computation or not.",
+    )
+    parser.add_argument("--source_lang", type=str, default=None, help="Source language id for translation.")
+    parser.add_argument("--target_lang", type=str, default=None, help="Target language id for translation.")
+    parser.add_argument(
+        "--source_prefix",
+        type=str,
+        default=None,
+        help="A prefix to add before every source text (useful for T5 models).",
+    )
+    parser.add_argument(
+        "--preprocessing_num_workers",
+        type=int,
+        default=None,
+        help="The number of processes to use for the preprocessing.",
+    )
+    parser.add_argument(
+        "--overwrite_cache", type=bool, default=None, help="Overwrite the cached training and evaluation sets"
+    )
+    # seems to be unused, commenting out
+    # parser.add_argument(
+    #     "--max_length",
+    #     type=int,
+    #     default=128,
+    #     help=(
+    #         "The maximum total input sequence length after tokenization. Sequences longer than this will be truncated,"
+    #         " sequences shorter will be padded if `--pad_to_max_lengh` is passed."
+    #     ),
+    # )
+    parser.add_argument(
+        "--model_name_or_path",
+        type=str,
+        help="Path to pretrained model or model identifier from huggingface.co/models.",
+        required=False,
+    )
+    parser.add_argument(
+        "--config_name",
+        type=str,
+        default=None,
+        help="Pretrained config name or path if not the same as model_name",
+    )
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        default=None,
+        help="Pretrained tokenizer name or path if not the same as model_name",
+    )
+    parser.add_argument(
+        "--use_slow_tokenizer",
+        action="store_true",
+        help="If passed, will use a slow tokenizer (not backed by the 🤗 Tokenizers library).",
+    )
+    parser.add_argument(
+        "--per_device_train_batch_size",
+        type=int,
+        default=8,
+        help="Batch size (per device) for the training dataloader.",
+    )
+    parser.add_argument(
+        "--per_device_eval_batch_size",
+        type=int,
+        default=8,
+        help="Batch size (per device) for the evaluation dataloader.",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=5e-5,
+        help="Initial learning rate (after the potential warmup period) to use.",
+    )
+    parser.add_argument("--weight_decay", type=float, default=0.0, help="Weight decay to use.")
+    parser.add_argument("--num_train_epochs", type=int, default=3, help="Total number of training epochs to perform.")
+    parser.add_argument(
+        "--max_train_steps",
+        type=int,
+        default=None,
+        help="Total number of training steps to perform. If provided, overrides num_train_epochs.",
+    )
+    parser.add_argument(
+        "--gradient_accumulation_steps",
+        type=int,
+        default=1,
+        help="Number of updates steps to accumulate before performing a backward/update pass.",
+    )
+    parser.add_argument(
+        "--lr_scheduler_type",
+        type=SchedulerType,
+        default="linear",
+        help="The scheduler type to use.",
+        choices=["linear", "cosine", "cosine_with_restarts", "polynomial", "constant", "constant_with_warmup"],
+    )
+    parser.add_argument(
+        "--num_warmup_steps", type=int, default=0, help="Number of steps for the warmup in the lr scheduler."
+    )
+    parser.add_argument("--output_dir", type=str, default=None, help="Where to store the final model.")
+    parser.add_argument("--seed", type=int, default=None, help="A seed for reproducible training.")
+    parser.add_argument(
+        "--model_type",
+        type=str,
+        default=None,
+        help="Model type to use if training from scratch.",
+        # choices=MODEL_TYPES, # unused, commented out for simplicity
+    )
+    parser.add_argument("--push_to_hub", action="store_true", help="Whether or not to push the model to the Hub.")
+    parser.add_argument(
+        "--hub_model_id", type=str, help="The name of the repository to keep in sync with the local `output_dir`."
+    )
+    parser.add_argument("--hub_token", type=str, help="The token to use to push to the Model Hub.")
+    parser.add_argument(
+        "--checkpointing_steps",
+        type=str,
+        default=None,
+        help="Whether the various states should be saved at the end of every n steps, or 'epoch' for each epoch.",
+    )
+    parser.add_argument(
+        "--resume_from_checkpoint",
+        type=str,
+        default=None,
+        help="If the training should continue from a checkpoint folder.",
+    )
+    parser.add_argument(
+        "--with_tracking",
+        action="store_true",
+        help="Whether to enable experiment trackers for logging.",
+    )
+    parser.add_argument(
+        "--report_to",
+        type=str,
+        default="all",
+        help=(
+            'The integration to report the results and logs to. Supported platforms are `"tensorboard"`,'
+            ' `"wandb"` and `"comet_ml"`. Use `"all"` (default) to report to all integrations.'
+            "Only applicable when `--with_tracking` is passed."
+        ),
+    )
+    args = parser.parse_args(in_args)
+
+    # Sanity checks
+
+    if args.dataset_name is None and args.train_file is None and args.validation_file is None:
+        raise ValueError("Need either a task name or a training/validation file.")
+
+    if args.train_file is not None:
+        extension = args.train_file.split(".")[-1]
+        assert extension in ["csv", "json"], "`train_file` should be a csv or a json file."
+    if args.validation_file is not None:
+        extension = args.validation_file.split(".")[-1]
+        assert extension in ["csv", "json"], "`validation_file` should be a csv or a json file."
+
+    if args.push_to_hub:
+        assert args.output_dir is not None, "Need an `output_dir` to create a repo when `--push_to_hub` is passed."
+
+    return args

--- a/torchbenchmark/util/framework/transformers/translation/args.py
+++ b/torchbenchmark/util/framework/transformers/translation/args.py
@@ -1,20 +1,30 @@
 """
 Hacked from https://github.com/huggingface/transformers/blob/main/examples/pytorch/translation/run_translation_no_trainer.py 
-# TODO: put the commit hash for the above link instead of main
 It runs HuggingFace transformer models translation on WMT16
 """
 import argparse
 from transformers import SchedulerType
 
 task_to_keys = {
-    "wmt16": ("sentence", None),
-    "stas/wmt14-en-de-pre-processed": (), # TODO: fix this one
+    # hf args to include for different tasks
+    # english to romanian
+    "wmt-en-ro": [
+        "--dataset_name", "wmt16",
+        "--dataset_config_name", "ro-en",
+        "--source_lang", "en",
+        "--target_lang", "ro",
+    ],
+    # english to german
+    "wmt-en-de": [
+        "--dataset_name", "stas/wmt14-en-de-pre-processed",
+        "--source_lang", "en",
+        "--target_lang", "de",
+    ], 
 }
 
 def parse_torchbench_args(extra_args):
     parser = argparse.ArgumentParser()
-    # TODO: eventually allow task name to correspond to set of args for wmt16 eng->romanian for example
-    # parser.add_argument("--task_name", default="wmt16", choices=task_to_keys.keys(), help="Name of task to run") 
+    parser.add_argument("--task_name", default="wmt16", choices=task_to_keys.keys(), help="Name of task to run") 
     # do not validate in train by default
     parser.add_argument("--validate_in_train", action="store_true", help="Validate result in train")
     # use fp16 mixed precision by default

--- a/torchbenchmark/util/framework/transformers/translation/dataset.py
+++ b/torchbenchmark/util/framework/transformers/translation/dataset.py
@@ -1,7 +1,5 @@
 from datasets import load_dataset
 
-from .args import task_to_keys
-
 def prep_dataset(hf_args):
     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
     # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/

--- a/torchbenchmark/util/framework/transformers/translation/dataset.py
+++ b/torchbenchmark/util/framework/transformers/translation/dataset.py
@@ -1,0 +1,78 @@
+from datasets import load_dataset
+
+from .args import task_to_keys
+
+def prep_dataset(hf_args):
+    # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+    # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+    # (the dataset will be downloaded automatically from the datasets Hub).
+    #
+    # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+    # 'text' is found. You can easily tweak this behavior (see below).
+    #
+    # In distributed training, the load_dataset function guarantee that only one local process can concurrently
+    # download the dataset.
+    if hf_args.dataset_name is not None:
+        # Downloading and loading a dataset from the hub.
+        raw_datasets = load_dataset(hf_args.dataset_name, hf_args.dataset_config_name)
+    else:
+        data_files = {}
+        if hf_args.train_file is not None:
+            data_files["train"] = hf_args.train_file
+        if hf_args.validation_file is not None:
+            data_files["validation"] = hf_args.validation_file
+        extension = hf_args.train_file.split(".")[-1]
+        raw_datasets = load_dataset(extension, data_files=data_files)
+    # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
+    # https://huggingface.co/docs/datasets/loading_datasets.html.
+
+    return raw_datasets
+
+def preprocess_dataset(hf_args, raw_datasets, tokenizer, prefix, accelerator):
+    # Preprocessing the datasets.
+    # First we tokenize all the texts.
+    column_names = raw_datasets["train"].column_names
+
+    # Get the language codes for input/target.
+    source_lang = hf_args.source_lang.split("_")[0]
+    target_lang = hf_args.target_lang.split("_")[0]
+
+    padding = "max_length" if hf_args.pad_to_max_length else False
+
+    # Temporarily set max_target_length for training.
+    max_target_length = hf_args.max_target_length
+    padding = "max_length" if hf_args.pad_to_max_length else False
+
+    def preprocess_function(examples):
+        inputs = [ex[source_lang] for ex in examples["translation"]]
+        targets = [ex[target_lang] for ex in examples["translation"]]
+        inputs = [prefix + inp for inp in inputs]
+        model_inputs = tokenizer(inputs, max_length=hf_args.max_source_length, padding=padding, truncation=True)
+
+        # Setup the tokenizer for targets
+        with tokenizer.as_target_tokenizer():
+            labels = tokenizer(targets, max_length=max_target_length, padding=padding, truncation=True)
+
+        # If we are padding here, replace all tokenizer.pad_token_id in the labels by -100 when we want to ignore
+        # padding in the loss.
+        if padding == "max_length" and hf_args.ignore_pad_token_for_loss:
+            labels["input_ids"] = [
+                [(l if l != tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
+            ]
+
+        model_inputs["labels"] = labels["input_ids"]
+        return model_inputs
+
+    with accelerator.main_process_first():
+        processed_datasets = raw_datasets.map(
+            preprocess_function,
+            batched=True,
+            num_proc=hf_args.preprocessing_num_workers,
+            remove_columns=column_names,
+            load_from_cache_file=not hf_args.overwrite_cache,
+            desc="Running tokenizer on dataset",
+        )
+
+    train_dataset = processed_datasets["train"]
+    eval_dataset = processed_datasets["validation"]
+    return train_dataset, eval_dataset


### PR DESCRIPTION
What this benchmark will have
- Add T5 e2e benchmark
- Allow DDP and Deepspeed to run on T5 
- Have both train and eval only modes, and include eval as part of train
- Add new wmt16 dataset for general translation tasks. Can be extended to other seq2seq models. 

To Do Later
- Add FSDP 