### PR TITLE
Add flag for dynamo+ddp optimizations

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -111,6 +111,7 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
     parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
+    parser.add_argument("--optimize_dynamo_ddp", action='store_true', help="enable extra optimizations for DDP + dynamo")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"
@@ -146,3 +147,16 @@ def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argp
         module, exmaple_inputs = model.get_module()
         precision = 'fp16' if not model.dargs.precision == "fp32" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))
+
+    if args.optimize_dynamo_ddp:
+        import torchdynamo
+        @contextlib.contextmanager
+        def optimize_ddp_ctx(val: bool):
+            old_value = torchdynamo.config.optimize_ddp
+            try:
+                torchdynamo.config.optimize_ddp = val
+                yield
+            finally:
+                torchdynamo.config.optimize_ddp = old_value
+
+        model.add_context(lambda: optimize_ddp_ctx(True))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1219

Add a flag that can be used to turn dynamo+ddp optimizations on. This
will be used to compare how dynamo+ddp performs with and without the
additional graph break strategy for improving dynamo+ddp
compute/communication overlap.