### PR TITLE
distributed submit script fixes for model_args

### DIFF
--- a/torchbenchmark/util/distributed/submit.py
+++ b/torchbenchmark/util/distributed/submit.py
@@ -87,7 +87,7 @@ def parse_args(args: List[str]=None):
         if args:
             return parser.parse_known_args(args)
         else:
-            return parser.parse_args()
+            return parser.parse_known_args()
     except:
         parser.print_help()
         sys.exit(0)
@@ -145,7 +145,7 @@ class TrainerWrapper(object):
 
 
 def main():
-    args = parse_args()
+    args, model_args, = parse_args()
 
     # Note that the folder will depend on the job_id, to easily track experiments
     executor = submitit.AutoExecutor(folder=args.job_dir, cluster=args.cluster, slurm_max_num_timeout=3000)
@@ -167,7 +167,7 @@ def main():
     args.dist_url = get_init_file(args).as_uri()
     args.output_dir = args.job_dir
 
-    job = executor.submit(TrainerWrapper(args))
+    job = executor.submit(TrainerWrapper(args, model_args))
     # print ID of the Slurm job
     print(job.job_id)
 

--- a/torchbenchmark/util/distributed/trainer.py
+++ b/torchbenchmark/util/distributed/trainer.py
@@ -1,3 +1,4 @@
+import argparse
 from datetime import datetime
 import os
 from pathlib import Path
@@ -9,12 +10,18 @@ from torch.profiler import profile, ProfilerActivity, tensorboard_trace_handler
 from torchbenchmark.util.e2emodel import E2EBenchmarkModel, nested
 import torch.distributed as dist
 
+def parse_model_args(model_args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--device", choices=["cpu", "cuda"], default="cuda", help="Which device to use.")
+    return parser.parse_known_args(model_args)
+
 class Trainer():
     DEFAULT_MEASURE_ITERATIONS = 10
 
     def __init__(self, args, model_class, mode="SPMD", model_args=None):
         self.args = args
-        self.model_args = model_args
+        known_args, other_model_args = parse_model_args(model_args)
+        self.model_args = other_model_args
         self.model_class = model_class
         self.mode = mode
 
@@ -29,7 +36,7 @@ class Trainer():
 
         # create model instance after Trainer setup, so that
         # visible devices won't be revised in model constructor
-        self.e2e_benchmark: E2EBenchmarkModel = model_class("train", batch_size=None, extra_args=extra_args)
+        self.e2e_benchmark: E2EBenchmarkModel = model_class("train", known_args.device, batch_size=None, extra_args=extra_args)
 
         expected_attrs = ["model", "optimizer", "train_dataloader", "accelerator", "run_contexts"]
         assert all(attr in dir(self.e2e_benchmark) for attr in expected_attrs), (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1135

- always use parse_known_args (so that we can separate out the model_args)
- pass in model_args to TrainerWrapper.
- provide "device" argument (defaulting to CUDA)

tested with
```
python -m torchbenchmark.util.distributed.submit --model=torchbenchmark.models.resnet50.Model --partition=train --job_dir=/data/home/dberard/logs --nodes=2 --ngpus=8
```

Differential Revision: [D39076188](https://our.internmc.facebook.com/intern/diff/D39076188)