### PR TITLE
functorch userbenchmark

### DIFF
--- a/torchbenchmark/models/lennard_jones/__init__.py
+++ b/torchbenchmark/models/lennard_jones/__init__.py
@@ -60,7 +60,7 @@ class Model(BenchmarkModel):
         )
         self.model = self.model.to(device)
 
-        r = torch.linspace(0.5, 2 * sigma, steps=self.batch_size, requires_grad=True)
+        r = torch.linspace(0.5, 2 * sigma, steps=self.batch_size)
 
         # Create a bunch of vectors that point along positive-x.
         # These are the dummy inputs to the model.

--- a/userbenchmark/functorch/__init__.py
+++ b/userbenchmark/functorch/__init__.py
@@ -1,0 +1,32 @@
+import torch
+from ..utils import dump_output
+from .cases import benchmark_cases
+from .util import benchmark
+import pprint
+from typing import List
+
+
+BM_NAME = 'functorch'
+
+
+def run_benchmarks():
+    metrics = {}
+
+    for case_ctor in benchmark_cases:
+        case = case_ctor()
+        runtime_ms = benchmark(case)
+        metrics[case.name()] = runtime_ms
+    return metrics
+
+
+def run(args: List[str]):
+    metrics = run_benchmarks()
+    result = {
+        'name': BM_NAME,
+        'environ': {
+            'git_version': torch.version.git_version,
+        },
+        'metrics': metrics,
+    }
+    pprint.pprint(result)
+    dump_output(BM_NAME, result)

--- a/userbenchmark/functorch/cases.py
+++ b/userbenchmark/functorch/cases.py
@@ -1,0 +1,63 @@
+from .util import BenchmarkCase
+from torchbenchmark.models.lennard_jones import Model as LJModel
+from torchbenchmark.models.functorch_maml_omniglot import Model as FTMamlOmniglot
+from torchbenchmark.models.functorch_dp_cifar10 import Model as FTDPCifar10
+from .vmap_hessian_fc import VmapHessianFC
+from .simple_models import (
+    SimpleCNN,
+    SimpleMLP,
+    VmapWrapper,
+    EnsembleMultiWrapper,
+    EnsembleSingleWrapper,
+    PerSampleGradWrapper,
+)
+
+
+class TorchBenchModelWrapper(BenchmarkCase):
+    def __init__(self, name, model, device):
+        self.model = model('train', device)
+        self.name_ = f'{name}_{device}'
+
+    def name(self):
+        return self.name_
+
+    def run(self):
+        return self.model.train()
+
+
+# functorch user benchmark
+# ------------------------
+# This userbenchmark is used for regression testing of:
+# - microbenchmarks,
+# - low-quality models that shouldn't go into torchbenchmark
+# - pieces of models where we do not have access to the full model.
+# - models in torchbenchmark that have not yet made it to a release branch
+# (and therefore are not being tracked for regressions).
+#
+# When adding a functorch-related benchmark, please prefer finding a high-quality
+# model that uses the benchmark and adding it to the torchbenchmark suite.
+# There is better infra support there and other folks use those models
+# for cross-cutting tests.
+benchmark_cases = [
+    # [models from torchbench that haven't made it to stable yet]
+    lambda: TorchBenchModelWrapper('lennard_jones', LJModel, 'cpu'),
+    lambda: TorchBenchModelWrapper('lennard_jones', LJModel, 'cuda'),
+    lambda: TorchBenchModelWrapper('functorch_maml_omniglot', FTMamlOmniglot, 'cpu'),
+    lambda: TorchBenchModelWrapper('functorch_maml_omniglot', FTMamlOmniglot, 'cuda'),
+    lambda: TorchBenchModelWrapper('functorch_dp_cifar10', FTDPCifar10, 'cuda'),
+    # end [models from torchbench that haven't made it to stable yet]
+    VmapHessianFC,
+    # [combinations from functorch tutorials]
+    lambda: VmapWrapper(SimpleMLP, 'cpu'),
+    lambda: VmapWrapper(SimpleMLP, 'cuda'),
+    lambda: EnsembleMultiWrapper(SimpleMLP, 'cpu'),
+    lambda: EnsembleMultiWrapper(SimpleMLP, 'cuda'),
+    lambda: EnsembleMultiWrapper(SimpleCNN, 'cuda'),
+    lambda: EnsembleSingleWrapper(SimpleMLP, 'cpu'),
+    lambda: EnsembleSingleWrapper(SimpleMLP, 'cuda'),
+    lambda: EnsembleSingleWrapper(SimpleCNN, 'cuda'),
+    lambda: PerSampleGradWrapper(SimpleMLP, 'cpu'),
+    lambda: PerSampleGradWrapper(SimpleMLP, 'cuda'),
+    lambda: PerSampleGradWrapper(SimpleCNN, 'cuda'),
+    # end [combinations from functorch tutorials]
+]

