### PR TITLE
Enable CI on AWS T4 Metal instance

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -6,6 +6,8 @@ on:
     inputs:
       userbenchmark_name:
         description: "Name of the user benchmark to run"
+      userbenchmark_options:
+        description: "Option of the user benchmark to run"
 env:
   PYTHON_VERSION: "3.8"
   TENSORRT_PYTHON_VERSION: "cp38"
@@ -13,7 +15,7 @@ env:
   CUDA_VERSION: "cu116"
   CONDA_ENV_NAME: "userbenchmarks-ci"
   MAGMA_VERSION: "magma-cuda116"
-  PLATFORM_NAME: "gcp-a100"
+  PLATFORM_NAME: "gcp_a100"
   TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
   SETUP_SCRIPT: "/data/shared/setup_instance.sh"
 jobs:
@@ -61,7 +63,7 @@ jobs:
             python ./.github/scripts/userbenchmark/schedule-benchmarks.py --platform ${PLATFORM_NAME}
             cp -r ./.userbenchmark ../benchmark-output
           else
-            python run_benchmark.py "${{ github.event.inputs.userbenchmark_name }}"
+            python run_benchmark.py "${{ github.event.inputs.userbenchmark_name }}" ${{ github.event.inputs.userbenchmark_options }}
             cp -r ./.userbenchmark/"${{ github.event.inputs.userbenchmark_name }}" ../benchmark-output
           fi
       - name: Upload result jsons to Scribe
@@ -71,7 +73,7 @@ jobs:
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
           echo "Uploading result jsons: ${RESULTS}"
           for r in ${RESULTS[@]}; do
-            python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${r}"
+            python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -47,10 +47,16 @@ jobs:
               exit 1
           fi
           # Install PyTorch and torchvision nightly from pip
-          pip install --pre torch torchvision \
+          pip install --pre torch torchvision torchtext \
             -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
           # make sure pytorch+cuda works
           python -c "import torch; torch.cuda.init()"
+      - name: Install TorchBench
+        run: |
+          set -x
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          pushd benchmark
+          python install.py
       - name: Run user benchmark
         run: |
           set -x

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -1,10 +1,11 @@
 name: TorchBench Userbenchmark on T4 Metal
 on:
+  schedule:
+    - cron: '0 17 * * *' # run at 5 PM UTC
   workflow_dispatch:
     inputs:
       userbenchmark_name:
         description: "Name of the user benchmark to run"
-        required: true
       userbenchmark_options:
         description: "Option of the user benchmark to run"
 env:
@@ -12,6 +13,9 @@ env:
   CUDA_VERSION: "cu116"
   CONDA_ENV_NAME: "userbenchmarks-ci"
   MAGMA_VERSION: "magma-cuda116"
+  PLATFORM_NAME: "aws_t4_metal"
+  TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+  SETUP_SCRIPT: "/data/nvme/bin/setup_instance.sh"
 jobs:
   run-userbenchmark:
     runs-on: [self-hosted, bm-runner]
@@ -26,7 +30,7 @@ jobs:
           conda create -y -q --name "${CONDA_ENV_NAME}" python="${PYTHON_VERSION}"
       - name: Install PyTorch nightly
         run: |
-          . activate "${CONDA_ENV_NAME}" && . /data/nvme/bin/setup_instance.sh
+          . "${SETUP_SCRIPT}" && . activate "${CONDA_ENV_NAME}"
           pushd benchmark
           # Install dependencies
           conda install -y pyyaml numpy ninja
@@ -49,12 +53,30 @@ jobs:
           python -c "import torch; torch.cuda.init()"
       - name: Run user benchmark
         run: |
-          . activate "${CONDA_ENV_NAME}"
+          set -x
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          # remove old results
           if [ -d benchmark-output ]; then rm -Rf benchmark-output; fi
           pushd benchmark
           if [ -d .userbenchmark ]; then rm -Rf .userbenchmark; fi
