### PR TITLE
Fix name of the platform

### DIFF
--- a/.github/scripts/userbenchmark/schedule-benchmarks.py
+++ b/.github/scripts/userbenchmark/schedule-benchmarks.py
@@ -32,7 +32,7 @@ def run_userbenchmark(ub_name, dryrun=True):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--platform", choices=["gcp-a100", "ai-cluster"], required=True, help="specify the benchmark platform.")
+    parser.add_argument("--platform", choices=["gcp_a100", "aws_t4_metal", "ai_cluster"], required=True, help="specify the benchmark platform.")
     parser.add_argument("--dryrun", action="store_true", help="only dry run the command.")
     args = parser.parse_args()
     benchmarks = get_userbenchmarks_by_platform(args.platform)

--- a/userbenchmark/distributed/ci.yaml
+++ b/userbenchmark/distributed/ci.yaml
@@ -1,2 +1,2 @@
-platform: "ai-cluster"
+platform: "ai_cluster"
 schedule:   "nightly"

--- a/userbenchmark/functorch/ci.yaml
+++ b/userbenchmark/functorch/ci.yaml
@@ -1,2 +1,2 @@
-platform: "aws-t4-metal"
+platform: "aws_t4_metal"
 schedule: "nightly"

--- a/userbenchmark/nvfuser/ci.yaml
+++ b/userbenchmark/nvfuser/ci.yaml
@@ -1,2 +1,2 @@
-platform:   "gcp-a100"
+platform:   "gcp_a100"
 schedule:   "nightly"


### PR DESCRIPTION
The name of the platform will be embeded in the scribe upload object, so we want to keep it consistent with the format used in scribe.