### PR TITLE
Required changes after cuBLAS workspace allocation change

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -520,10 +520,11 @@ class ModelTask(base_task.TaskBase):
         if skip or os.getenv('PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK', '0') == '1':
             yield
             return
-
+        torch._C._cuda_clearCublasWorkspaces()
         self.gc_collect()
         memory_before = self.worker.load_stmt("torch.cuda.memory_allocated()")
         yield
+        torch._C._cuda_clearCublasWorkspaces()
         self.gc_collect()
         assert_equal(
             memory_before,

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -520,11 +520,11 @@ class ModelTask(base_task.TaskBase):
         if skip or os.getenv('PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK', '0') == '1':
             yield
             return
-        torch._C._cuda_clearCublasWorkspaces()
+        self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
         self.gc_collect()
         memory_before = self.worker.load_stmt("torch.cuda.memory_allocated()")
         yield
-        torch._C._cuda_clearCublasWorkspaces()
+        self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
         self.gc_collect()
         assert_equal(
             memory_before,

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple
 from urllib import request
 
+import torch
+
 from components._impl.tasks import base as base_task
 from components._impl.workers import subprocess_worker
 
@@ -520,11 +522,13 @@ class ModelTask(base_task.TaskBase):
         if skip or os.getenv('PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK', '0') == '1':
             yield
             return
-        self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
+        if hasattr(torch._C, '_cuda_clearCublasWorkspaces'):
+            self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
         self.gc_collect()
         memory_before = self.worker.load_stmt("torch.cuda.memory_allocated()")
         yield
-        self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
+        if hasattr(torch._C, '_cuda_clearCublasWorkspaces'):
+            self.worker.load_stmt("torch._C._cuda_clearCublasWorkspaces()")
         self.gc_collect()
         assert_equal(
             memory_before,


### PR DESCRIPTION
The cuBLAS workspace PR https://github.com/pytorch/pytorch/pull/85447 moves allocations that were previously managed by cuBLAS to the `CUDACachingAllocator`. While the lifetime of this memory has not changed, it is now visible to `torch.cuda.memory_allocated()` which can throw false-positives in testing results. A workaround to get an accurate memory measurement is to clear all allocated cuBLAS workspaces via `torch._C._cuda_clearCublasWorkspaces()` which was also added in this PR.

Do not merge this for now as the cuBLAS workspace PR has been reverted.

CC @xuzhao9 @seemethere