### PR TITLE
Add flag for dynamo+ddp optimizations

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -27,7 +27,6 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
     optimize_ddp_context = contextlib.nullcontext
 
     if args.optimize_dynamo_ddp:
-        import torchdynamo
         @contextlib.contextmanager
         def optimize_ddp_ctx(val: bool):
             old_value = torchdynamo.config.optimize_ddp

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -2,6 +2,7 @@
 Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 """
 import argparse
+import contextlib
 from typing import List
 import torchdynamo
 
@@ -14,19 +15,42 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dy
     parser.add_argument(
         "--extra-py-args", type=str, help="Extra Python args to evaluate."
     )
+    parser.add_argument(
+        "--optimize_dynamo_ddp",
+        action='store_true',
+        help="enable extra optimizations for DDP + dynamo"
+    )
     args, extra_args = parser.parse_known_args(dynamo_args)
     return args, extra_args
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace, precision: str):
-    if args.torchdynamo == "fx2trt" and precision == "fp16":
-        dynamo_optimizer = torchdynamo.optimize(torchdynamo.optimizations.backends.fx2trt_compiler_fp16)
-    else:
-        dynamo_optimizer = torchdynamo.optimize(args.torchdynamo)
-    # evaluate extra python code passed by the user
-    if args.extra_py_args:
-        exec(args.extra_py_args)
-    if model.test == "train":
-        model.train = dynamo_optimizer(model.train)
-    else:
-        model.eval = dynamo_optimizer(model.eval)
+    optimize_ddp_context = contextlib.nullcontext
+
+    if args.optimize_dynamo_ddp:
+        import torchdynamo
+        @contextlib.contextmanager
+        def optimize_ddp_ctx(val: bool):
+            old_value = torchdynamo.config.optimize_ddp
+            try:
+                torchdynamo.config.optimize_ddp = val
+                yield
+            finally:
+                torchdynamo.config.optimize_ddp = old_value
+        optimize_ddp_context = lambda: optimize_ddp_ctx(True)
+
+    with optimize_ddp_context():
+        if args.torchdynamo == "fx2trt" and precision == "fp16":
+            dynamo_optimizer = torchdynamo.optimize(torchdynamo.optimizations.backends.fx2trt_compiler_fp16)
+        else:
+            dynamo_optimizer = torchdynamo.optimize(args.torchdynamo)
+        # evaluate extra python code passed by the user
+        if args.extra_py_args:
+            exec(args.extra_py_args)
+        if model.test == "train":
+            model.train = dynamo_optimizer(model.train)
+        else:
+            model.eval = dynamo_optimizer(model.eval)
+
+    model.add_context(optimize_ddp_context)
+
     torchdynamo.reset()

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 from typing import List, Optional, Tuple
 from torchbenchmark.util.backends import list_backends, BACKENDS
 

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -112,7 +112,6 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
     parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
-    parser.add_argument("--optimize_dynamo_ddp", action='store_true', help="enable extra optimizations for DDP + dynamo")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"
@@ -148,16 +147,4 @@ def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argp
         module, exmaple_inputs = model.get_module()
         precision = 'fp16' if not model.dargs.precision == "fp32" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))
-
-    if args.optimize_dynamo_ddp:
-        import torchdynamo
-        @contextlib.contextmanager
-        def optimize_ddp_ctx(val: bool):
-            old_value = torchdynamo.config.optimize_ddp
-            try:
-                torchdynamo.config.optimize_ddp = val
-                yield
-            finally:
-                torchdynamo.config.optimize_ddp = old_value
-
         model.add_context(lambda: optimize_ddp_ctx(True))

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -111,6 +111,7 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser.add_argument("--torch_trt", action='store_true', help="enable torch_tensorrt")
     parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
     parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
+    parser.add_argument("--optimize_dynamo_ddp", action='store_true', help="enable extra optimizations for DDP + dynamo")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"
@@ -146,3 +147,16 @@ def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argp
         module, exmaple_inputs = model.get_module()
         precision = 'fp16' if not model.dargs.precision == "fp32" else 'fp32'
         model.set_module(enable_torchtrt(precision=precision, model=module, example_inputs=exmaple_inputs))
+
+    if args.optimize_dynamo_ddp:
+        import torchdynamo
+        @contextlib.contextmanager
+        def optimize_ddp_ctx(val: bool):
+            old_value = torchdynamo.config.optimize_ddp
+            try:
+                torchdynamo.config.optimize_ddp = val
+                yield
+            finally:
+                torchdynamo.config.optimize_ddp = old_value
+
+        model.add_context(lambda: optimize_ddp_ctx(True))

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib
 import os
+import copy
 import csv
 import io
 import submitit
@@ -131,7 +132,7 @@ class TrainerWrapper(object):
     def __init__(self, args, model_args):
         self.args = args
         self.args.output_dir = args.job_dir
-        
+
         # extra args just passed to the Trainer class ctor
         self.model_args=model_args
 
@@ -184,7 +185,7 @@ def main():
 
     # Note that the folder will depend on the job_id, to easily track experiments
     executor = submitit.AutoExecutor(folder=args.job_dir, slurm_max_num_timeout=3000)
-    
+
     executor.update_parameters(
         gpus_per_node=args.ngpus,
         # one task per GPU
@@ -199,7 +200,7 @@ def main():
 
     executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=1000)
 
-    
+
     # args.dist_url = get_init_file(args).as_uri()
     # args.output_dir = args.job_dir
     # job = executor.submit(TrainerWrapper(args))
@@ -247,33 +248,41 @@ def main():
     for nodes in node_list:
         for model_name in models:
             for model_args in model_args_configs:
-                batch_size = model_batch_size[model_name]
-                args.model = model_name
-                args.batch_size = batch_size
-                args.nodes = nodes
-                args.dist_url = get_init_file(args).as_uri()
-                args.output_dir = args.job_dir
-                executor.update_parameters(
-                    gpus_per_node=args.ngpus,
-                    # one task per GPU
-                    tasks_per_node=args.ngpus,
-                    cpus_per_task=10,
-                    nodes=args.nodes,
-                    timeout_min=args.timeout,
-                    # Below are cluster dependent parameters
-                    slurm_partition=args.partition,
-                    slurm_signal_delay_s=120,
-                )
-                job = executor.submit(TrainerWrapper(args, model_args))
+                for has_breaks in [True, False]:
+                    # copy the model args so we can add more arguments without modifying
+                    # the original model_args list.
+                    copied_model_args = copy.copy(model_args)
+                    breakname = "withbreaks" if has_breaks else "nobreaks"
+                    if has_breaks:
+                        copied_model_args.append("--optimize_dynamo_ddp")
+                    batch_size = model_batch_size[model_name]
+                    args.model = model_name
+                    args.batch_size = batch_size
+                    args.nodes = nodes
+                    args.dist_url = get_init_file(args).as_uri()
+                    args.output_dir = args.job_dir
+                    executor.update_parameters(
+                        gpus_per_node=args.ngpus,
+                        # one task per GPU
+                        tasks_per_node=args.ngpus,
+                        cpus_per_task=10,
+                        nodes=args.nodes,
+                        timeout_min=args.timeout,
+                        # Below are cluster dependent parameters
+                        slurm_partition=args.partition,
+                        slurm_signal_delay_s=120,
+                        slurm_exclude=args.exclude,
+                    )
+                    job = executor.submit(TrainerWrapper(args, copied_model_args))
 
-                # print ID of the Slurm job
-                backend_name = get_backend_name(model_args)
-                print(f"{model_name}_{backend_name}_{nodes}: {job.job_id}")
-                output_csv(
-                    args.index_file,
-                    ("model", "backend", "nodes", "job_id"),
-                    (model_name, backend_name, nodes, job.job_id),
-                )
+                    # print ID of the Slurm job
+                    backend_name = get_backend_name(model_args)
+                    print(f"{model_name}_{backend_name}_{nodes}_{breakname}: {job.job_id}")
+                    output_csv(
+                        args.index_file,
+                        ("model", "backend", "nodes", "has_breaks", "job_id"),
+                        (model_name, backend_name, nodes, has_breaks, job.job_id),
+                    )
 
     # waits for completion and returns output
     print(job.results())

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -249,6 +249,9 @@ def main():
         for model_name in models:
             for model_args in model_args_configs:
                 for has_breaks in [True, False]:
+                    backend_name = get_backend_name(model_args)
+                    if backend_name == "eager" and has_breaks:
+                        continue
                     # copy the model args so we can add more arguments without modifying
                     # the original model_args list.
                     copied_model_args = copy.copy(model_args)
@@ -276,7 +279,6 @@ def main():
                     job = executor.submit(TrainerWrapper(args, copied_model_args))
 
                     # print ID of the Slurm job
-                    backend_name = get_backend_name(model_args)
                     print(f"{model_name}_{backend_name}_{nodes}_{breakname}: {job.job_id}")
                     output_csv(
                         args.index_file,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1221

Add a flag that can be used to turn dynamo+ddp optimizations on. This
will be used to compare how dynamo+ddp performs with and without the
additional graph break strategy for improving dynamo+ddp
compute/communication overlap.

Differential Revision: [D39976005](https://our.internmc.facebook.com/intern/diff/D39976005)