### PR TITLE
Add train test for cmf_10x, ads_dhen_5x, umia_v1_fbr and blue_reels_vdd_v2

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -44,8 +44,7 @@ def get_hf_maxlength(model: 'torchbenchmark.util.model.BenchmarkModel') -> Optio
 
 def check_precision(model: 'torchbenchmark.util.model.BenchmarkModel', precision: str) -> bool:
     if precision == "fp16":
-        # we disable half precision train (non-amp) for now
-        return model.device == 'cuda' and model.test == 'eval' and hasattr(model, "enable_fp16_half")
+        return model.device == 'cuda' and hasattr(model, "enable_fp16_half")
     if precision == "amp":
         if model.test == 'eval' and model.device == 'cuda':
             return True

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -84,11 +84,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             enable_profiling_executor  # force JIT profiling executor to be enabled by default
         ]
         set_random_seed()
-
-    # Run the post processing for model acceleration
-    def __post__init__(self):
         # sanity checks of the options
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
+        # parse the args
         self.dargs, opt_args = parse_decoration_args(self, self.extra_args)
         # if the args contain "--torchdynamo", parse torchdynamo args
         if "--torchdynamo" in opt_args:
@@ -98,6 +96,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         else:
             self.dynamo = False
             self.opt_args, self.extra_args = parse_opt_args(self, opt_args)
+
+    # Run the post processing for model acceleration
+    def __post__init__(self):
         should_check_correctness = check_correctness_p(self, self.opt_args)
         if should_check_correctness:
             self.eager_output = stableness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY, rounds=1)


### PR DESCRIPTION
Summary:
Add train tests for cmf_10x, ads_dhen_5x, umia_v1_fbr and blue_reels_vdd_v2 models.

Upstream code changes break blue_reels_vdd_v2 and umia_v1_fbr. Fix the model code accordingly.

Differential Revision: D39712630

