### PR TITLE
Run PR test on GCP A100 runner

### DIFF
--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -1,13 +1,38 @@
-name: TorchBench Infra GHA runner test
+name: TorchBench PR Test
 on:
   workflow_dispatch:
 
+env:
+  PYTHON_VERSION: "3.8"
+  CUDA_VERSION: "cu116"
+  MAGMA_VERSION: "magma-cuda116"
+  SETUP_INSTANCE_SCRIPT: "/workspace/setup_instance.sh"
+
 jobs:
-  place_holder:
-    runs-on: linux.2xlarge
+  run-test:
+    runs-on: [self-hosted, a100-runner]
+    timeout-minutes: 1440 # 24 hours
     steps:
-    - name: Checkout
+    - name: Checkout TorchBench
       uses: actions/checkout@v3
-    - name: Simple check
+    - name: Check GPU availability
       run: |
-        echo "Success. You are running on GHA runner."
+        . "${SETUP_INSTANCE_SCRIPT}"
+        nvidia-smi
+     - name: Install PyTorch nightly
+        run: |
+          . "${SETUP_INSTANCE_SCRIPT}"
+          bash ./scripts/install_nightlies.sh
+    - name: Install TorchBench
+        run: |
+          . "${SETUP_INSTANCE_SCRIPT}"
+          python install.py
+      - name: Validate benchmark components (Worker)
+        run: |
+          . "${SETUP_INSTANCE_SCRIPT}"
+          python -m components.test.test_subprocess
+          python -m components.test.test_worker
+      - name: Validate benchmark components (Model)
+        run: |
+          . "${SETUP_INSTANCE_SCRIPT}"
+          python test.py

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -1,5 +1,6 @@
 name: TorchBench PR Test
 on:
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - name: Checkout TorchBench
         uses: actions/checkout@v3
-      - name: Check GPU availability
+      - name: GPU Tuning
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"
+          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -pm 1
+          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -ac 1215,1410
           nvidia-smi
       - name: Install PyTorch nightly
         run: |

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -9,21 +9,21 @@ env:
   SETUP_INSTANCE_SCRIPT: "/workspace/setup_instance.sh"
 
 jobs:
-  run-test:
+  pr-test:
     runs-on: [self-hosted, a100-runner]
     timeout-minutes: 1440 # 24 hours
     steps:
-    - name: Checkout TorchBench
-      uses: actions/checkout@v3
-    - name: Check GPU availability
-      run: |
-        . "${SETUP_INSTANCE_SCRIPT}"
-        nvidia-smi
-     - name: Install PyTorch nightly
+      - name: Checkout TorchBench
+        uses: actions/checkout@v3
+      - name: Check GPU availability
+        run: |
+          . "${SETUP_INSTANCE_SCRIPT}"
+          nvidia-smi
+      - name: Install PyTorch nightly
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"
           bash ./scripts/install_nightlies.sh
-    - name: Install TorchBench
+      - name: Install TorchBench
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"
           python install.py

--- a/scripts/install_basics.sh
+++ b/scripts/install_basics.sh
@@ -16,7 +16,7 @@ conda activate base
 # Use python3.8 by default
 conda install -y python=3.8
 # install unittest-xml-reporting
-pip install unittest-xml-reporting regex
+pip install unittest-xml-reporting
 
 # install CUDA 11.6
 wget -q https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run \

--- a/scripts/install_nightlies.sh
+++ b/scripts/install_nightlies.sh
@@ -4,7 +4,7 @@ set -e
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-conda install -y numpy requests ninja pyyaml setuptools gitpython beautifulsoup4
+conda install -y numpy requests ninja pyyaml setuptools gitpython beautifulsoup4 regex
 conda install -y -c pytorch magma-cuda116
 
 # install the most recent successfully built pytorch packages

--- a/torchbenchmark/models/hf_BigBird/metadata.yaml
+++ b/torchbenchmark/models/hf_BigBird/metadata.yaml
@@ -1,6 +1,6 @@
 devices:
   NVIDIA A100-SXM4-40GB:
-    eval_batch_size: 8
+    eval_batch_size: 4
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true


### PR DESCRIPTION
We plan to move away from CircleCI and use GitHub Actions+Google Cloud A100 runners for PR testing.
This PR adds the GitHub Actions workflow that uses the GCP A100 runner to perform the PR CI test.

Workflow: https://github.com/pytorch/benchmark/actions/runs/3285422295/jobs/5412496491