### PR TITLE
Remove the use of niter in the model code

### DIFF
--- a/lazy_bench.py
+++ b/lazy_bench.py
@@ -281,7 +281,7 @@ def timed(args, benchmark, sync, times=1):
         if args.test == 'eval':
             results = call_model_with(model, example_inputs)
         elif args.test == 'train':
-            benchmark.train(niter=1)
+            benchmark.train()
 
         # for the last i, let final_sync take care of it
         if i < times - 1:
@@ -449,7 +449,7 @@ def just_run_once(args, lazy_benchmark):
         model, example_inputs = lazy_benchmark.get_module()
         results.append(call_model_with(model, example_inputs))
     elif args.test == 'train':
-        lazy_benchmark.train(niter=1)
+        lazy_benchmark.train()
     torch._lazy.mark_step()
     torch._lazy.wait_device_ops()
     if current_device == 'cuda':
@@ -504,7 +504,7 @@ def run_tracing_execute_noops(test, lazy_benchmark):
         if test == 'eval':
             results.append(call_model_with(model, example_inputs))
         elif test == 'train':
-            lazy_benchmark.train(niter=1)
+            lazy_benchmark.train()
         # we still do a mark step, to preserve the ratio of how often we split the graph
         # and run through the process of 'compile and execute' (even though these are now noops)
         torch._lazy.mark_step()

--- a/torchbenchmark/e2e_models/hf_bert/trainer.py
+++ b/torchbenchmark/e2e_models/hf_bert/trainer.py
@@ -147,7 +147,7 @@ class Model(BenchmarkModel):
     def get_module(self):
         raise NotImplementedError("get_module is not supported by this model")
 
-    def train(self, niter=1):
+    def train(self):
         if self.jit:
             raise NotImplementedError("JIT is not supported by this model")
         if not self.device == "cuda":

--- a/torchbenchmark/models/tts_angular/angular_tts_main.py
+++ b/torchbenchmark/models/tts_angular/angular_tts_main.py
@@ -249,7 +249,8 @@ class TTSModel:
     def __del__(self):
         del self.SYNTHETIC_DATA[0]
 
-    def train(self, niter=1):
+    def train(self):
+        niter = 1
         _, global_step = self._train(self.model, self.criterion,
                                      self.optimizer, self.scheduler, None,
                                      self.global_step, self.c, niter)

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -108,17 +108,15 @@ class HuggingFaceModel(BenchmarkModel):
     def enable_fp16_half(self):
         self.model = self.model.half()
 
-    def train(self, niter=3):
-        for _ in range(niter):
-            outputs = self.model(**self.example_inputs)
-            loss = outputs.loss
-            loss.backward()
-            self.optimizer.step()
+    def train(self):
+        outputs = self.model(**self.example_inputs)
+        loss = outputs.loss
+        loss.backward()
+        self.optimizer.step()
 
-    def eval(self, niter=1) -> Tuple[torch.Tensor]:
+    def eval(self) -> Tuple[torch.Tensor]:
         with torch.no_grad():
-            for _ in range(niter):
-                out = self.model(**self.example_inputs)
+            out = self.model(**self.example_inputs)
         # logits: prediction scores of language modeling head
         # https://github.com/huggingface/transformers/blob/v4.16.2/src/transformers/modeling_outputs.py#L455
         # transformations such as fx2trt will cast the original output type to dict

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -83,13 +83,11 @@ class TimmModel(BenchmarkModel):
     def get_module(self):
         return self.model, (self.example_inputs,)
 
-    def train(self, niter=1):
-        for _ in range(niter):
-            self._step_train()
+    def train(self):
+        self._step_train()
 
-    def eval(self, niter=1) -> typing.Tuple[torch.Tensor]:
+    def eval(self) -> typing.Tuple[torch.Tensor]:
         with torch.no_grad():
             with self.amp_context():
-                for _ in range(niter):
-                    out = self._step_eval()
+                out = self._step_eval()
         return (out, )


### PR DESCRIPTION
To get more consistent results with torchdynamo's benchmark script, let's completely deprecate the niter argument.