-          python run_benchmark.py "${{ github.event.inputs.userbenchmark_name }}" ${{ github.event.inputs.userbenchmark_options }}
-          cp -r ./.userbenchmark/"${{ github.event.inputs.userbenchmark_name }}" ../benchmark-output
+          MANUAL_WORKFLOW="${{ github.event.inputs.userbenchmark_name }}"
+          if [ -z "${MANUAL_WORKFLOW}" ]; then
+            # Figure out what userbenchmarks we should run, and run it
+            python ./.github/scripts/userbenchmark/schedule-benchmarks.py --platform ${PLATFORM_NAME}
+            cp -r ./.userbenchmark ../benchmark-output
+          else
+            python run_benchmark.py "${{ github.event.inputs.userbenchmark_name }}" ${{ github.event.inputs.userbenchmark_options }}
+            cp -r ./.userbenchmark/"${{ github.event.inputs.userbenchmark_name }}" ../benchmark-output
+          fi
+      - name: Upload result jsons to Scribe
+        run: |
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          pushd benchmark
+          RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
+          echo "Uploading result jsons: ${RESULTS}"
+          for r in ${RESULTS[@]}; do
+            python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
+          done
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -46,8 +46,8 @@ jobs:
               echo "Torch nightly build failed. Cancel the workflow."
               exit 1
           fi
-          # Install PyTorch nightly from pip
-          pip install --pre torch \
+          # Install PyTorch and torchvision nightly from pip
+          pip install --pre torch torchvision \
             -f https://download.pytorch.org/whl/nightly/${CUDA_VERSION}/torch_nightly.html
           # make sure pytorch+cuda works
           python -c "import torch; torch.cuda.init()"

--- a/scripts/userbenchmark/upload_scribe.py
+++ b/scripts/userbenchmark/upload_scribe.py
@@ -61,11 +61,15 @@ class ScribeUploader:
 
 class TorchBenchUserbenchmarkUploader(ScribeUploader):
     CLIENT_NAME = 'torchbench_userbenchmark_upload_scribe.py'
-    UNIX_USER = 'torchbench_userbenchmark_gcp_a100_ci'
-    SUBMISSION_GROUP_GUID = 'oss-ci-gcp-a100'
+    # We use the UNIX_USER field to store the name of the benchmark platform
+    UNIX_USER = None
+    SUBMISSION_GROUP_GUID = 'oss-ci'
 
-    def __init__(self):
+    def __init__(self, platform_name):
         super().__init__('perfpipe_pytorch_user_benchmarks')
+        assert platform_name, f"We require non-empty platform_name from user."
+        self.UNIX_USER = f"torchbench_userbenchmark_{platform_name}_ci"
+
         self.schema = {
             'int': [
                 'time',                     # timestamp of upload
@@ -119,12 +123,14 @@ def process_benchmark_json(userbenchmark_json):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--userbenchmark_platform", required=True,
+                        help='Name of the userbenchmark platform')
     parser.add_argument("--userbenchmark_json", required=True,
                         type=argparse.FileType('r'),
                         help='Upload userbenchmark json data')
     args = parser.parse_args()
     benchmark_time, benchmark_data = process_benchmark_json(args.userbenchmark_json)
     # use uploader
-    uploader = TorchBenchUserbenchmarkUploader()
+    uploader = TorchBenchUserbenchmarkUploader(args.userbenchmark_platform)
     uploader.post_userbenchmark_results(benchmark_time, benchmark_data)
 

--- a/userbenchmark/functorch/__init__.py
+++ b/userbenchmark/functorch/__init__.py
@@ -24,7 +24,7 @@ def run(args: List[str]):
     result = {
         'name': BM_NAME,
         'environ': {
-            'git_version': torch.version.git_version,
+            'pytorch_git_version': torch.version.git_version,
         },
         'metrics': metrics,
     }


### PR DESCRIPTION
Enable T4 metal CI runs and fix functorch userbenchmark.
We need to fix a few places to run functorch userbenchmark:
1. in the CI workflow, we need to install the TorchBench models (later, we could optimize this to only install the models needed by userbenchmarks)
2. fix a bug in the functorch userbenchmark code ("git_version" -> "pytorch_git_version")
3. allow upload script to annotate with different CI platforms

Test workflow:
https://github.com/pytorch/benchmark/actions/runs/3211948969

