### PR TITLE
Skip hf_GPT2_large_train on cpu

### DIFF
--- a/torchbenchmark/models/hf_GPT2_large/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2_large/metadata.yaml
@@ -8,3 +8,5 @@ not_implemented:
   - jit: true
   # OOMs on torchbench CI
   - device: cuda
+  # OSError: Subprocess terminates with code 9
+  - device: cpu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1232

Skip model train test on cpu because it is failing in CI.

Differential Revision: [D40113201](https://our.internmc.facebook.com/intern/diff/D40113201)