### PR TITLE
Add lennard-jones model

### DIFF
--- a/torchbenchmark/models/lennard_jones/__init__.py
+++ b/torchbenchmark/models/lennard_jones/__init__.py
@@ -60,9 +60,7 @@ class Model(BenchmarkModel):
         )
         self.model = self.model.to(device)
 
-        if batch_size is None:
-            batch_size = Model.DEFAULT_TRAIN_BSIZE
-        r = torch.linspace(0.5, 2 * sigma, steps=batch_size, requires_grad=True)
+        r = torch.linspace(0.5, 2 * sigma, steps=self.batch_size, requires_grad=True)
 
         # Create a bunch of vectors that point along positive-x.
         # These are the dummy inputs to the model.

--- a/torchbenchmark/models/lennard_jones/__init__.py
+++ b/torchbenchmark/models/lennard_jones/__init__.py
@@ -70,6 +70,7 @@ class Model(BenchmarkModel):
 
         # Generate some dummy targets based off of some interpretation of the lennard_jones force.
         norms = torch.norm(self.drs, dim=1).reshape(-1, 1)
+        self.norms = norms
         # Create training energies
         self.training_energies = torch.stack(list(map(lennard_jones, norms))).reshape(-1, 1)
         # Create forces with random direction vectors
@@ -80,7 +81,7 @@ class Model(BenchmarkModel):
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-3)
 
     def get_module(self):
-        return self.model, self.drs
+        return self.model, (self.norms, )
 
     def train(self):
         model = self.model

--- a/torchbenchmark/models/lennard_jones/__init__.py
+++ b/torchbenchmark/models/lennard_jones/__init__.py
@@ -1,0 +1,100 @@
+# This example was adapated from https://github.com/muhrin/milad
+# It is licensed under the GLPv3 license. You can find a copy of it
+# here: https://www.gnu.org/licenses/gpl-3.0.en.html .
+
+import torch
+import torch.optim as optim
+import torch.nn as nn
+import torch.nn.functional as F
+from functorch import vmap, jacrev
+from typing import Tuple
+
+from ...util.model import BenchmarkModel
+from torchbenchmark.tasks import OTHER
+
+
+sigma = 0.5
+epsilon = 4.
+
+
+def lennard_jones(r):
+    return epsilon * ((sigma / r)**12 - (sigma / r)**6)
+
+
+def lennard_jones_force(r):
+    """Get magnitude of LJ force"""
+    return -epsilon * ((-12 * sigma**12 / r**13) + (6 * sigma**6 / r**7))
+
+
+def make_prediction(model, drs):
+    norms = torch.norm(drs, dim=1).reshape(-1, 1)
+    energies = model(norms)
+
+    network_derivs = vmap(jacrev(model))(norms).squeeze(-1)
+    forces = -network_derivs * drs / norms
+    return energies, forces
+
+
+def loss_fn(energies, forces, predicted_energies, predicted_forces):
+    return F.mse_loss(energies, predicted_energies) + 0.01 * F.mse_loss(forces, predicted_forces) / 3
+
+
+class Model(BenchmarkModel):
+    task = OTHER.OTHER_TASKS
+    DEFAULT_TRAIN_BSIZE = 1000
+    DEFAULT_EVAL_BSIZE = 1000
+
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+
+        self.model = nn.Sequential(
+            nn.Linear(1, 16),
+            nn.Tanh(),
+            nn.Linear(16, 16),
+            nn.Tanh(),
+            nn.Linear(16, 16),
+            nn.Tanh(),
+            nn.Linear(16, 16),
+            nn.Tanh(),
+            nn.Linear(16, 1)
+        )
+        self.model = self.model.to(device)
+
+        if batch_size is None:
+            batch_size = Model.DEFAULT_TRAIN_BSIZE
+        r = torch.linspace(0.5, 2 * sigma, steps=batch_size, requires_grad=True)
+
+        # Create a bunch of vectors that point along positive-x.
+        # These are the dummy inputs to the model.
+        self.drs = torch.outer(r, torch.tensor([1.0, 0, 0])).to(device=device)
+
+        # Generate some dummy targets based off of some interpretation of the lennard_jones force.
+        norms = torch.norm(self.drs, dim=1).reshape(-1, 1)
+        # Create training energies
+        self.training_energies = torch.stack(list(map(lennard_jones, norms))).reshape(-1, 1)
+        # Create forces with random direction vectors
+        self.training_forces = torch.stack([
+            force * dr for force, dr in zip(map(lennard_jones_force, norms), self.drs)
+        ])
+
+        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=1e-3)
+
+    def get_module(self):
+        return self.model, self.drs
+
+    def train(self):
+        model = self.model
+        optimizer = self.optimizer
+        model.train()
+        optimizer.zero_grad()
+        energies, forces = make_prediction(model, self.drs)
+        loss = loss_fn(self.training_energies, self.training_forces, energies, forces)
+        loss.backward()
+        optimizer.step()
+
+    def eval(self) -> Tuple[torch.Tensor]:
+        model = self.model
+        model.eval()
+        with torch.no_grad():
+            out = make_prediction(model, self.drs)
+        return out

--- a/torchbenchmark/models/lennard_jones/install.py
+++ b/torchbenchmark/models/lennard_jones/install.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()

--- a/torchbenchmark/models/lennard_jones/metadata.yaml
+++ b/torchbenchmark/models/lennard_jones/metadata.yaml
@@ -1,0 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 1000
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+not_implemented:
+- jit: true
+train_benchmark: false
+train_deterministic: false


### PR DESCRIPTION
The main thing we want to test here is that using functorch's vmap x jacrev on some fully connected layers works. This is a common sequence of operations for functorch and this PR is an example of one such model that exercises it.

Test Plan:
- `python test.py -k "test_lennard_jones_eval_cuda"`
- `python test.py -k "test_lennard_jones_train_cuda"`