### PR TITLE
ddp_experiments: improve error handling

### DIFF
--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -281,7 +281,7 @@ class TrainerWrapper(object):
         return FileBarrier(
             rank=rank,
             world_size=world_size,
-            sync_file=self.job_config.outer_sync_path
+            sync_file=self.job_config.outer_sync_path,
             timeout=self.timeout
         )
 

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -233,6 +233,7 @@ class TrainerWrapper(object):
                 got_exit = False
                 exit_code = None
                 result = None
+                start_time = time.time()
                 while time.time() < start_time + timeout_seconds and not got_exit:
                     proc.join(timeout=5)
                     if proc.exitcode is not None:

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -256,7 +256,7 @@ class TrainerWrapper(object):
                     result_dict['result'] = result
                 else:
                     result_dict['result'] = None
-                print(f"exit code: {proc.exitcode} and result: {result_dict}")
+                print(f"exit code: {exit_code} and result: {result_dict}")
                 assert 'result' in result_dict
                 # wrap in <RESULT></RESULT> so we can parse partial results in the stdout logs
                 print(f"<RESULT>{json.dumps(result_dict)}</RESULT>")

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -9,6 +9,7 @@ import json
 import multiprocessing
 import queue
 import submitit
+import time
 from datetime import datetime, timedelta
 import sys
 import torch

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -220,7 +220,9 @@ class TrainerWrapper(object):
                 proc.start()
 
                 # wait for 3 minutes less than timeout, to give some buffer time so that
-                # the barrier doesn't time out
+                # the barrier doesn't time out.
+                # 3 minutes chosen based on 3x the 60s timeout for killing & joining jobs
+                # that are timing out.
                 timeout_seconds = (self.timeout - timedelta(minutes=3)).total_seconds()
 
                 # Wait in a loop because:
@@ -235,14 +237,14 @@ class TrainerWrapper(object):
                 result = None
                 start_time = time.time()
                 while time.time() < start_time + timeout_seconds and not got_exit:
-                    proc.join(timeout=5)
+                    proc.join(timeout=1)
                     if proc.exitcode is not None:
                         got_exit = True
                         exit_code = proc.exitcode
 
                     if not got_result:
                         try:
-                            result = q.get(timeout=5)
+                            result = q.get(timeout=1)
                             got_result = True
                         except queue.Empty:
                             pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1265
* __->__ #1264

- Add a timeout on the model subprocess itself; this way, the subprocess
will get killed and we won't timeout on the outer barrier call
- When waiting for the model subprocess, wait in a loop where we
alternate between checking the queue and checking if the process is
finished. This prevents us from waiting for the entire timeout when the
worker process fails, and also prevents the worker process from hanging
in the case where the queue fills up and blocks.

Differential Revision: [D40825608](https://our.internmc.facebook.com/intern/diff/D40825608)