### PR TITLE
Use torch._dynamo instead of torchdynamo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,17 +12,11 @@ RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
 RUN apt-get update
 RUN apt-get install -y git git-lfs jq
 
-RUN git clone https://github.com/pytorch/functorch /workspace/functorch
-RUN git clone https://github.com/pytorch/torchdynamo /workspace/torchdynamo
 RUN git clone https://github.com/pytorch/benchmark /workspace/benchmark
 
 # Clone conda env
 RUN conda create --name torchbench --clone base && \
     echo "conda activate torchbench" >> ${HOME}/.bashrc
 
-# Uninstall domain packages if they pre-exist
-RUN pip uninstall -y functorch torchdynamo
 # Run the setup
 RUN cd /workspace/benchmark; python install.py
-RUN cd /workspace/functorch; python setup.py develop
-RUN cd /workspace/torchdynamo; python setup.py develop

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -4,7 +4,7 @@ Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 import argparse
 import contextlib
 from typing import List
-import torchdynamo
+import torch._dynamo as torchdynamo
 from torchbenchmark.util.model import is_staged_train_test
 
 def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dynamo_args: List[str]) -> argparse.Namespace:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

pytorch/torchdynamo got moved into pytorch/pytorch, so we should use
torch._dynamo instead of torchdynamo to get the latest version of
dynamo.

functorch was also moved into pytorch/pytorch.