### PR TITLE
Support extra_py_args in torchdynamo options

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -28,5 +28,5 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         model.eval = dynamo_optimizer(model.eval)
     # evaluate extra python code passed by the user
     if args.extra_py_args:
-        eval(args.extra_py_args)
+        exec(args.extra_py_args)
     torchdynamo.reset()

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -11,6 +11,9 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dy
     parser.add_argument(
         "--torchdynamo", choices=available_backends, help="Specify torchdynamo backends"
     )
+    parser.add_argument(
+        "--extra-py-args", type=str, help="Extra Python args to evaluate."
+    )
     args, extra_args = parser.parse_known_args(dynamo_args)
     return args, extra_args
 
@@ -23,4 +26,7 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         model.train = dynamo_optimizer(model.train)
     else:
         model.eval = dynamo_optimizer(model.eval)
+    # evaluate extra python code passed by the user
+    if args.extra_py_args:
+        eval(args.extra_py_args)
     torchdynamo.reset()


### PR DESCRIPTION
This is to support customized triton options for torchdynamo. For example:
```
python run.py resnet18 -d cuda --torchdynamo inductor --extra-py-args 'torchinductor.config.triton.mm = "triton”'
```