--- a/userbenchmark/functorch/ci.yaml
+++ b/userbenchmark/functorch/ci.yaml
@@ -1,0 +1,2 @@
+platform: "aws-t4-metal"
+schedule: "nightly"

--- a/userbenchmark/functorch/simple_models.py
+++ b/userbenchmark/functorch/simple_models.py
@@ -1,0 +1,155 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from functorch import vmap, grad, combine_state_for_ensemble, make_functional_with_buffers
+import functools
+
+from .util import BenchmarkCase
+
+
+class SimpleMLP(nn.Module):
+    def __init__(self):
+        super(SimpleMLP, self).__init__()
+        self.fc1 = nn.Linear(784, 128)
+        self.fc2 = nn.Linear(128, 128)
+        self.fc3 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = x.flatten(1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.fc2(x)
+        x = F.relu(x)
+        x = self.fc3(x)
+        return x
+
+    @classmethod
+    def make_input(cls, bs=None):
+        shape = [64, 1, 28, 28]
+        if bs is None:
+            return torch.randn(*shape)
+        return torch.randn(bs, *shape)
+
+    @classmethod
+    def make_target(cls, bs=None):
+        shape = [64]
+        if bs is None:
+            return torch.randint(10, shape)
+        return torch.randn(10, [bs] + shape)
+
+
+class SimpleCNN(nn.Module):
+    def __init__(self):
+        super(SimpleCNN, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        output = x
+        return output
+
+    @classmethod
+    def make_input(cls, bs=None):
+        shape = [64, 1, 28, 28]
+        if bs is None:
+            return torch.randn(*shape)
+        return torch.randn(bs, *shape)
+
+    @classmethod
+    def make_target(cls, bs=None):
+        shape = [64]
+        if bs is None:
+            return torch.randint(10, shape)
+        return torch.randn(10, [bs] + shape)
+
+
+
+class VmapWrapper(BenchmarkCase):
+    def __init__(self, model_cls, device):
+        self.name_ = f'{model_cls.__name__}_vmap_{device}'
+
+        self.model = model_cls().to(device)
+        self.inputs = model_cls.make_input().to(device)
+
+    def name(self):
+        return self.name_
+
+    def run(self):
+        vmap(self.model)(self.inputs)
+
+
+def ensemble_setup(self, model_cls, device):
+    num_models = 10
+    models = [model_cls().to(device) for _ in range(num_models)]
+    fmodel, params, buffers = combine_state_for_ensemble(models)
+    self.fmodel = fmodel
+    self.params = params
+    self.buffers = buffers
+    self.inputs = model_cls.make_input(num_models).to(device)
+
+
+class EnsembleMultiWrapper(BenchmarkCase):
+    def __init__(self, model_cls, device):
+        self.name_ = f'{model_cls.__name__}_ensemble_multi_{device}'
+        ensemble_setup(self, model_cls, device)
+
+    def name(self):
+        return self.name_
+
+    def run(self):
+        vmap(self.fmodel)(self.params, self.buffers, self.inputs)
+
+
+class EnsembleSingleWrapper(BenchmarkCase):
+    def __init__(self, model_cls, device):
+        self.name_ = f'{model_cls.__name__}_ensemble_single_{device}'
+        ensemble_setup(self, model_cls, device)
+        self.inputs = self.inputs[0]
+
+    def name(self):
+        return self.name_
+
+    def run(self):
+        vmap(self.fmodel, (0, 0, None))(self.params, self.buffers, self.inputs)
+
+
+def loss_fn(predictions, targets):
+    return F.nll_loss(predictions, targets)
+
+
+def compute_loss(fmodel, params, buffers, sample, target):
+    sample = sample.unsqueeze(0)  # prepend batch dimension for processing
+    target = target.unsqueeze(0)
+
+    prediction = fmodel(params, buffers, sample)
+    return loss_fn(prediction, target)
+
+
+class PerSampleGradWrapper(BenchmarkCase):
+    def __init__(self, model_cls, device):
+        self.name_ = f'{model_cls.__name__}_persamplegrad_{device}'
+        model = model_cls().to(device)
+        self.model = make_functional_with_buffers(model)
+        self.inputs = model_cls.make_input().to(device)
+        self.targets = model_cls.make_target().to(device)
+
+    def name(self):
+        return self.name_
+
+    def run(self):
+        fmodel, params, buffers = self.model
+
+        loss = functools.partial(compute_loss, fmodel)
+        vmap(grad(loss), (None, None, 0, 0))(params, buffers, self.inputs, self.targets)

--- a/userbenchmark/functorch/util.py
+++ b/userbenchmark/functorch/util.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+from torch.utils.benchmark import Timer
+from torch.utils._pytree import tree_flatten
+
+
+class BenchmarkCase(ABC):
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abstractmethod
+    def run(self) -> Callable:
+        pass
+
+
+def time(fn: Callable, test_runs: int) -> float:
+    t = Timer(stmt="fn()", globals={"fn": fn})
+    times = t.blocked_autorange()
+    return times.median * 1000  # time in ms
+
+
+def benchmark(case: BenchmarkCase, warmup_runs: int = 10, test_runs: int = 20) -> float:
+    for _ in range(warmup_runs):
+        case.run()
+
+    return time(case.run, test_runs)

--- a/userbenchmark/functorch/vmap_hessian_fc.py
+++ b/userbenchmark/functorch/vmap_hessian_fc.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn as nn
+from functorch import vmap, jacfwd, jacrev
+from .util import BenchmarkCase
+
+# batched hessians of fully connected layers is a popular quantity
+# in physics-related models.
+# This test case is from https://github.com/pytorch/functorch/issues/989
+# We haven't been able to get the full model yet, so, this test case
+# is going into the functorch userbenchmark instead of torchbenchmark.
+class VmapHessianFC(BenchmarkCase):
+    def __init__(self):
+        device = 'cuda'
+        D1 = 2  # x, y
+        D2 = 3  # u, v, p
+        B = 10000
+        x = torch.randn(B, D1).to(device)
+
+        model = nn.Sequential(
+            nn.Linear(D1, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, D2),
+        ).to(device)
+
+        self.model = model
+        self.x = x
+
+    def name(self):
+        return 'vmap_hessian_fc_cuda'
+
+    def run(self):
+        def predict(x):
+            out = self.model(x)
+            return out, out
+
+        hessian, pred = vmap(
+            jacfwd(jacrev(predict, argnums=0, has_aux=True), argnums=0, has_aux=True),
+            in_dims=0,
+        )(
+            self.x
+        )


### PR DESCRIPTION
functorch userbenchmark

This PR sets up the functorch userbenchmark and configures it to run 3
functorch models in the torchbenchmark suite that have not made it to
stable (e.g. torchbench v3) yet, so we can get regression testing on
them.

In addition, this PR adds some microbenchmarks for functorch into the userbenchmark.

Test Plan:

`python run_benchmark.py functorch` gives:


```
(/raid/rzou/pt/binaries4-env) [1] rzou@devfair0317:~/pytorch/benchmark (functorch_userbenchmark) $ cat .userbenchmark/func
torch/metrics-20221007144500.json
{
    "name": "functorch",
    "environ": {
        "git_version": "b472915d42b840469910e8fb243d40441a4b5a17"
    },
    "metrics": {
        "lennard_jones_cpu": 4.601219408214092,
        "lennard_jones_cuda": 6.164539773017168,
        "functorch_maml_omniglot_cpu": 12597.586147487164,
        "functorch_maml_omniglot_cuda": 318.9176507294178,
        "functorch_dp_cifar10_cuda": 83.94835330545902,
        "vmap_hessian_fc_cuda": 60.61760187149048,
        "SimpleMLP_vmap_cpu": 0.46687781251966953,
        "SimpleMLP_vmap_cuda": 0.36797603964805603,
        "SimpleMLP_ensemble_multi_cpu": 2.3521081916987896,
        "SimpleMLP_ensemble_multi_cuda": 0.502417491748929,
        "SimpleCNN_ensemble_multi_cuda": 5.7795668579638,
        "SimpleMLP_ensemble_single_cpu": 2.3946920223534107,
        "SimpleMLP_ensemble_single_cuda": 0.5035349484533072,
        "SimpleCNN_ensemble_single_cuda": 5.614033993333578,
        "SimpleMLP_persamplegrad_cpu": 8.035034853965044,
        "SimpleMLP_persamplegrad_cuda": 1.9205754343420267,
        "SimpleCNN_persamplegrad_cuda": 3.8312537409365177
    }
}
```