### PR TITLE
Reduce profiling runs on distributed models

### DIFF
--- a/torchbenchmark/util/distributed/core_model/trainer.py
+++ b/torchbenchmark/util/distributed/core_model/trainer.py
@@ -12,6 +12,7 @@ import torch.distributed as dist
 
 class Trainer():
     DEFAULT_MEASURE_ITERATIONS = 10
+    PROFILE_ITERATIONS = 2
 
     def __init__(self, args, model_class, mode="SPMD", model_args=None):
         self.args = args
@@ -118,7 +119,7 @@ class Trainer():
                     use_gzip=True,
                 )
             ):
-                for i in range(niters):
+                for i in range(self.PROFILE_ITERATIONS):
                     self.benchmark.invoke()
 
         # wait for all pending CUDA ops to finish

--- a/torchbenchmark/util/distributed/core_model/trainer.py
+++ b/torchbenchmark/util/distributed/core_model/trainer.py
@@ -108,6 +108,7 @@ class Trainer():
             ################################################
             # 3. meausre complete metrics through profiler #
             ################################################
+            wait_runs = 2
             warmup_runs = 2
             with profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
@@ -119,9 +120,9 @@ class Trainer():
                     self.rank,
                     use_gzip=True,
                 ),
-                schedule=schedule(warmup=warmup_runs, active=self.PROFILE_ITERATIONS),
+                schedule=schedule(wait=wait_runs, warmup=warmup_runs, active=self.PROFILE_ITERATIONS),
             ) as profiler:
-                for i in range(self.PROFILE_ITERATIONS + warmup_runs):
+                for i in range(self.PROFILE_ITERATIONS + warmup_runs + wait_runs):
                     self.benchmark.invoke()
                     profiler.step()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1243

Many of the models are fairly large, and 10 iterations is way too much
(chrometrace take sa long time to load and freezes). 2 is probably
enough for most applications and even on the largest models the results
are reasonable.

Differential Revision: [D40705586](https://our.internmc.facebook.com/intern/diff/D40705586)