### PR TITLE
Setup CUDA environment when running bisection and abtest

### DIFF
--- a/.github/scripts/run-config.py
+++ b/.github/scripts/run-config.py
@@ -16,25 +16,12 @@ from typing import List, Optional
 
 from bmutils import add_path
 from bmutils.summarize import analyze_result
+
 REPO_DIR = str(Path(__file__).parent.parent.parent.resolve())
 
 with add_path(REPO_DIR):
     from torchbenchmark import _list_model_paths
-
-CUDA_VERSION_MAP = {
-    "11.3": {
-        "pytorch_url": "cu113",
-        "magma_version": "magma-cuda113",
-    },
-    "11.6": {
-         "pytorch_url": "cu116",
-         "magma_version": "magma-cuda116",
-    },
-    "11.7": {
-         "pytorch_url": "cu117",
-         "magma_version": "magma-cuda117",
-    }
-}
+    from utils.cuda_utils import prepare_cuda_env, install_pytorch_nightly
 
 @dataclass
 class BenchmarkModelConfig:
@@ -130,43 +117,12 @@ def parse_bmconfigs(repo_path: Path, config_name: str) -> List[BenchmarkModelCon
 
 def prepare_bmconfig_env(config: BenchmarkModelConfig, repo_path: Path, dryrun=False):
     """Prepare the correct cuda version environment for the benchmarking."""
-    env = os.environ
     if not config.cuda_version:
-        return env
+        return os.environ.copy()
     cuda_version = config.cuda_version
-    # step 1: setup CUDA path and environment variables
-    cuda_path = Path("/").joinpath("usr", "local", f"cuda-{cuda_version}")
-    assert cuda_path.exists() and cuda_path.is_dir(), f"Expected CUDA Library path {cuda_path} doesn't exist."
-    env["CUDA_ROOT"] = str(cuda_path)
-    env["CUDA_HOME"] = str(cuda_path)
-    env["PATH"] = f"{str(cuda_path)}/bin:{env['PATH']}"
-    env["LD_LIBRARY_PATH"] = f"{str(cuda_path)}/lib64:{str(cuda_path)}/extras/CUPTI/lib64:{env['LD_LIBRARY_PATH']}"
-    # step 2: test call nvcc to confirm the version
-    test_nvcc = ["nvcc", "--version"]
-    if not dryrun:
-        subprocess.check_call(test_nvcc)
-    # step 1: uninstall all pytorch packages
-    uninstall_torch_cmd = ["pip", "uninstall", "-y", "torch", "torchvision", "torchtext"]
-    print(f"Uninstall pytorch: {uninstall_torch_cmd}")
-    if not dryrun:
-        for _loop in range(3):
-            subprocess.check_call(uninstall_torch_cmd)
-    # step 2: install pytorch nightly with the correct cuda version
-    install_magma_cmd = ["conda", "install", "-c", "pytorch", CUDA_VERSION_MAP[cuda_version]['magma_version']]
-    print(f"Install magma: {install_magma_cmd}")
-    if not dryrun:
-        subprocess.check_call(install_magma_cmd)
-    pytorch_nightly_url = f"https://download.pytorch.org/whl/nightly/{CUDA_VERSION_MAP[cuda_version]['pytorch_url']}/torch_nightly.html"
-    install_torch_cmd = ["pip", "install", "--pre", "torch", "torchvision", "torchtext", "-f",  pytorch_nightly_url]
-    print(f"Install pytorch nightly: {install_torch_cmd}")
-    if not dryrun:
-        subprocess.check_call(install_torch_cmd)
-    # step 3: install torchbench
-    install_torchbench_cmd = [sys.executable, "install.py"]
-    print(f"Install torchbench: {install_torchbench_cmd}")
-    if not dryrun:
-        subprocess.check_call(install_torchbench_cmd, cwd=repo_path)
-    return env
+    new_env = prepare_cuda_env(cuda_version=cuda_version)
+    install_pytorch_nightly(cuda_version=cuda_version, dryrun=dryrun)
+    return new_env
 
 def run_bmconfig(config: BenchmarkModelConfig, repo_path: Path, output_path: Path, dryrun=False):
     run_env = prepare_bmconfig_env(config, repo_path=repo_path, dryrun=dryrun)

--- a/.github/scripts/run-config.py
+++ b/.github/scripts/run-config.py
@@ -121,7 +121,7 @@ def prepare_bmconfig_env(config: BenchmarkModelConfig, repo_path: Path, dryrun=F
         return os.environ.copy()
     cuda_version = config.cuda_version
     new_env = prepare_cuda_env(cuda_version=cuda_version)
-    install_pytorch_nightly(cuda_version=cuda_version, dryrun=dryrun)
+    install_pytorch_nightly(cuda_version=cuda_version, env=new_env, dryrun=dryrun)
     return new_env
 
 def run_bmconfig(config: BenchmarkModelConfig, repo_path: Path, output_path: Path, dryrun=False):

--- a/bisection.py
+++ b/bisection.py
@@ -473,7 +473,7 @@ class TorchBenchBisection:
             return False
         if not self.torch_src.init_commits(self.start, self.end, self.abtest):
             return False
-        if not self.bench.prep():
+        if not self.bench.prep(base_build_env):
             return False
         left_commit = self.torch_src.commits[0]
         right_commit = self.torch_src.commits[-1]

--- a/bisection.py
+++ b/bisection.py
@@ -22,10 +22,7 @@ from datetime import datetime
 from typing import Optional, List, Dict, Tuple
 
 from torchbenchmark.util import gitutils
-from utils.cuda_utils import prepare_cuda_env
-
-# defines the default CUDA version to compile against
-DEFAULT_CUDA_VERSION = "11.6"
+from utils.cuda_utils import prepare_cuda_env, DEFAULT_CUDA_VERSION
 
 TORCH_GITREPO="https://github.com/pytorch/pytorch.git"
 TORCHBENCH_GITREPO="https://github.com/pytorch/benchmark.git"

--- a/bisection.py
+++ b/bisection.py
@@ -23,6 +23,10 @@ from datetime import datetime
 from typing import Optional, List, Dict, Tuple
 
 from torchbenchmark.util import gitutils
+from utils.cuda_utils import prepare_cuda_env
+
+# defines the default CUDA version to compile against
+DEFAULT_CUDA_VERSION = "11.6"
 
 TORCH_GITREPO="https://github.com/pytorch/pytorch.git"
 TORCHBENCH_GITREPO="https://github.com/pytorch/benchmark.git"

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+from pathlib import Path
+
+CUDA_VERSION_MAP = {
+    "11.3": {
+        "pytorch_url": "cu113",
+        "magma_version": "magma-cuda113",
+    },
+    "11.6": {
+         "pytorch_url": "cu116",
+         "magma_version": "magma-cuda116",
+    },
+    "11.7": {
+         "pytorch_url": "cu117",
+         "magma_version": "magma-cuda117",
+    }
+}
+
+def _nvcc_output_match(nvcc_output, target_cuda_version):
+    return False
+
+def prepare_cuda_env(cuda_version: str, dryrun=False):
+    assert cuda_version in CUDA_VERSION_MAP, f"Required CUDA version {cuda_version} doesn't exist in {CUDA_VERSION_MAP.keys()}."
+    env = os.environ.copy()
+    # step 1: setup CUDA path and environment variables
+    cuda_path = Path("/").joinpath("usr", "local", f"cuda-{cuda_version}")
+    assert cuda_path.exists() and cuda_path.is_dir(), f"Expected CUDA Library path {cuda_path} doesn't exist."
+    cuda_path_str = str(cuda_path.resolve())
+    env["CUDA_ROOT"] = cuda_path_str
+    env["CUDA_HOME"] = cuda_path_str
+    env["PATH"] = f"{cuda_path_str}/bin:{env['PATH']}"
+    env["CMAKE_CUDA_COMPILER"] = str(cuda_path.joinpath('bin', 'nvcc').resolve())
+    env["LD_LIBRARY_PATH"] = f"{cuda_path_str}/lib64:{cuda_path_str}/extras/CUPTI/lib64:{env['LD_LIBRARY_PATH']}"
+    if dryrun:
+        print(f"CUDA_HOME is set to {env['CUDA_HOME']}")
+    # step 2: test call to nvcc to confirm the version is correct
+    test_nvcc = ["nvcc", "--version"]
+    if dryrun:
+        print(f"Checking nvcc version, command {test_nvcc}")
+    else:
+        output = subprocess.check_output(test_nvcc)
+        assert _nvcc_output_match(output, cuda_version), f"Expected CUDA version {cuda_version}, getting nvcc test result {output}"
+    # step 3: install the correct magma version
+    install_magma_cmd = ["conda", "install", "-c", "pytorch", CUDA_VERSION_MAP[cuda_version]['magma_version']]
+    if dryrun:
+        print(f"Installing CUDA magma: {install_magma_cmd}")
+    subprocess.check_call(install_magma_cmd)
+    return env
+
+def install_pytorch_nightly(cuda_version: str, dryrun=False):
+    uninstall_torch_cmd = ["pip", "uninstall", "-y", "torch", "torchvision", "torchtext"]
+    if dryrun:
+        print(f"Uninstall pytorch: {uninstall_torch_cmd}")
+    else:
+        # uninstall multiple times to make sure the env is clean
+        for _loop in range(3):
+            subprocess.check_call(uninstall_torch_cmd)
+    pytorch_nightly_url = f"https://download.pytorch.org/whl/nightly/{CUDA_VERSION_MAP[cuda_version]['pytorch_url']}/torch_nightly.html"
+    install_torch_cmd = ["pip", "install", "--pre", "torch", "torchvision", "torchtext", "-f",  pytorch_nightly_url]
+    if dryrun:
+        print(f"Install pytorch nightly: {install_torch_cmd}")
+    else:
+        subprocess.check_call(install_torch_cmd)

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -3,6 +3,9 @@ import re
 import subprocess
 from pathlib import Path
 
+# defines the default CUDA version to compile against
+DEFAULT_CUDA_VERSION = "11.6"
+
 CUDA_VERSION_MAP = {
     "11.3": {
         "pytorch_url": "cu113",
@@ -43,6 +46,7 @@ def prepare_cuda_env(cuda_version: str, dryrun=False):
         print(f"Checking nvcc version, command {test_nvcc}")
     else:
         output = subprocess.check_output(test_nvcc, stderr=subprocess.STDOUT, env=env).decode()
+        print(f"NVCC version output: {output}")
         assert _nvcc_output_match(output, cuda_version), f"Expected CUDA version {cuda_version}, getting nvcc test result {output}"
     # step 3: install the correct magma version
     install_magma_cmd = ["conda", "install", "-c", "pytorch", CUDA_VERSION_MAP[cuda_version]['magma_version']]


### PR DESCRIPTION
CUDA 11.3 is being deprecated, and we are using environment variables to control the CUDA version instead of changing the link target of `/usr/local/cuda`.

This has many benefits:
- switching cuda version no longer needs sudo permission
- support switching cuda versions at both runtime and compile time

This PR also creates a `cuda_utils.py` to place all CUDA version related code.
