### PR TITLE
accept 2 outputs from parse_torchdynamo_args

### DIFF
--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -94,7 +94,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         if "--torchdynamo" in opt_args:
             self.dynamo = True
             from torchbenchmark.util.backends.torchdynamo import parse_torchdynamo_args
-            self.opt_args = parse_torchdynamo_args(self, opt_args)
+            self.opt_args, self.extra_args = parse_torchdynamo_args(self, opt_args)
         else:
             self.dynamo = False
             self.opt_args, self.extra_args = parse_opt_args(self, opt_args)


### PR DESCRIPTION
Summary: parse_torchdynamo_args was changed to output (torchbench_args, extra_args), but the usage in model.py was not changed. This updates model.py to accept two outputs instead of accepting the tuple.

Differential Revision: D38923007

