### PR TITLE
Fix Huggingface model issue with distributed

### DIFF
--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -67,30 +67,27 @@ class HuggingFaceModel(BenchmarkModel):
         if test == "train":
             input_ids = torch.randint(0, config.vocab_size, (self.batch_size, self.max_length)).to(device)
             decoder_ids = torch.randint(0, config.vocab_size, (self.batch_size, self.max_length)).to(device)
-            example_inputs = {'input_ids': input_ids, 'labels': decoder_ids}
+            self.example_inputs = {'input_ids': input_ids, 'labels': decoder_ids}
             self.model.train()
         elif test == "eval":
             # Cut the length of sentence when running on CPU, to reduce test time
             if self.device == "cpu" and self.name in cpu_input_slice:
                 self.max_length = int(self.max_length / cpu_input_slice[self.name])
             eval_context = torch.randint(0, config.vocab_size, (self.batch_size, self.max_length)).to(device)
-            example_inputs = {'input_ids': eval_context, }
+            self.example_inputs = {'input_ids': eval_context, }
             if class_models[name][3] == 'AutoModelForSeq2SeqLM':
-                example_inputs['decoder_input_ids'] = eval_context
+                self.example_inputs['decoder_input_ids'] = eval_context
             self.model.eval()
-        self.example_inputs = self._convert_kw_inputs_to_list(example_inputs)
 
-    def _convert_kw_inputs_to_list(self, example_inputs):
+    def get_module(self, wrap_model=True):
         if class_models[self.name][3] == 'AutoModelForSeq2SeqLM':
             k = 'labels' if self.test == 'train' else 'decoder_input_ids'
-            return (example_inputs['input_ids'], example_inputs[k])
-        return (example_inputs["input_ids"], )
-
-    def get_module(self):
-        if class_models[self.name][3] == 'AutoModelForSeq2SeqLM':
-            k = 'labels' if self.test == 'train' else 'decoder_input_ids'
-            return ArgsToKwargsWrapper(self.model), self.example_inputs
-        return self.model, self.example_inputs
+            if not wrap_model:
+                return self.model, (
+                    self.example_inputs['input_ids'], self.example_inputs[k])
+            return ArgsToKwargsWrapper(self.model), (
+                    self.example_inputs['input_ids'], self.example_inputs[k])
+        return self.model, (self.example_inputs["input_ids"], )
 
     def get_dynamic_shapes_module(self):
         if self.dynamic_example_inputs is None:
@@ -115,14 +112,14 @@ class HuggingFaceModel(BenchmarkModel):
         self.model = self.model.half()
 
     def train(self):
-        outputs = self.model(*self.example_inputs)
+        outputs = self.model(**self.example_inputs)
         loss = outputs.loss
         loss.backward()
         self.optimizer.step()
 
     def eval(self) -> Tuple[torch.Tensor]:
         with torch.no_grad():
-            out = self.model(*self.example_inputs)
+            out = self.model(**self.example_inputs)
         # logits: prediction scores of language modeling head
         # https://github.com/huggingface/transformers/blob/v4.16.2/src/transformers/modeling_outputs.py#L455
         # transformations such as fx2trt will cast the original output type to dict


### PR DESCRIPTION
Fixes https://github.com/pytorch/benchmark/issues/1174

Test Plan:
```
python run_benchmark.py distributed --ngpus 8 --nodes 1 --model torchbenchmark.models.hf_T5.Model --trainer torchbenchmark.util.distributed.core_model.trainer.Trainer --distributed ddp --job_dir $PWD/.userbenchmark/distributed

```

Output:
```
{
    "name": "distributed",
    "environ": {
        "pytorch_git_version": "0feda8a4ba4c9fc395186686c74152e12cc5c63e"
    },
    "args": {
        "ngpus": 8,
        "nodes": 1,
        "timeout": 1440,
        "profiler": false,
        "partition": "train",
        "cluster": null,
        "job_dir": "/data/home/xzhao9/benchmark/.userbenchmark/distributed/",
        "model": "torchbenchmark.models.hf_T5.Model",
        "trainer": "torchbenchmark.util.distributed.core_model.trainer.Trainer",
        "distributed": "ddp",
        "dist_url": "file:///data/home/xzhao9/benchmark/.userbenchmark/distributed/52a9247de6324bd385612e697e077a7c_init",
        "output_dir": "/data/home/xzhao9/benchmark/.userbenchmark/distributed/",
        "extra_args": []
    },
    "metrics": {
        "0-latency_median": 398.9452362060547,
        "0-latency_stdev": 1.2685990462640786,
        "1-latency_median": 398.97906494140625,
        "1-latency_stdev": 1.2198633774230698,
        "2-latency_median": 398.9121856689453,
        "2-latency_stdev": 1.0341724509167218,
        "3-latency_median": 399.0419158935547,
        "3-latency_stdev": 1.1147936411123855,
        "4-latency_median": 398.67335510253906,
        "4-latency_stdev": 1.1395044277789603,
        "5-latency_median": 399.1611328125,
        "5-latency_stdev": 1.684352926731195,
        "6-latency_median": 399.2419891357422,
        "6-latency_stdev": 1.2517432020509627,
        "7-latency_median": 398.93389892578125,
        "7-latency_stdev": 1.3721978229900935
    }
}
```