### PR TITLE
Add PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -517,7 +517,7 @@ class ModelTask(base_task.TaskBase):
         # This context manager is used in testing to ensure we're not leaking
         # memory; these tests are generally parameterized by device, so in some
         # cases we want this (and the outer check) to simply be a no-op.
-        if skip:
+        if skip or os.getenv('PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK', '0') == '1':
             yield
             return
 


### PR DESCRIPTION
This PR allows to skip CUDA memory leak check by using `PYTORCH_TEST_SKIP_CUDA_MEM_LEAK_CHECK=1 python test.py`. 

The same config is used in PyTorch unittests:

https://github.com/pytorch/pytorch/blob/a348975e00081334ac96d855932d2753a62f1e77/torch/testing/_internal/common_utils.py#L993