### PR TITLE
Improve bisection workflow

### DIFF
--- a/.github/scripts/bmutils/analyze-bisection-result.py
+++ b/.github/scripts/bmutils/analyze-bisection-result.py
@@ -25,8 +25,8 @@ def setup_gh_issue(bisection_root: str, gh_workflow_id: str):
     json_path = bisection_path.joinpath("result.json")
     with open(json_path, "r") as jp:
         result = jp.read()
-    result = f"```\n {result} \n```"
-    workflow_str = f"Bisection workflow link: {WORKFLOW_LINK_TEMPLATE}{gh_workflow_id}"
+    result = f"\nResult json: \n```\n{result}\n```"
+    workflow_str = f"\nBisection workflow link: {WORKFLOW_LINK_TEMPLATE}{gh_workflow_id}\n"
     gh_issue_path = bisection_path.joinpath("gh-issue.md")
     with open(gh_issue_path, "a") as ghi:
         ghi.write(result)

--- a/.github/scripts/bmutils/analyze-bisection-result.py
+++ b/.github/scripts/bmutils/analyze-bisection-result.py
@@ -1,0 +1,59 @@
+import argparse
+import os
+import json
+import yaml
+from pathlib import Path
+
+WORKFLOW_LINK_TEMPLATE = "https://github.com/pytorch/benchmark/actions/runs/"
+
+def check_env(bisection_root: str):
+    "Check `bisection_root` contains bisection config file, github issue file, and result json."
+    # gh-issue.md exists
+    # result.json exists
+    bisection_path = Path(bisection_root)
+    assert os.environ["GITHUB_ENV"], f"GITHUB_ENV environment variable doesn't exist."
+    assert bisection_path.is_dir(), f"Specified bisection root {bisection_path} is not a directory."
+    assert bisection_path.joinpath("gh-issue.md").exists(), \
+        f"Bisection directory {bisection_path} doesn't contain file gh-issue.md."
+    assert bisection_path.joinpath("result.json").exists(), \
+        f"Bisection directory {bisection_path} doesn't contain file result.json."
+    assert bisection_path.joinpath("config.yaml").exists(), \
+        f"Bisection directory {bisection_path} doesn't contain file config.yaml."
+
+def setup_gh_issue(bisection_root: str, gh_workflow_id: str):
+    bisection_path = Path(bisection_root)
+    json_path = bisection_path.joinpath("result.json")
+    with open(json_path, "r") as jp:
+        result = jp.read()
+    result = f"```\n {result} \n```"
+    workflow_str = f"Bisection workflow link: {WORKFLOW_LINK_TEMPLATE}{gh_workflow_id}"
+    gh_issue_path = bisection_path.joinpath("gh-issue.md")
+    with open(gh_issue_path, "a") as ghi:
+        ghi.write(result)
+        ghi.write(workflow_str)
+
+def set_env_if_nonempty(bisection_root: str):
+    bisection_path = Path(bisection_root)
+    json_path = bisection_path.joinpath("result.json")
+    with open(json_path, "r") as jp:
+        result = json.load(jp)
+    # if result is empty, no need to setup the env
+    if result["result"] == []:
+        return
+    yaml_path = bisection_path.joinpath("config.yaml")
+    with open(yaml_path, "r") as config_file:
+        config = yaml.safe_load(config_file)
+    affected_pytorch_version = config["end_version"]
+    fname = os.environ["GITHUB_ENV"]
+    content = f"TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL='{affected_pytorch_version}'\n"
+    with open(fname, 'a') as fo:
+        fo.write(content)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bisection-root", required=True, help="Root directory of the bisection directory")
+    parser.add_argument("--gh-workflow-id", required=True, help="GitHub workflow id")
+    args = parser.parse_args()
+    check_env(args.bisection_root)
+    setup_gh_issue(args.bisection_root, args.gh_workflow_id)
+    set_env_if_nonempty(args.bisection_root)

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -46,6 +46,19 @@ jobs:
           # Update the result json symbolic link
           ln -sf "${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json" "${BISECT_BASE}/result.json"
           cp -r "${BISECT_BASE}" ./bisection-result
+      - name: Analyze bisection result
+        run: |
+          export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
+          export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
+          python ./.github/scripts/analyze-bisection-result.py --bisection-base "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
+      - name: Create the github issue
+        if: env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: V1 Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL }}
+          content-filepath: ./benchmark-output/gh-issue.md
+          labels: |
+            torchbench-perf-report
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
           export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
