### PR TITLE
ddp_experiments: disable cudagraphs for inductor & disable static_graph

### DIFF
--- a/torchbenchmark/util/distributed/core_model/apply_trainer.py
+++ b/torchbenchmark/util/distributed/core_model/apply_trainer.py
@@ -7,7 +7,8 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 def apply_trainer(model, trainer):
     local_rank = int(os.getenv("LOCAL_RANK", -1))
 
-    if trainer == "ddp":
+    if trainer == "ddp" or trainer == "ddp_no_static_graph":
+        static_graph = (trainer == "ddp")
         ddp_model = DDP(
             model,
             device_ids=[local_rank],
@@ -17,7 +18,7 @@ def apply_trainer(model, trainer):
             # Set gradient as bucket view to avoid unnecessary copies
             gradient_as_bucket_view=True,
             # TODO: tune bucket_cap_mb
-            static_graph=True,
+            static_graph=static_graph,
         )
         return ddp_model
     elif trainer == "fsdp":

--- a/torchbenchmark/util/distributed/submit.py
+++ b/torchbenchmark/util/distributed/submit.py
@@ -78,7 +78,7 @@ def parse_args(args: List[str]=None):
     parser.add_argument(
         "--distributed",
         type=str,
-        choices=["ddp", "fsdp", "deepspeed", "none"],
+        choices=["ddp", "ddp_no_static_graph", "fsdp", "deepspeed", "none"],
         default="ddp",
         help="distributed training paradigm, by default using DDP",
     )

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -80,7 +80,12 @@ def get_precision_default(model: 'torchbenchmark.util.model.BenchmarkModel') -> 
 
 def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', extra_args: List[str]) -> Tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--distributed", choices=["ddp", "fsdp"], default=None, help="Enable distributed trainer")
+    parser.add_argument(
+        "--distributed",
+        choices=["ddp", "ddp_no_static_graph", "fsdp"],
+        default=None,
+        help="Enable distributed trainer",
+    )
     parser.add_argument("--precision", choices=["fp32", "tf32", "fp16", "amp"], default=get_precision_default(model), help="choose precisions from: fp32, tf32, fp16, or amp")
     parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
     dargs, opt_args = parser.parse_known_args(extra_args)

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -74,7 +74,7 @@ def parse_args(args: List[str]=None):
 
     parser.add_argument(
         "--distributed",
-        default="ddp",
+        default="ddp_no_static_graph",
         type=str,
         help="the distributed runner to use"
     )
@@ -388,6 +388,8 @@ def main():
                         breakname = "withbreaks" if has_breaks else "nobreaks"
                         if has_breaks:
                             copied_model_args.append("--optimize_dynamo_ddp")
+                        if "inductor" in backend_name:
+                            copied_model_args.append("--torchinductor_cudagraph False")
                         batch_size = model_batch_size[model_name]
                         args_copy = copy.deepcopy(args)
                         args_copy.model = model_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1265
* #1264

* Disable static_graph, because it doesn't work with DDP+Dynamo
* Turn of cudagraphs by default for now, since they cause a lot of
issues with inductor (e.g. OOMs).

Differential Revision: [D40825742](https://our.internmc.facebook.com/intern/diff/D40825742)