### PR TITLE
Fix broken ci from gpt2_large

### DIFF
--- a/torchbenchmark/models/hf_GPT2_large/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2_large/metadata.yaml
@@ -8,3 +8,6 @@ not_implemented:
   - jit: true
   # OOMs on torchbench CI
   - device: cuda
+  # CPU OOM on torchbench CI
+  - device: cpu
+    test: train


### PR DESCRIPTION
The trunk ci is broken because gpt2_large test returns exit code 9 (Out-of-memory).

This PR skips the cpu train test for GPT2_large