### PR TITLE
Update DDP result parser to gather partial results

### DIFF
--- a/userbenchmark/ddp_experiments/parse_ddp.py
+++ b/userbenchmark/ddp_experiments/parse_ddp.py
@@ -1,4 +1,6 @@
 import csv
+import json
+import copy
 import argparse
 from typing import OrderedDict
 from dataclasses import dataclass
@@ -8,47 +10,32 @@ from collections import defaultdict
 import tabulate
 import sys
 
-def get_job_result(args, job_id, worker_rank=0):
-    root = os.path.join(args.results_dir, f"{job_id}_{worker_rank}_")
-    err = root + "log.err"
-    out = root + "log.out"
-    pkl = root + "result.pkl"
-    if not os.path.isfile(pkl):
-        return False, f"waiting.. or {pkl} did not exist"
-
-    with open(pkl, 'rb') as f:
-        dat = pickle.load(f)
-        assert isinstance(dat, tuple), f"Expected a tuple as result but got a {type(dat)}: {dat}"
-        desc, payload = dat
-        if desc == "error":
-            # print(f"Got error: {desc}, traceback:\n{payload}")
-            return False, payload
-        elif desc == "success":
-            # print(f"Success: {payload}")
-            return True, payload
-
-        # print(f"Unknown result: {dat}")
-        return False, dat
-
-    return False, None
-
-def parse_data(args):
+def parse_partial(args):
     """
     Schema:
-    model_data["model"]["backend"][#nodes] = latency_median
+    model_data["model"]["backend"][#nodes] = result
+    where "result" can be a list of results, or "error"
     """
-    model_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(float))))
-    with open(args.csv) as f:
-        runs = csv.DictReader(f)
-        for row in runs:
-            model = row["model"]
+    model_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list))))
+    rank_id = 0
+    log_path = os.path.join(args.results_dir, f"{args.job_id}_{rank_id}_log.out")
+    with open(log_path, "r") as f:
+        content = f.read()
+        pieces = content.split("<RESULT>")
+        pieces = [x.split("</RESULT>") for x in pieces]
+        pieces = [x[0] for x in pieces if len(x) == 2]
+        pieces = [json.loads(x) for x in pieces]
+        for row in pieces:
+            model = row["model_name"]
             backend = row["backend"]
             nodes = row["nodes"]
-            has_breaks = row["has_breaks"]
-            job_id = row["job_id"]
-            result_code, result_data = get_job_result(args, job_id)
-            latency = f"{result_data['latency_median']:.3f}" if result_code else str(result_data)[:10]
-            model_data[model][backend][nodes][has_breaks] = latency
+            has_breaks = str(row["has_breaks"])
+            if isinstance(row["result"], dict):
+                latency = float(row["result"]["latency_median"])
+                if isinstance(model_data[model][backend][nodes][has_breaks], list):
+                    model_data[model][backend][nodes][has_breaks].append(latency)
+            else:
+                model_data[model][backend][nodes][has_breaks] = "error"
     return model_data
 
 def model_name(model):
@@ -58,18 +45,37 @@ def model_name(model):
         model = model[:model.find(".Model")]
     return model
 
+def median(x):
+    if len(x) == 0:
+        return 0
+    x = copy.copy(x)
+    x = sorted(x)
+    idx = int(len(x)/2)
+    if len(x) % 2 == 0:
+        return (x[idx - 1] + x[idx]) / 2
+    else:
+        return x[idx]
+
 def print_model_table(args, model, model_data):
     node_counts = OrderedDict()
     for backend in model_data:
         for node in model_data[backend]:
             node_counts[node] = node  # hack orderedset
+    node_counts = list(node_counts)
+    node_counts = sorted(node_counts)
     rows = []
     for has_breaks in [False, True]:
         for backend in model_data:
             row = [f"{backend} {'w/' if has_breaks else 'wo/'}breaks", ]
             for node in node_counts:
                 if node in model_data[backend]:
-                    row.append(model_data[backend][node][str(has_breaks)])
+                    res = model_data[backend][node][str(has_breaks)]
+                    if isinstance(res, list):
+                        if len(res) > 0:
+                            res = f"{median(res):.3f}"
+                        else:
+                            res = 0.0
+                    row.append(res)
                 else:
                     row.append("-")
             rows.append(row)
@@ -86,9 +92,13 @@ def print_csv(args, data):
         for backend in data[model]:
             for node in data[model][backend]:
                 node_counts[node] = node  # hack orderedset
+    node_counts = list(node_counts)
+    node_counts = sorted(node_counts)
     labels = ["model", "has_ddp_breaks", "backend"]
     for node in node_counts:
-        labels.append(f"{node}-node")
+        labels.append(f"{node}-node median")
+        # labels.append(f"{node}-node min")
+        # labels.append(f"{node}-node max")
     for has_breaks in [False, True]:
         for model in data:
             for backend in data[model]:
@@ -102,8 +112,16 @@ def print_csv(args, data):
                         latency = data[model][backend][node][str(has_breaks)]
                     else:
                         latency = 0.
-                    node_label = f"{node}-node"
-                    row[node_label] = latency
+
+                    if isinstance(latency, list) and len(latency) == 0:
+                        latency = 0.
+                    node_label_median = f"{node}-node median"
+                    node_label_min = f"{node}-node min"
+                    node_label_max = f"{node}-node max"
+                    latency_list = latency if isinstance(latency, list) else [latency]
+                    row[node_label_median] = median(latency_list)
+                    # row[node_label_min] = min(latency_list)
+                    # row[node_label_max] = max(latency_list)
                 csv_data.append(row)
     csv_writer = csv.DictWriter(sys.stdout, fieldnames=labels)
     csv_writer.writeheader()
@@ -116,11 +134,11 @@ def print_results(args, data):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--csv", required=True)
+    parser.add_argument("--job_id", required=True)
     parser.add_argument("--results_dir", required=True)
     parser.add_argument("--csv_out", action="store_true")
     args = parser.parse_args()
-    data = parse_data(args)
+    data = parse_partial(args)
     if args.csv_out:
         print_csv(args, data)
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1251

Usage:

First, start a job with
```
python userbenchmark/ddp_experiments/__init__.py --job_dir /full/path/to/dir
```
Take note of the jobid that gets printed.

Then you can run the following to get the results in a more easily readable format:

```
python userbenchmark/ddp_experiments/parse_ddp.py --results_dir path/to/dir --job_id 12345
```

It will look up path/to/dir/12345_0_log.out and parse out results wrapped like `<RESULT>{RESULT_JSON}</RESULT>`

Parsing results that are dumped into the stdout logs means that we can view partial results before the job completes.

The `--csv_out` flag can be used to dump the results in csv format for use in google sheets, etc.

This PR relies on https://github.com/pytorch/benchmark/pull/1245.

Differential Revision: [D40454556](https://our.internmc.facebook.com/intern/diff/D40454556)