### PR TITLE
Upgrade to checkout@v3

### DIFF
--- a/.github/workflows/benchmark-config.yml
+++ b/.github/workflows/benchmark-config.yml
@@ -20,22 +20,22 @@ jobs:
     timeout-minutes: 1440 # 24 hours
     steps:
       - name: Checkout TorchBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: benchmark
       - name: Checkout xuzhao9/TensorRT
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: xuzhao9/TensorRT
           ref: xz9/gcp-a100-ci
           path: torch-tensorrt
       - name: Checkout TorchDynamo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: facebookresearch/torchdynamo
           path: torchdynamo
       - name: Checkout functorch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: pytorch/functorch
           path: functorch

--- a/.github/workflows/devinfra-nightly.yml
+++ b/.github/workflows/devinfra-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [ linux.4xlarge.nvidia.gpu ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v2.0
       - name: Create conda env

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: linux.2xlarge
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Simple check
       run: |
         echo "Success. You are running on GHA runner."

--- a/.github/workflows/pr-gpu-stability-ci.yml
+++ b/.github/workflows/pr-gpu-stability-ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 120 # 2 hours
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create conda environment with pytorch nightly
         run: |
           conda create -y -n "${CONDA_ENV}" python="${PYTHON_VERSION}"

--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 1440 # 24 hours
     steps:
       - name: Checkout TorchBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: benchmark
       - name: Create conda environment

--- a/.github/workflows/userbenchmark-ai-cluster.yml
+++ b/.github/workflows/userbenchmark-ai-cluster.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60 # 1 hour
     steps:
       - name: Checkout TorchBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: benchmark
       - name: Install conda

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 1440 # 24 hours
     steps:
       - name: Checkout TorchBench
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: benchmark
       - name: Create conda environment

--- a/.github/workflows/v1-bisection.yml
+++ b/.github/workflows/v1-bisection.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v1.0
       - name: Create conda environment

--- a/.github/workflows/v1-nightly.yml
+++ b/.github/workflows/v1-nightly.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: [self-hosted, bm-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v1.0
       - name: Create conda env

--- a/.github/workflows/v1-sweep.yml
+++ b/.github/workflows/v1-sweep.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v1.0
       - name: Run sweep job

--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v2.0
       - name: Create conda environment

--- a/.github/workflows/v2-nightly.yml
+++ b/.github/workflows/v2-nightly.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, bm-runner]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v2.0
       - name: Create conda env

--- a/.github/workflows/v2-sweep.yml
+++ b/.github/workflows/v2-sweep.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 2880 # 48 hours
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: v2.0
       - name: Run sweep job


### PR DESCRIPTION
To shed the following warning from GHA:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/upload-artifact, actions/checkout
```