-          python ./.github/scripts/analyze-bisection-result.py --bisection-base "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
+          python ./.github/scripts/analyze-bisection-result.py --bisection-root "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
       - name: Create the github issue
         if: env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL
         uses: peter-evans/create-issue-from-file@v3

--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -80,6 +80,7 @@ jobs:
             # Setup the bisection environment
             BISECTION_HOME="${HOME}/${{ env.BISECTION_ROOT }}/bisection-gh${GITHUB_RUN_ID}"
             mkdir -p "${BISECTION_HOME}"
+            mv ./benchmark-output/gh-issue.md "${BISECTION_HOME}/gh-issue.md"
             cp ./benchmark-output/bisection.yaml "${BISECTION_HOME}/config.yaml"
           fi
       - name: Dispatch the v1-bisection workflow

--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -92,14 +92,6 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
              https://api.github.com/repos/pytorch/benchmark/actions/workflows/10693192/dispatches \
             -d '{"ref": "main", "inputs": {"issue_name": "bisection-gh'"${GITHUB_RUN_ID}"'" } }'
-      - name: Create the github issue
-        if: env.TORCHBENCH_PERF_SIGNAL
-        uses: peter-evans/create-issue-from-file@v3
-        with:
-          title: Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_SIGNAL }}
-          content-filepath: ./benchmark-output/gh-issue.md
-          labels: |
-            torchbench-perf-report
       - name: Copy artifact and upload to scribe
         run: |
           . activate "${CONDA_ENV_NAME}"

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
           export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
-          python ./.github/scripts/analyze-bisection-result.py --bisection-root "${BISECT_BASE}"
+          python ./.github/scripts/analyze-bisection-result.py --bisection-root "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
       - name: Create the github issue
         if: env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL
         uses: peter-evans/create-issue-from-file@v3

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -47,6 +47,14 @@ jobs:
           # Update the result json symbolic link
           ln -sf "${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json" "${BISECT_BASE}/result.json"
           cp -r "${BISECT_BASE}" ./bisection-result
+      - name: Create the github issue
+        if: env.TORCHBENCH_PERF_BISECTION_SIGNAL
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: V2 Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_BISECTION_SIGNAL }}
+          content-filepath: ./bisection-result/gh-issue.md
+          labels: |
+            torchbench-perf-report
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -47,11 +47,16 @@ jobs:
           # Update the result json symbolic link
           ln -sf "${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json" "${BISECT_BASE}/result.json"
           cp -r "${BISECT_BASE}" ./bisection-result
+      - name: Analyze bisection result
+        run: |
+          export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
+          export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
+          python ./.github/scripts/analyze-bisection-result.py --bisection-root "${BISECT_BASE}"
       - name: Create the github issue
-        if: env.TORCHBENCH_PERF_BISECTION_SIGNAL
+        if: env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL
         uses: peter-evans/create-issue-from-file@v3
         with:
-          title: V2 Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_BISECTION_SIGNAL }}
+          title: V2 Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL }}
           content-filepath: ./bisection-result/gh-issue.md
           labels: |
             torchbench-perf-report

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -95,14 +95,6 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/pytorch/benchmark/actions/workflows/16176850/dispatches \
             -d '{"ref": "main", "inputs": {"issue_name": "bisection-gh'"${GITHUB_RUN_ID}"'" } }'
-      - name: Create the github issue
-        if: env.TORCHBENCH_PERF_SIGNAL
-        uses: peter-evans/create-issue-from-file@v3
-        with:
-          title: V2 Performance Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_PERF_SIGNAL }}
-          content-filepath: ./benchmark-output/gh-issue.md
-          labels: |
-            torchbench-perf-report
       - name: Copy artifact and upload to scribe
         run: |
           . activate "${CONDA_ENV_NAME}"

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -83,6 +83,7 @@ jobs:
             # Setup the bisection environment
             BISECTION_HOME="${HOME}/${{ env.BISECTION_ROOT }}/bisection-gh${GITHUB_RUN_ID}"
             mkdir -p "${BISECTION_HOME}"
+            mv ./benchmark-output/gh-issue.md "${BISECTION_HOME}/gh-issue.md"
             cp ./benchmark-output/bisection.yaml "${BISECTION_HOME}/config.yaml"
           fi
       - name: Dispatch the bisection workflow


### PR DESCRIPTION
This PR improves the bisection workflow by moving the GitHub issue part to the bisection workflow.
After the bisection finishes, if the result is non-empty, create a GitHub issue tracker. Otherwise, treat it as noise and do not create an issue.

TODO: we still need to post GitHub issues when bisection workflow fails, but we can leave it to a follow-up PR. See https://github.com/pytorch/benchmark/issues/1212