### PR TITLE
Fix backward-compatiblity issue when mps was not available in pytorch

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,12 +13,13 @@ import time
 import numpy as np
 import torch.profiler as profiler
 
-
 from torchbenchmark import load_model_by_name
 import torch
 
-
 WARMUP_ROUNDS = 3
+SUPPORT_DEVICE_LIST = ["cpu", "cuda"]
+if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+    SUPPORT_DEVICE_LIST.append("mps")
 
 def run_one_step_with_cudastreams(func, streamcount):
 
@@ -198,9 +199,7 @@ def profile_one_step(func, nwarmup=WARMUP_ROUNDS):
 
 def _validate_devices(devices: str):
     devices_list = devices.split(",")
-    valid_devices = ['cpu', 'cuda']
-    if (torch.backends.mps.is_available()):
-        valid_devices.append('mps')
+    valid_devices = SUPPORT_DEVICE_LIST
     for d in devices_list:
         if d not in valid_devices:
             raise ValueError(f'Invalid device {d} passed into --profile-devices. Expected devices: {valid_devices}.')
@@ -209,9 +208,6 @@ def _validate_devices(devices: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(__doc__)
-    SUPPORT_DEVICE_LIST = ["cpu", "cuda"]
-    if (torch.backends.mps.is_available()):
-        SUPPORT_DEVICE_LIST.append("mps")
     parser.add_argument("model", help="Full or partial name of a model to run.  If partial, picks the first match.")
     parser.add_argument("-d", "--device", choices=SUPPORT_DEVICE_LIST, default="cpu", help="Which device to use.")
     parser.add_argument("-m", "--mode", choices=["eager", "jit"], default="eager", help="Which mode to run.")

--- a/test.py
+++ b/test.py
@@ -124,7 +124,7 @@ def _load_tests():
     devices = ['cpu']
     if torch.cuda.is_available():
         devices.append('cuda')
-    if torch.backends.mps.is_available():
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
         devices.append('mps')
 
     for path in _list_model_paths():

--- a/test_bench.py
+++ b/test_bench.py
@@ -25,7 +25,7 @@ def pytest_generate_tests(metafunc):
     # e.g. by using info in metafunc.config
     devices = ['cpu', 'cuda']
 
-    if (torch.backends.mps.is_available()):
+    if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
         devices.append('mps')
 
     if metafunc.config.option.cpu_only:


### PR DESCRIPTION
Old pytorch versions don't have the 'mps' backend. Therefore, we first detect whether it exists, then check if it is available.