### PR TITLE
ddp experiments: run all measurements on the same allocation

### DIFF
--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -160,15 +160,12 @@ class FileBarrier:
 
     def barrier(self):
         self.call_idx += 1
-        print(f"Barrier call on round {self.call_idx}.")
         my_key = f"barrier{self.call_idx}.{self.rank}"
-        print(f"my key {my_key}")
         self.store.add(my_key, 1)
         wait_for = []
         for i in range(self.world_size):
             key = f"barrier{self.call_idx}.{i}"
             wait_for.append(key)
-        print(f"waiting on {wait_for}")
         self.store.wait(wait_for)
 
 

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -369,12 +369,13 @@ def main():
                         }
                         experiments.append((config, args_copy, copied_model_args))
 
+    allocation_nodes = max(node_list)
     executor.update_parameters(
         gpus_per_node=args.ngpus,
         # one task per GPU
         tasks_per_node=args.ngpus,
         cpus_per_task=10,
-        nodes=max(node_list),
+        nodes=allocation_nodes,
         timeout_min=args.timeout,
         # Below are cluster dependent parameters
         slurm_partition=args.partition,
@@ -387,7 +388,7 @@ def main():
     job = executor.submit(TrainerWrapper(job_config, experiments))
 
     # print ID of the Slurm job
-    print(f"{nodes} nodes: {job.job_id}")
+    print(f"{allocation_nodes} nodes: {job.job_id}")
     output_csv(
         args.index_file,
         ("job_id",),

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -13,7 +13,7 @@ import torch
 import uuid
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 def output_csv(filename, headers, row):
     assert filename
@@ -137,12 +137,14 @@ def get_init_file(args):
 
 
 class FileBarrier:
-    def __init__(self, rank, world_size, sync_file):
+    def __init__(self, rank, world_size, sync_file, timeout: Optional[timedelta] = None):
         self.rank = rank
         self.world_size = world_size
         self.sync_file = sync_file
         self.store = torch.distributed.FileStore(sync_file, world_size)
-        self.store.set_timeout(timedelta(minutes=30))
+        if timeout is None:
+            timeout = timedelta(minutes=30)
+        self.store.set_timeout(timeout)
         self.call_idx = 0
 
     def barrier(self):

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -353,12 +353,12 @@ def main():
                         if has_breaks:
                             copied_model_args.append("--optimize_dynamo_ddp")
                         batch_size = model_batch_size[model_name]
-                        args.model = model_name
-                        args.batch_size = batch_size
-                        args.nodes = nodes
-                        args.dist_url = get_init_file(args).as_uri()
-                        args.output_dir = args.job_dir
                         args_copy = copy.deepcopy(args)
+                        args_copy.model = model_name
+                        args_copy.batch_size = batch_size
+                        args_copy.nodes = nodes
+                        args_copy.dist_url = get_init_file(args).as_uri()
+                        args_copy.output_dir = args.job_dir
                         config = {
                             "nodes": nodes,
                             "model_name": model_name,

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -225,8 +225,6 @@ class TrainerWrapper(object):
                 else:
                     result_dict['result'] = None
                 assert 'result' in result_dict
-                if not isinstance(result_dict['result'], dict):
-                    result_dict['result'] = ('error', None)
                 # wrap in <RESULT></RESULT> so we can parse partial results in the stdout logs
                 print(f"<RESULT>{json.dumps(result_dict)}</RESULT>")
                 results.append(result_dict)


### PR DESCRIPTION
Previously, we would launch a different slurm job for measurement, e.g.:
1) resnet50 w/ inductor + graph breaks, 2 node
2) resnet50 w/ inductor + NO graph breaks, 2 node
3) ...

But there's a of variation between different nodes - possibly due to network topology etc. These slurm jobs would often each be submitted to a different set of nodes, which would add a lot of noise to the data.

So instead, with this PR, we do the following:
* allocate enough nodes to run all the measurements
* launch (8 * max_nodes) jobs, and provide a list of measurements to each of the jobs
* in each job, we iterate through the list of measurements. For each measurement, we spawn a new process that runs the measurement.
* Once the new process exits, we synchronize via a barrier that's implemented via torch.distributed's FileStore.
* Note that if we have, say, 8 nodes, and one measurement only requires 4 nodes, then the other 4 nodes won't launch any jobs and will just sit idle waiting on the barrier.

Typical usage:
```
python userbenchmark/ddp_experiments/__init__.py --job_dir /full/path/to/shared/directory
```
then the results will be dumped in `/full/path/to/shared/directory`.  From there you can use `userbenchmark/ddp_experiments/parse_ddp.py` to view the results (follow up PR coming soon). Other options include:
```
--repeat [n] : repeats the experiments n times each so you can reduce the effect of any transient load on the machines or network
--profile True : turn on the profiler (note that for inductor, you need to turn off cuda graphs for the profiler to work)
--exclude node1,node2 : exclude a comma-separated list of nodes from the slurm allocation.
--timeout 600 : timeout in minutes  
```