### PR TITLE
add metrics support for CPU GPU peak memory usage

### DIFF
--- a/.github/workflows/v2-bisection.yml
+++ b/.github/workflows/v2-bisection.yml
@@ -49,7 +49,6 @@ jobs:
           bash ./.github/scripts/run-bisection.sh
           # Update the result json symbolic link
           ln -sf "${BISECT_BASE}/gh${GITHUB_RUN_ID}/result.json" "${BISECT_BASE}/result.json"
-          cp -r "${BISECT_BASE}" ./bisection-result
       - name: Analyze bisection result
         run: |
           export BISECT_ISSUE="${{ github.event.inputs.issue_name }}"
@@ -57,6 +56,7 @@ jobs:
           . activate "$BISECT_CONDA_ENV"
           . /data/nvme/bin/setup_instance.sh
           python ./.github/scripts/bmutils/analyze-bisection-result.py --bisection-root "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
+          cp -r "${BISECT_BASE}" ./bisection-result
       - name: Create the github issue
         if: env.TORCHBENCH_PERF_BISECTION_NONEMPTY_SIGNAL
         uses: peter-evans/create-issue-from-file@v3

--- a/bisection.py
+++ b/bisection.py
@@ -27,6 +27,7 @@ from utils.cuda_utils import prepare_cuda_env, DEFAULT_CUDA_VERSION
 TORCH_GITREPO="https://github.com/pytorch/pytorch.git"
 TORCHBENCH_GITREPO="https://github.com/pytorch/benchmark.git"
 TORCHBENCH_DEPS = {
+    "torchdata": (os.path.expandvars("${HOME}/data"), "main"),
     "torchtext": (os.path.expandvars("${HOME}/text"), "main"),
     "torchvision": (os.path.expandvars("${HOME}/vision"), "main"),
     "torchaudio": (os.path.expandvars("${HOME}/audio"), "main"),
@@ -207,6 +208,11 @@ class TorchSource:
     
     # Install dependencies such as torchtext and torchvision
     def build_install_deps(self, build_env):
+        # Build torchdata (required by torchtext)
+        print(f"Building torchdata ...", end="", flush=True)
+        command = "python setup.py install"
+        subprocess.check_call(command, cwd=TORCHBENCH_DEPS["torchdata"][0], env=build_env, shell=True)
+        print("done")
         # Build torchvision
         print(f"Building torchvision ...", end="", flush=True)
         command = "python setup.py install"
@@ -266,7 +272,7 @@ class TorchSource:
         self.build_install_deps(build_env)
 
     def cleanup(self):
-        packages = ["torch", "torchtext", "torchvision", "torchaudio"]
+        packages = ["torch"] + list(TORCHBENCH_DEPS.keys())
         CLEANUP_ROUND = 5
         # Clean up multiple times to make sure the packages are all uninstalled
         for _ in range(CLEANUP_ROUND):

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -32,8 +32,9 @@ class ModelAnalyzer:
         # For debug
         # set_logger(logging.DEBUG)
         set_logger()
-        self.gpu_factory = GPUDeviceFactory()
-        self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
+        # delay the initialization to start_monitor
+        self.gpu_factory = None
+        self.gpus = None
         # the cpu metrics to be collected
         # self.gpu_metrics = [GPUUtilization, GPUPowerUsage,
         #                     GPUFreeMemory, GPUPeakMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
@@ -76,6 +77,8 @@ class ModelAnalyzer:
     def start_monitor(self):
         try:
             if self.gpu_metrics:
+                self.gpu_factory = GPUDeviceFactory()
+                self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
                 self.gpu_monitor = DCGMMonitor(
                     self.gpus, self.config.monitoring_interval, self.gpu_metrics)
             if self.cpu_metrics:

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -34,7 +34,7 @@ class ModelAnalyzer:
         # the metrics to be collected
         # self.gpu_metrics = [GPUUtilization, GPUPowerUsage,
         #                     GPUFreeMemory, GPUPeakMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
-        self.gpu_metrics = [GPUFP32Active]
+        self.gpu_metrics = []
         # the final metric results. Its format is {GPU_UUID: {GPUUtilization: }}
         # Example:
         # {'GPU-4177e846-1274-84e3-dcde': 
@@ -53,7 +53,8 @@ class ModelAnalyzer:
 
     def add_metric_gpu_peak_mem(self):
         self.gpu_metrics.append(GPUPeakMemory)
-    
+    def add_metric_gpu_flops(self):
+        self.gpu_metrics.append(GPUFP32Active)
 
     def set_export_csv_name(self, export_csv_name=''):
         self.export_csv_name = export_csv_name
@@ -137,6 +138,8 @@ class ModelAnalyzer:
                         tmp_line = "%s, " % (record_type.tag + '(%)')
                     elif record_type.tag.startswith('gpu_pice'):
                         tmp_line = "%s, " % (record_type.tag + '(bytes)')
+                    elif record_type.tag == 'gpu_peak_memory':
+                        tmp_line = "%s, " % (record_type.tag + '(MB)')
                     else:
                         tmp_line = "%s, " % record_type.tag
                     fout.write(tmp_line)
@@ -207,6 +210,7 @@ class ModelAnalyzer:
 def check_dcgm():
     try: 
         temp_model_analyzer = ModelAnalyzer()
+        temp_model_analyzer.add_metric_gpu_flops()
         temp_model_analyzer.start_monitor()
         temp_model_analyzer.stop_monitor()
     except DCGMError as e:

--- a/components/model_analyzer/dcgm/cpu_monitor.py
+++ b/components/model_analyzer/dcgm/cpu_monitor.py
@@ -1,0 +1,36 @@
+import os
+import time
+from .monitor import Monitor
+import psutil
+from ..tb_dcgm_types.cpu_peak_memory import CPUPeakMemory
+
+class CPUMonitor(Monitor):
+    """
+    A CPU monitor that uses psutil to monitor CPU usage
+    """
+
+    def __init__(self, frequency, metrics_needed=[]):
+        super().__init__(frequency, metrics_needed)
+        self._cpu_records = []
+        # the current process is the process which launches and runs the deep learning models.
+        self._monitored_pid = os.getpid()
+
+
+    def _get_cpu_stats(self):
+        """
+        Append a raw record into self._cpu_metric_values.
+        A raw record includes the timestamp in nanosecond, the CPU memory usage, CPU available memory in MB.
+        """
+        server_process = psutil.Process(self._monitored_pid)
+        process_memory_info = server_process.memory_full_info()
+        system_memory_info = psutil.virtual_memory()
+        # Divide by 1.0e6 to convert from bytes to MB
+        a_raw_record = (time.time_ns(), process_memory_info.uss // 1.0e6, system_memory_info.available // 1.0e6)
+        return a_raw_record
+        
+    def _monitoring_iteration(self):
+        if CPUPeakMemory in self._metrics:
+            self._cpu_records.append(self._get_cpu_stats())
+
+    def _collect_records(self):
+        return self._cpu_records

--- a/components/model_analyzer/dcgm/dcgm_agent.py
+++ b/components/model_analyzer/dcgm/dcgm_agent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,13 +11,53 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+##
+# Python bindings for the internal API of DCGM library (dcgm_agent.h)
+##
+
 from . import dcgm_structs
+from . import dcgm_fields
 from ctypes import *
+import functools
+
+def ensure_byte_strings():
+    """
+    Ensures that we don't call C APIs with unicode strings in the arguments
+    every unicode args gets converted to UTF-8 before the function is called
+    """
+    def convert_result_from_bytes(result):
+        if isinstance(result, bytes):
+            return result.decode('utf-8')
+        if isinstance(result, list):
+            return list(map(convert_result_from_bytes, result))
+        if isinstance(result, tuple):
+            return tuple(map(convert_result_from_bytes, result))
+        return result
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            newargs = []
+            newkwargs = {}
+            for arg in args:
+                if isinstance(arg, str):
+                    newargs.append(bytes(arg, 'utf-8'))
+                else:
+                    newargs.append(arg)
+            for k, v in kwargs.items():
+                if isinstance(v, str):
+                    newkwargs[k] = bytes(v, 'utf-8')
+                else:
+                    newkwargs[k] = v
+            newargs = tuple(newargs)
+            return fn(*newargs, **newkwargs)
+        return wrapper
+    return decorator
+
 # Provides access to functions from dcgm_agent_internal
 dcgmFP = dcgm_structs._dcgmGetFunctionPointer
 
-
 # This method is used to initialize DCGM
+@ensure_byte_strings()
 def dcgmInit():
     dcgm_handle = c_void_p()
     fn = dcgmFP("dcgmInit")
@@ -25,15 +65,15 @@ def dcgmInit():
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
 # This method is used to shutdown DCGM Engine
+@ensure_byte_strings()
 def dcgmShutdown():
     fn = dcgmFP("dcgmShutdown")
     ret = fn()
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmStartEmbedded(opMode):
     dcgm_handle = c_void_p()
     fn = dcgmFP("dcgmStartEmbedded")
@@ -41,14 +81,14 @@ def dcgmStartEmbedded(opMode):
     dcgm_structs._dcgmCheckReturn(ret)
     return dcgm_handle
 
-
+@ensure_byte_strings()
 def dcgmStopEmbedded(dcgm_handle):
     fn = dcgmFP("dcgmStopEmbedded")
     ret = fn(dcgm_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmConnect(ip_address):
     dcgm_handle = c_void_p()
     fn = dcgmFP("dcgmConnect")
@@ -56,10 +96,8 @@ def dcgmConnect(ip_address):
     dcgm_structs._dcgmCheckReturn(ret)
     return dcgm_handle
 
-
-def dcgmConnect_v2(ip_address,
-                   connectParams,
-                   version=dcgm_structs.c_dcgmConnectV2Params_version):
+@ensure_byte_strings()
+def dcgmConnect_v2(ip_address, connectParams, version=dcgm_structs.c_dcgmConnectV2Params_version):
     connectParams.version = version
     dcgm_handle = c_void_p()
     fn = dcgmFP("dcgmConnect_v2")
@@ -67,14 +105,14 @@ def dcgmConnect_v2(ip_address,
     dcgm_structs._dcgmCheckReturn(ret)
     return dcgm_handle
 
-
+@ensure_byte_strings()
 def dcgmDisconnect(dcgm_handle):
     fn = dcgmFP("dcgmDisconnect")
     ret = fn(dcgm_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGetAllSupportedDevices(dcgm_handle):
     c_count = c_uint()
     gpuid_list = c_uint * dcgm_structs.DCGM_MAX_NUM_DEVICES
@@ -82,9 +120,9 @@ def dcgmGetAllSupportedDevices(dcgm_handle):
     fn = dcgmFP("dcgmGetAllSupportedDevices")
     ret = fn(dcgm_handle, c_gpuid_list, byref(c_count))
     dcgm_structs._dcgmCheckReturn(ret)
-    return [c_gpuid_list[i] for i in range(c_count.value)[0:int(c_count.value)]]
+    return list(c_gpuid_list[0:int(c_count.value)])
 
-
+@ensure_byte_strings()
 def dcgmGetAllDevices(dcgm_handle):
     c_count = c_uint()
     gpuid_list = c_uint * dcgm_structs.DCGM_MAX_NUM_DEVICES
@@ -92,18 +130,22 @@ def dcgmGetAllDevices(dcgm_handle):
     fn = dcgmFP("dcgmGetAllDevices")
     ret = fn(dcgm_handle, c_gpuid_list, byref(c_count))
     dcgm_structs._dcgmCheckReturn(ret)
-    return [c_gpuid_list[i] for i in range(c_count.value)[0:int(c_count.value)]]
+    return list(c_gpuid_list[0:int(c_count.value)])
 
-
-def dcgmGetDeviceAttributes(dcgm_handle, gpuId):
+@ensure_byte_strings()
+def dcgmGetDeviceAttributes(dcgm_handle, gpuId, version=dcgm_structs.dcgmDeviceAttributes_version3):
     fn = dcgmFP("dcgmGetDeviceAttributes")
-    device_values = dcgm_structs.c_dcgmDeviceAttributes_v2()
-    device_values.version = dcgm_structs.dcgmDeviceAttributes_version2
+    if version == dcgm_structs.dcgmDeviceAttributes_version3:
+        device_values = dcgm_structs.c_dcgmDeviceAttributes_v3()
+        device_values.version = dcgm_structs.dcgmDeviceAttributes_version3
+    else:
+        dcgm_structs._dcgmCheckReturn(dcgm_structs.DCGM_ST_VER_MISMATCH)
+
     ret = fn(dcgm_handle, c_int(gpuId), byref(device_values))
     dcgm_structs._dcgmCheckReturn(ret)
     return device_values
 
-
+@ensure_byte_strings()
 def dcgmGetEntityGroupEntities(dcgm_handle, entityGroup, flags):
     capacity = dcgm_structs.DCGM_GROUP_MAX_ENTITIES
     c_count = c_int32(capacity)
@@ -114,25 +156,25 @@ def dcgmGetEntityGroupEntities(dcgm_handle, entityGroup, flags):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_entityIds[0:int(c_count.value)]
 
-
+@ensure_byte_strings()
 def dcgmGetNvLinkLinkStatus(dcgm_handle):
-    linkStatus = dcgm_structs.c_dcgmNvLinkStatus_v2()
-    linkStatus.version = dcgm_structs.dcgmNvLinkStatus_version2
+    linkStatus = dcgm_structs.c_dcgmNvLinkStatus_v3()
+    linkStatus.version = dcgm_structs.dcgmNvLinkStatus_version3
     fn = dcgmFP("dcgmGetNvLinkLinkStatus")
     ret = fn(dcgm_handle, byref(linkStatus))
     dcgm_structs._dcgmCheckReturn(ret)
     return linkStatus
 
-
+@ensure_byte_strings()
 def dcgmGetGpuInstanceHierarchy(dcgm_handle):
-    hierarchy = dcgm_structs.c_dcgmMigHierarchy_v1()
-    hierarchy.version = dcgm_structs.c_dcgmMigHierarchy_version1
+    hierarchy = dcgm_structs.c_dcgmMigHierarchy_v2()
+    hierarchy.version = dcgm_structs.c_dcgmMigHierarchy_version2
     fn = dcgmFP("dcgmGetGpuInstanceHierarchy")
     ret = fn(dcgm_handle, byref(hierarchy))
     dcgm_structs._dcgmCheckReturn(ret)
     return hierarchy
 
-
+@ensure_byte_strings()
 def dcgmCreateMigEntity(dcgm_handle, parentId, profile, createOption, flags):
     fn = dcgmFP("dcgmCreateMigEntity")
     cme = dcgm_structs.c_dcgmCreateMigEntity_v1()
@@ -144,7 +186,7 @@ def dcgmCreateMigEntity(dcgm_handle, parentId, profile, createOption, flags):
     ret = fn(dcgm_handle, byref(cme))
     dcgm_structs._dcgmCheckReturn(ret)
 
-
+@ensure_byte_strings()
 def dcgmDeleteMigEntity(dcgm_handle, entityGroupId, entityId, flags):
     fn = dcgmFP("dcgmDeleteMigEntity")
     dme = dcgm_structs.c_dcgmDeleteMigEntity_v1()
@@ -155,7 +197,7 @@ def dcgmDeleteMigEntity(dcgm_handle, entityGroupId, entityId, flags):
     ret = fn(dcgm_handle, byref(dme))
     dcgm_structs._dcgmCheckReturn(ret)
 
-
+@ensure_byte_strings()
 def dcgmGroupCreate(dcgm_handle, type, groupName):
     c_group_id = c_void_p()
     fn = dcgmFP("dcgmGroupCreate")
@@ -163,59 +205,57 @@ def dcgmGroupCreate(dcgm_handle, type, groupName):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_group_id
 
-
+@ensure_byte_strings()
 def dcgmGroupDestroy(dcgm_handle, group_id):
     fn = dcgmFP("dcgmGroupDestroy")
     ret = fn(dcgm_handle, group_id)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGroupAddDevice(dcgm_handle, group_id, gpu_id):
     fn = dcgmFP("dcgmGroupAddDevice")
     ret = fn(dcgm_handle, group_id, gpu_id)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGroupAddEntity(dcgm_handle, group_id, entityGroupId, entityId):
     fn = dcgmFP("dcgmGroupAddEntity")
     ret = fn(dcgm_handle, group_id, entityGroupId, entityId)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGroupRemoveDevice(dcgm_handle, group_id, gpu_id):
     fn = dcgmFP("dcgmGroupRemoveDevice")
     ret = fn(dcgm_handle, group_id, gpu_id)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGroupRemoveEntity(dcgm_handle, group_id, entityGroupId, entityId):
     fn = dcgmFP("dcgmGroupRemoveEntity")
     ret = fn(dcgm_handle, group_id, entityGroupId, entityId)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
-def dcgmGroupGetInfo(dcgm_handle,
-                     group_id,
-                     version=dcgm_structs.c_dcgmGroupInfo_version2):
+@ensure_byte_strings()
+def dcgmGroupGetInfo(dcgm_handle, group_id, version=dcgm_structs.c_dcgmGroupInfo_version2):
     fn = dcgmFP("dcgmGroupGetInfo")
-
-    # support the old version of the request since the host engine does
+    
+    #support the old version of the request since the host engine does
     if version == dcgm_structs.c_dcgmGroupInfo_version2:
         device_values = dcgm_structs.c_dcgmGroupInfo_v2()
         device_values.version = dcgm_structs.c_dcgmGroupInfo_version2
     else:
         dcgm_structs._dcgmCheckReturn(dcgm_structs.DCGM_ST_VER_MISMATCH)
-
+    
     ret = fn(dcgm_handle, group_id, byref(device_values))
     dcgm_structs._dcgmCheckReturn(ret)
     return device_values
 
-
+@ensure_byte_strings()
 def dcgmGroupGetAllIds(dcgmHandle):
     fn = dcgmFP("dcgmGroupGetAllIds")
     c_count = c_uint()
@@ -223,27 +263,26 @@ def dcgmGroupGetAllIds(dcgmHandle):
     c_groupIdList = groupIdList()
     ret = fn(dcgmHandle, c_groupIdList, byref(c_count))
     dcgm_structs._dcgmCheckReturn(ret)
-    return map(None, c_groupIdList[0:int(c_count.value)])
+    return list(c_groupIdList[0:int(c_count.value)])
 
-
+@ensure_byte_strings()
 def dcgmFieldGroupCreate(dcgm_handle, fieldIds, fieldGroupName):
     c_field_group_id = c_void_p()
     c_num_field_ids = c_int32(len(fieldIds))
     c_field_ids = (c_uint16 * len(fieldIds))(*fieldIds)
     fn = dcgmFP("dcgmFieldGroupCreate")
-    ret = fn(dcgm_handle, c_num_field_ids, byref(c_field_ids), fieldGroupName,
-             byref(c_field_group_id))
+    ret = fn(dcgm_handle, c_num_field_ids, byref(c_field_ids), fieldGroupName, byref(c_field_group_id))
     dcgm_structs._dcgmCheckReturn(ret)
     return c_field_group_id
 
-
+@ensure_byte_strings()
 def dcgmFieldGroupDestroy(dcgm_handle, fieldGroupId):
     fn = dcgmFP("dcgmFieldGroupDestroy")
     ret = fn(dcgm_handle, fieldGroupId)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmFieldGroupGetInfo(dcgm_handle, fieldGroupId):
     c_fieldGroupInfo = dcgm_structs.c_dcgmFieldGroupInfo_v1()
     c_fieldGroupInfo.version = dcgm_structs.dcgmFieldGroupInfo_version1
@@ -253,7 +292,7 @@ def dcgmFieldGroupGetInfo(dcgm_handle, fieldGroupId):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_fieldGroupInfo
 
-
+@ensure_byte_strings()
 def dcgmFieldGroupGetAll(dcgm_handle):
     c_allGroupInfo = dcgm_structs.c_dcgmAllFieldGroup_v1()
     c_allGroupInfo.version = dcgm_structs.dcgmAllFieldGroup_version1
@@ -262,22 +301,22 @@ def dcgmFieldGroupGetAll(dcgm_handle):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_allGroupInfo
 
-
+@ensure_byte_strings()
 def dcgmStatusCreate():
     c_status_handle = c_void_p()
     fn = dcgmFP("dcgmStatusCreate")
     ret = fn(byref(c_status_handle))
     dcgm_structs._dcgmCheckReturn(ret)
-    return c_status_handle
+    return c_status_handle        
 
-
+@ensure_byte_strings()
 def dcgmStatusDestroy(status_handle):
     fn = dcgmFP("dcgmStatusDestroy")
     ret = fn(status_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmStatusGetCount(status_handle):
     c_count = c_uint()
     fn = dcgmFP("dcgmStatusGetCount")
@@ -285,7 +324,7 @@ def dcgmStatusGetCount(status_handle):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_count.value
 
-
+@ensure_byte_strings()
 def dcgmStatusPopError(status_handle):
     c_errorInfo = dcgm_structs.c_dcgmErrorInfo_v1()
     fn = dcgmFP("dcgmStatusPopError")
@@ -296,14 +335,14 @@ def dcgmStatusPopError(status_handle):
         return None
     return c_errorInfo
 
-
+@ensure_byte_strings()
 def dcgmStatusClear(status_handle):
     fn = dcgmFP("dcgmStatusClear")
     ret = fn(status_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmConfigSet(dcgm_handle, group_id, configToSet, status_handle):
     fn = dcgmFP("dcgmConfigSet")
     configToSet.version = dcgm_structs.dcgmDeviceConfig_version1
@@ -311,7 +350,7 @@ def dcgmConfigSet(dcgm_handle, group_id, configToSet, status_handle):
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmConfigGet(dcgm_handle, group_id, reqCfgType, count, status_handle):
     fn = dcgmFP("dcgmConfigGet")
 
@@ -321,28 +360,27 @@ def dcgmConfigGet(dcgm_handle, group_id, reqCfgType, count, status_handle):
     for index in range(0, count):
         c_config_values[index].version = dcgm_structs.dcgmDeviceConfig_version1
 
-    ret = fn(dcgm_handle, group_id, reqCfgType, count, c_config_values,
-             status_handle)
+    ret = fn(dcgm_handle, group_id, reqCfgType, count, c_config_values, status_handle)
     dcgm_structs._dcgmCheckReturn(ret)
-    return map(None, c_config_values[0:count])
+    return list(c_config_values[0:count])
 
-
+@ensure_byte_strings()
 def dcgmConfigEnforce(dcgm_handle, group_id, status_handle):
     fn = dcgmFP("dcgmConfigEnforce")
     ret = fn(dcgm_handle, group_id, status_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
 # This method is used to tell the cache manager to update all fields
+@ensure_byte_strings()
 def dcgmUpdateAllFields(dcgm_handle, waitForUpdate):
     fn = dcgmFP("dcgmUpdateAllFields")
     ret = fn(dcgm_handle, c_int(waitForUpdate))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
 # This method is used to get the policy information
+@ensure_byte_strings()
 def dcgmPolicyGet(dcgm_handle, group_id, count, status_handle):
     fn = dcgmFP("dcgmPolicyGet")
     policy_array = count * dcgm_structs.c_dcgmPolicy_v1
@@ -356,82 +394,70 @@ def dcgmPolicyGet(dcgm_handle, group_id, count, status_handle):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_policy_values[0:count]
 
-
 # This method is used to set the policy information
+@ensure_byte_strings()
 def dcgmPolicySet(dcgm_handle, group_id, policy, status_handle):
     fn = dcgmFP("dcgmPolicySet")
     ret = fn(dcgm_handle, group_id, byref(policy), status_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
+#First parameter below is the return type
+dcgmFieldValueEnumeration_f = CFUNCTYPE(c_int32, c_uint32, POINTER(dcgm_structs.c_dcgmFieldValue_v1), c_int32, c_void_p)
+dcgmFieldValueEntityEnumeration_f = CFUNCTYPE(c_int32, c_uint32, c_uint32, POINTER(dcgm_structs.c_dcgmFieldValue_v1), c_int32, c_void_p)
 
-# First parameter below is the return type
-dcgmFieldValueEnumeration_f = CFUNCTYPE(
-    c_int32, c_uint32, POINTER(dcgm_structs.c_dcgmFieldValue_v1), c_int32,
-    c_void_p)
-dcgmFieldValueEntityEnumeration_f = CFUNCTYPE(
-    c_int32, c_uint32, c_uint32, POINTER(dcgm_structs.c_dcgmFieldValue_v1),
-    c_int32, c_void_p)
-
-
-def dcgmGetValuesSince(dcgm_handle, groupId, fieldGroupId, sinceTimestamp,
-                       enumCB, userData):
+@ensure_byte_strings()
+def dcgmGetValuesSince(dcgm_handle, groupId, fieldGroupId, sinceTimestamp, enumCB, userData):
     fn = dcgmFP("dcgmGetValuesSince")
     c_nextSinceTimestamp = c_int64()
-    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(sinceTimestamp),
-             byref(c_nextSinceTimestamp), enumCB, py_object(userData))
+    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(sinceTimestamp), byref(c_nextSinceTimestamp), enumCB, py_object(userData))
     dcgm_structs._dcgmCheckReturn(ret)
     return c_nextSinceTimestamp.value
 
-
-def dcgmGetValuesSince_v2(dcgm_handle, groupId, fieldGroupId, sinceTimestamp,
-                          enumCB, userData):
+@ensure_byte_strings()
+def dcgmGetValuesSince_v2(dcgm_handle, groupId, fieldGroupId, sinceTimestamp, enumCB, userData):
     fn = dcgmFP("dcgmGetValuesSince_v2")
     c_nextSinceTimestamp = c_int64()
-    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(sinceTimestamp),
-             byref(c_nextSinceTimestamp), enumCB, py_object(userData))
+    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(sinceTimestamp), byref(c_nextSinceTimestamp), enumCB, py_object(userData))
     dcgm_structs._dcgmCheckReturn(ret)
     return c_nextSinceTimestamp.value
 
-
+@ensure_byte_strings()
 def dcgmGetLatestValues(dcgm_handle, groupId, fieldGroupId, enumCB, userData):
     fn = dcgmFP("dcgmGetLatestValues")
     ret = fn(dcgm_handle, groupId, fieldGroupId, enumCB, py_object(userData))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
-def dcgmGetLatestValues_v2(dcgm_handle, groupId, fieldGroupId, enumCB,
-                           userData):
+@ensure_byte_strings()
+def dcgmGetLatestValues_v2(dcgm_handle, groupId, fieldGroupId, enumCB, userData):
     fn = dcgmFP("dcgmGetLatestValues_v2")
     ret = fn(dcgm_handle, groupId, fieldGroupId, enumCB, py_object(userData))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
-def dcgmWatchFields(dcgm_handle, groupId, fieldGroupId, updateFreq, maxKeepAge,
-                    maxKeepSamples):
+@ensure_byte_strings()
+def dcgmWatchFields(dcgm_handle, groupId, fieldGroupId, updateFreq, maxKeepAge, maxKeepSamples):
     fn = dcgmFP("dcgmWatchFields")
-    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(updateFreq),
-             c_double(maxKeepAge), c_int32(maxKeepSamples))
+    ret = fn(dcgm_handle, groupId, fieldGroupId, c_int64(updateFreq), c_double(maxKeepAge), c_int32(maxKeepSamples))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmUnwatchFields(dcgm_handle, groupId, fieldGroupId):
     fn = dcgmFP("dcgmUnwatchFields")
     ret = fn(dcgm_handle, groupId, fieldGroupId)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmHealthSet(dcgm_handle, groupId, systems):
     fn = dcgmFP("dcgmHealthSet")
     ret = fn(dcgm_handle, groupId, systems)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmHealthSet_v2(dcgm_handle, groupId, systems, updateInterval, maxKeepAge):
     params = dcgm_structs.c_dcgmHealthSetParams_v2()
     params.version = dcgm_structs.dcgmHealthSetParams_version2
@@ -445,7 +471,7 @@ def dcgmHealthSet_v2(dcgm_handle, groupId, systems, updateInterval, maxKeepAge):
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmHealthGet(dcgm_handle, groupId):
     c_systems = c_int32()
     fn = dcgmFP("dcgmHealthGet")
@@ -453,13 +479,11 @@ def dcgmHealthGet(dcgm_handle, groupId):
     dcgm_structs._dcgmCheckReturn(ret)
     return c_systems.value
 
-
-def dcgmHealthCheck(dcgm_handle,
-                    groupId,
-                    version=dcgm_structs.dcgmHealthResponse_version4):
+@ensure_byte_strings()
+def dcgmHealthCheck(dcgm_handle, groupId, version=dcgm_structs.dcgmHealthResponse_version4):
     if version != dcgm_structs.dcgmHealthResponse_version4:
         dcgm_structs._dcgmCheckReturn(dcgm_structs.DCGM_ST_VER_MISMATCH)
-
+    
     c_results = dcgm_structs.c_dcgmHealthResponse_v4()
     c_results.version = dcgm_structs.dcgmHealthResponse_version4
     fn = dcgmFP("dcgmHealthCheck")
@@ -467,28 +491,26 @@ def dcgmHealthCheck(dcgm_handle,
     dcgm_structs._dcgmCheckReturn(ret)
     return c_results
 
-
-def dcgmPolicyRegister(dcgm_handle, groupId, condition, beginCallback,
-                       finishCallback):
+@ensure_byte_strings()
+def dcgmPolicyRegister(dcgm_handle, groupId, condition, beginCallback, finishCallback):
     fn = dcgmFP("dcgmPolicyRegister")
     ret = fn(dcgm_handle, groupId, condition, beginCallback, finishCallback)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmPolicyUnregister(dcgm_handle, groupId, condition):
     fn = dcgmFP("dcgmPolicyUnregister")
     ret = fn(dcgm_handle, groupId, condition)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmPolicyTrigger(dcgm_handle):
     fn = dcgmFP("dcgmPolicyTrigger")
     ret = fn(dcgm_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
-
 
 def helperDiagCheckReturn(ret, response):
     try:
@@ -499,32 +521,30 @@ def helperDiagCheckReturn(ret, response):
             import sys
             info = "%s" % response.systemError.msg
             e.SetAdditionalInfo(info)
-            raise e  # pylint: disable=E0710
+            raise e
         else:
             raise
 
     return response
 
-
-def dcgmActionValidate_v2(dcgm_handle,
-                          runDiagInfo,
-                          runDiagVersion=dcgm_structs.dcgmRunDiag_version6):
-    response = dcgm_structs.c_dcgmDiagResponse_v6()
+@ensure_byte_strings()
+def dcgmActionValidate_v2(dcgm_handle, runDiagInfo, runDiagVersion=dcgm_structs.dcgmRunDiag_version7):
+    response = dcgm_structs.c_dcgmDiagResponse_v8()
     runDiagInfo.version = runDiagVersion
-    response.version = dcgm_structs.dcgmDiagResponse_version6
+    response.version = dcgm_structs.dcgmDiagResponse_version8
     fn = dcgmFP("dcgmActionValidate_v2")
     ret = fn(dcgm_handle, byref(runDiagInfo), byref(response))
 
     return helperDiagCheckReturn(ret, response)
 
-
+@ensure_byte_strings()
 def dcgmActionValidate(dcgm_handle, group_id, validate):
-    response = dcgm_structs.c_dcgmDiagResponse_v6()
-    response.version = dcgm_structs.dcgmDiagResponse_version6
-
+    response = dcgm_structs.c_dcgmDiagResponse_v8()
+    response.version = dcgm_structs.dcgmDiagResponse_version8
+    
     # Put the group_id and validate into a dcgmRunDiag struct
-    runDiagInfo = dcgm_structs.c_dcgmRunDiag_v6()
-    runDiagInfo.version = dcgm_structs.dcgmRunDiag_version6
+    runDiagInfo = dcgm_structs.c_dcgmRunDiag_v7()
+    runDiagInfo.version = dcgm_structs.dcgmRunDiag_version7
     runDiagInfo.validate = validate
     runDiagInfo.groupId = group_id
 
@@ -533,25 +553,23 @@ def dcgmActionValidate(dcgm_handle, group_id, validate):
 
     return helperDiagCheckReturn(ret, response)
 
-
+@ensure_byte_strings()
 def dcgmRunDiagnostic(dcgm_handle, group_id, diagLevel):
-    response = dcgm_structs.c_dcgmDiagResponse_v6()
-    response.version = dcgm_structs.dcgmDiagResponse_version6
+    response = dcgm_structs.c_dcgmDiagResponse_v8()
+    response.version = dcgm_structs.dcgmDiagResponse_version8
     fn = dcgmFP("dcgmRunDiagnostic")
     ret = fn(dcgm_handle, group_id, diagLevel, byref(response))
 
     return helperDiagCheckReturn(ret, response)
 
-
-def dcgmWatchPidFields(dcgm_handle, groupId, updateFreq, maxKeepAge,
-                       maxKeepSamples):
+@ensure_byte_strings()
+def dcgmWatchPidFields(dcgm_handle, groupId, updateFreq, maxKeepAge, maxKeepSamples):
     fn = dcgmFP("dcgmWatchPidFields")
-    ret = fn(dcgm_handle, groupId, c_int64(updateFreq), c_double(maxKeepAge),
-             c_int32(maxKeepSamples))
+    ret = fn(dcgm_handle, groupId, c_int64(updateFreq), c_double(maxKeepAge), c_int32(maxKeepSamples))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmGetPidInfo(dcgm_handle, groupId, pid):
     fn = dcgmFP("dcgmGetPidInfo")
     pidInfo = dcgm_structs.c_dcgmPidInfo_v2()
@@ -563,7 +581,7 @@ def dcgmGetPidInfo(dcgm_handle, groupId, pid):
     dcgm_structs._dcgmCheckReturn(ret)
     return pidInfo
 
-
+@ensure_byte_strings()
 def dcgmGetDeviceTopology(dcgm_handle, gpuId):
     devtopo = dcgm_structs.c_dcgmDeviceTopology_v1()
     fn = dcgmFP("dcgmGetDeviceTopology")
@@ -571,7 +589,7 @@ def dcgmGetDeviceTopology(dcgm_handle, gpuId):
     dcgm_structs._dcgmCheckReturn(ret)
     return devtopo
 
-
+@ensure_byte_strings()
 def dcgmGetGroupTopology(dcgm_handle, groupId):
     grouptopo = dcgm_structs.c_dcgmGroupTopology_v1()
     fn = dcgmFP("dcgmGetGroupTopology")
@@ -579,30 +597,28 @@ def dcgmGetGroupTopology(dcgm_handle, groupId):
     dcgm_structs._dcgmCheckReturn(ret)
     return grouptopo
 
-
-def dcgmWatchJobFields(dcgm_handle, groupId, updateFreq, maxKeepAge,
-                       maxKeepSamples):
+@ensure_byte_strings()
+def dcgmWatchJobFields(dcgm_handle, groupId, updateFreq, maxKeepAge, maxKeepSamples):
     fn = dcgmFP("dcgmWatchJobFields")
-    ret = fn(dcgm_handle, groupId, c_int64(updateFreq), c_double(maxKeepAge),
-             c_int32(maxKeepSamples))
+    ret = fn(dcgm_handle, groupId, c_int64(updateFreq), c_double(maxKeepAge), c_int32(maxKeepSamples))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmJobStartStats(dcgm_handle, groupId, jobid):
     fn = dcgmFP("dcgmJobStartStats")
     ret = fn(dcgm_handle, groupId, jobid)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmJobStopStats(dcgm_handle, jobid):
     fn = dcgmFP("dcgmJobStopStats")
     ret = fn(dcgm_handle, jobid)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmJobGetStats(dcgm_handle, jobid):
     fn = dcgmFP("dcgmJobGetStats")
     jobInfo = dcgm_structs.c_dcgmJobInfo_v3()
@@ -613,124 +629,77 @@ def dcgmJobGetStats(dcgm_handle, jobid):
     dcgm_structs._dcgmCheckReturn(ret)
     return jobInfo
 
-
+@ensure_byte_strings()
 def dcgmJobRemove(dcgm_handle, jobid):
     fn = dcgmFP("dcgmJobRemove")
     ret = fn(dcgm_handle, jobid)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmJobRemoveAll(dcgm_handle):
     fn = dcgmFP("dcgmJobRemoveAll")
     ret = fn(dcgm_handle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
-def dcgmIntrospectToggleState(dcgm_handle, enabledState):
-    fn = dcgmFP("dcgmIntrospectToggleState")
-    ret = fn(dcgm_handle, enabledState)
-    dcgm_structs._dcgmCheckReturn(ret)
-    return ret
-
-
+@ensure_byte_strings()
 def dcgmIntrospectGetHostengineMemoryUsage(dcgm_handle, waitIfNoData=True):
     fn = dcgmFP("dcgmIntrospectGetHostengineMemoryUsage")
-
+    
     memInfo = dcgm_structs.c_dcgmIntrospectMemory_v1()
     memInfo.version = dcgm_structs.dcgmIntrospectMemory_version1
-
+    
     ret = fn(dcgm_handle, byref(memInfo), waitIfNoData)
     dcgm_structs._dcgmCheckReturn(ret)
     return memInfo
-
-
+    
+@ensure_byte_strings()
 def dcgmIntrospectGetHostengineCpuUtilization(dcgm_handle, waitIfNoData=True):
     fn = dcgmFP("dcgmIntrospectGetHostengineCpuUtilization")
-
+    
     cpuUtil = dcgm_structs.c_dcgmIntrospectCpuUtil_v1()
     cpuUtil.version = dcgm_structs.dcgmIntrospectCpuUtil_version1
-
+    
     ret = fn(dcgm_handle, byref(cpuUtil), waitIfNoData)
     dcgm_structs._dcgmCheckReturn(ret)
     return cpuUtil
-
-
-def dcgmIntrospectGetFieldsExecTime(dcgm_handle,
-                                    introspectContext,
-                                    waitIfNoData=True):
-    fn = dcgmFP("dcgmIntrospectGetFieldsExecTime")
-
-    execTime = dcgm_structs.c_dcgmIntrospectFullFieldsExecTime_v2()
-    execTime.version = dcgm_structs.dcgmIntrospectFullFieldsExecTime_version2
-
-    ret = fn(dcgm_handle, byref(introspectContext), byref(execTime),
-             waitIfNoData)
-    dcgm_structs._dcgmCheckReturn(ret)
-    return execTime
-
-
-def dcgmIntrospectGetFieldsMemoryUsage(dcgm_handle,
-                                       introspectContext,
-                                       waitIfNoData=True):
-    fn = dcgmFP("dcgmIntrospectGetFieldsMemoryUsage")
-
-    memInfo = dcgm_structs.c_dcgmIntrospectFullMemory_v1()
-    memInfo.version = dcgm_structs.dcgmIntrospectFullMemory_version1
-
-    ret = fn(dcgm_handle, byref(introspectContext), byref(memInfo),
-             waitIfNoData)
-    dcgm_structs._dcgmCheckReturn(ret)
-    return memInfo
-
-
-def dcgmIntrospectUpdateAll(dcgmHandle, waitForUpdate):
-    fn = dcgmFP("dcgmIntrospectUpdateAll")
-    ret = fn(dcgmHandle, c_int(waitForUpdate))
-    dcgm_structs._dcgmCheckReturn(ret)
-
-
+    
+@ensure_byte_strings()
 def dcgmEntityGetLatestValues(dcgmHandle, entityGroup, entityId, fieldIds):
     fn = dcgmFP("dcgmEntityGetLatestValues")
     field_values = (dcgm_structs.c_dcgmFieldValue_v1 * len(fieldIds))()
     id_values = (c_uint16 * len(fieldIds))(*fieldIds)
-    ret = fn(dcgmHandle, c_uint(entityGroup),
-             dcgm_fields.c_dcgm_field_eid_t(entityId), id_values,
-             c_uint(len(fieldIds)), field_values)
+    ret = fn(dcgmHandle, c_uint(entityGroup), dcgm_fields.c_dcgm_field_eid_t(entityId), id_values, c_uint(len(fieldIds)), field_values)
     dcgm_structs._dcgmCheckReturn(ret)
     return field_values
 
-
+@ensure_byte_strings()
 def dcgmEntitiesGetLatestValues(dcgmHandle, entities, fieldIds, flags):
     fn = dcgmFP("dcgmEntitiesGetLatestValues")
-    numFvs = len(fieldIds) * len(entities)
+    numFvs =  len(fieldIds) * len(entities)
     field_values = (dcgm_structs.c_dcgmFieldValue_v2 * numFvs)()
-    entities_values = (dcgm_structs.c_dcgmGroupEntityPair_t *
-                       len(entities))(*entities)
+    entities_values = (dcgm_structs.c_dcgmGroupEntityPair_t * len(entities))(*entities)
     field_id_values = (c_uint16 * len(fieldIds))(*fieldIds)
-    ret = fn(dcgmHandle, entities_values, c_uint(len(entities)),
-             field_id_values, c_uint(len(fieldIds)), flags, field_values)
+    ret = fn(dcgmHandle, entities_values, c_uint(len(entities)), field_id_values, c_uint(len(fieldIds)), flags, field_values)
     dcgm_structs._dcgmCheckReturn(ret)
     return field_values
 
-
+@ensure_byte_strings()
 def dcgmSelectGpusByTopology(dcgmHandle, inputGpuIds, numGpus, hintFlags):
     fn = dcgmFP("dcgmSelectGpusByTopology")
     outputGpuIds = c_int64()
-    ret = fn(dcgmHandle, c_uint64(inputGpuIds), c_uint32(numGpus),
-             byref(outputGpuIds), c_uint64(hintFlags))
+    ret = fn(dcgmHandle, c_uint64(inputGpuIds), c_uint32(numGpus), byref(outputGpuIds), c_uint64(hintFlags))
     dcgm_structs._dcgmCheckReturn(ret)
     return outputGpuIds
 
-
-def dcgmGetFieldSummary(dcgmHandle, fieldId, entityGroupType, entityId,
-                        summaryMask, startTime, endTime):
+@ensure_byte_strings()
+def dcgmGetFieldSummary(dcgmHandle, fieldId, entityGroupType, entityId, summaryMask, startTime, endTime):
     fn = dcgmFP("dcgmGetFieldSummary")
     request = dcgm_structs.c_dcgmFieldSummaryRequest_v1()
     request.version = dcgm_structs.dcgmFieldSummaryRequest_version1
-    request.fieldId = fieldId
-    request.entityGroupType = entityGroupType
+    request.fieldId = fieldId 
+    request.entityGroupType =entityGroupType
     request.entityId = entityId
     request.summaryTypeMask = summaryMask
     request.startTime = startTime
@@ -739,14 +708,14 @@ def dcgmGetFieldSummary(dcgmHandle, fieldId, entityGroupType, entityId,
     dcgm_structs._dcgmCheckReturn(ret)
     return request
 
-
-def dcgmModuleBlacklist(dcgmHandle, moduleId):
-    fn = dcgmFP("dcgmModuleBlacklist")
+@ensure_byte_strings()
+def dcgmModuleDenylist(dcgmHandle, moduleId):
+    fn = dcgmFP("dcgmModuleDenylist")
     ret = fn(dcgmHandle, c_uint32(moduleId))
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmModuleGetStatuses(dcgmHandle):
     moduleStatuses = dcgm_structs.c_dcgmModuleGetStatuses_v1()
     moduleStatuses.version = dcgm_structs.dcgmModuleGetStatuses_version1
@@ -755,59 +724,31 @@ def dcgmModuleGetStatuses(dcgmHandle):
     dcgm_structs._dcgmCheckReturn(ret)
     return moduleStatuses
 
-
-def dcgmProfGetSupportedMetricGroups(dcgmHandle, groupId):
-    msg = dcgm_structs.c_dcgmProfGetMetricGroups_v2()
-    msg.version = dcgm_structs.dcgmProfGetMetricGroups_version1
-    msg.groupId = groupId
+@ensure_byte_strings()
+def dcgmProfGetSupportedMetricGroups(dcgmHandle, gpuId):
+    msg = dcgm_structs.c_dcgmProfGetMetricGroups_v3()
+    msg.version = dcgm_structs.dcgmProfGetMetricGroups_version3
+    msg.gpuId = gpuId
     fn = dcgmFP("dcgmProfGetSupportedMetricGroups")
     ret = fn(dcgmHandle, byref(msg))
     dcgm_structs._dcgmCheckReturn(ret)
     return msg
 
-
-def dcgmProfWatchFields(dcgmHandle, fieldIds, groupId, updateFreq, maxKeepAge,
-                        maxKeepSamples):
-    msg = dcgm_structs.c_dcgmProfWatchFields_v1()
-    msg.version = dcgm_structs.dcgmProfWatchFields_version1
-    msg.groupId = groupId
-    msg.updateFreq = updateFreq
-    msg.maxKeepAge = maxKeepAge
-    msg.maxKeepSamples = maxKeepSamples
-    msg.numFieldIds = c_uint32(len(fieldIds))
-    for i, fieldId in enumerate(fieldIds):
-        msg.fieldIds[i] = fieldId
-
-    fn = dcgmFP("dcgmProfWatchFields")
-    ret = fn(dcgmHandle, byref(msg))
-    dcgm_structs._dcgmCheckReturn(ret)
-    return msg
-
-
-def dcgmProfUnwatchFields(dcgmHandle, groupId):
-    msg = dcgm_structs.c_dcgmProfUnwatchFields_v1()
-    msg.version = dcgm_structs.dcgmProfUnwatchFields_version1
-    msg.groupId = groupId
-    fn = dcgmFP("dcgmProfUnwatchFields")
-    ret = fn(dcgmHandle, byref(msg))
-    dcgm_structs._dcgmCheckReturn(ret)
-    return msg
-
-
+@ensure_byte_strings()
 def dcgmProfPause(dcgmHandle):
     fn = dcgmFP("dcgmProfPause")
     ret = fn(dcgmHandle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmProfResume(dcgmHandle):
     fn = dcgmFP("dcgmProfResume")
     ret = fn(dcgmHandle)
     dcgm_structs._dcgmCheckReturn(ret)
     return ret
 
-
+@ensure_byte_strings()
 def dcgmVersionInfo():
     msg = dcgm_structs.c_dcgmVersionInfo_v2()
     msg.version = dcgm_structs.dcgmVersionInfo_version2
@@ -816,7 +757,7 @@ def dcgmVersionInfo():
     dcgm_structs._dcgmCheckReturn(ret)
     return msg
 
-
+@ensure_byte_strings()
 def dcgmHostengineIsHealthy(dcgmHandle):
     heHealth = dcgm_structs.c_dcgmHostengineHealth_v1()
     heHealth.version = dcgm_structs.dcgmHostengineHealth_version1

--- a/components/model_analyzer/dcgm/dcgm_field_helpers.py
+++ b/components/model_analyzer/dcgm/dcgm_field_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,32 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# @Yueming Hao: Be careful! This file is different from the builtin file of DCGM python binding.
-
-import ctypes
-import json
-import time
-
 from . import dcgm_fields
 from . import dcgm_structs
 from . import dcgm_agent
 from . import dcgm_value as dcgmvalue
+from . import dcgm_fields_internal
+import ctypes
+import json
+
+# @Yueming Hao: add this warpper class to make fieldgroupid consistent with the latest dcgm_filed_helpers.py
+class DcgmFieldGroup:
+    def __init__(self, dcgm_handle, field_ids, group_name, fieldGroupId):
+        self.dcgm_handle = dcgm_handle
+        self.field_ids = field_ids
+        self.group_name = group_name
+        self.fieldGroupId = fieldGroupId
 
 
+'''
+Helper class that makes a python-friendly field value from one returned from the python bindings
+'''
 class DcgmFieldValue():
-    """
-    Helper class that makes a python-friendly field value from one returned
-    from the python bindings
-    """
+    '''
+    Constructor
 
+    rawValue is the latest dcgm_structs.c_dcgmFieldValue_v? structure of a field value returned from the raw APIs
+    '''
     def __init__(self, rawValue):
-        """
-        rawValue : dcgm_structs.c_dcgmFieldValue_v?
-            is the latest structure of a field value returned from the raw APIs
-        """
-        # Make sure the class passed in is an expected type
+        #Make sure the class passed in is an expected type
         if not type(rawValue) == dcgm_structs.c_dcgmFieldValue_v1:
-            raise Exception(f"Unexpected rawValue type {str(type(rawValue))}")
+            raise Exception("Unexpected rawValue type %s" % str(type(rawValue)))
 
         self.ts = rawValue.ts
         self.fieldId = rawValue.fieldId
@@ -52,8 +56,7 @@ class DcgmFieldValue():
         if self.fieldType == dcgm_fields.DCGM_FT_DOUBLE:
             self.value = float(rawValue.value.dbl)
             self.isBlank = dcgmvalue.DCGM_FP64_IS_BLANK(self.value)
-        elif self.fieldType == dcgm_fields.DCGM_FT_INT64 or \
-                self.fieldType == dcgm_fields.DCGM_FT_TIMESTAMP:
+        elif self.fieldType == dcgm_fields.DCGM_FT_INT64 or self.fieldType == dcgm_fields.DCGM_FT_TIMESTAMP:
             self.value = int(rawValue.value.i64)
             self.isBlank = dcgmvalue.DCGM_INT64_IS_BLANK(self.value)
         elif self.fieldType == dcgm_fields.DCGM_FT_STRING:
@@ -62,27 +65,25 @@ class DcgmFieldValue():
         elif self.fieldType == dcgm_fields.DCGM_FT_BINARY:
             if self.fieldId == dcgm_fields.DCGM_FI_DEV_ACCOUNTING_DATA:
                 accStats = dcgm_structs.c_dcgmDevicePidAccountingStats_v1()
-                ctypes.memmove(ctypes.addressof(accStats), rawValue.value.blob,
-                               accStats.FieldsSizeof())
-            if self.fieldId == dcgm_fields.DCGM_FI_DEV_COMPUTE_PIDS:
-                accStats = dcgm_structs.c_dcgmDeviceVgpuProcessUtilInfo_v1()
-                ctypes.memmove(ctypes.addressof(accStats), rawValue.value.blob,
-                               accStats.FieldsSizeof())
+                ctypes.memmove(ctypes.addressof(accStats), rawValue.value.blob, accStats.FieldsSizeof())
+            if self.fieldId in [dcgm_fields_internal.DCGM_FI_DEV_COMPUTE_PIDS, dcgm_fields_internal.DCGM_FI_DEV_GRAPHICS_PIDS]:
+                processStats = dcgm_structs.c_dcgmRunningProcess_t()
+                ctypes.memmove(ctypes.addressof(processStats), rawValue.value.blob, processStats.FieldsSizeof())
+                self.value = processStats
+                self.fieldType = dcgm_fields.DCGM_FT_BINARY
+                # This should always be false
+                self.isBlank = dcgmvalue.DCGM_INT64_IS_BLANK(processStats.pid)
             elif self.fieldId == dcgm_fields.DCGM_FI_SYNC_BOOST:
-                # Not exposed publicly for now
+                #Not exposed publicly for now
                 self.value = None
             else:
-                raise Exception("Blobs not handled yet for fieldId %d" %
-                                self.fieldId)
+                raise Exception("Blobs not handled yet for fieldId %d" % self.fieldId)
         else:
             raise Exception("Unhandled fieldType: %s" % self.fieldType)
 
-
 class DcgmFieldValueTimeSeries:
-
     def __init__(self):
-        # Values in timestamp order
-        self.values = []
+        self.values = [] #Values in timestamp order
 
     def __len__(self):
         return len(self.values)
@@ -95,7 +96,7 @@ class DcgmFieldValueTimeSeries:
             self.values.append(value)
             return
 
-        # Otherwise, we need to insert the value in the correct place.
+        #Otherwise, we need to insert the value in the correct place. Find the place
         for i, existingValue in enumerate(self.values):
             if value.ts < existingValue.ts:
                 self.values.insert(i, value)
@@ -103,79 +104,58 @@ class DcgmFieldValueTimeSeries:
 
         raise Exception("Unexpected no place to insert ts %d" % value.ts)
 
-
 class FieldValueEncoder(json.JSONEncoder):
-    # Pylint does not link overloading the default method, so the comment below
-    # is WAR for the linting problem
-    def default(self, obj):  # pylint: disable=E0202
+    # Pylint does not link overloading the default method, so the comment below is WAR for the linting problem
+    def default(self, obj): # pylint: disable=E0202
         nested_json = []
-        i = 0
+        i=0
         for key in obj:
             if isinstance(key, DcgmFieldValue):
-                if (key.isBlank):
+                if(key.isBlank):
                     continue
-                nested_json.append({
-                    'Timestamp': key.ts,
-                    'FieldId': key.fieldId,
-                    'Value': key.value
-                })
+                nested_json.append({'Timestamp' : key.ts, 'FieldId': key.fieldId, 'Value' : key.value})
             else:
-                return json.JSONEncoder.default(
-                    self, obj)  # Let default encoder throw exception
+                return json.JSONEncoder.default(self, obj) # Let default encoder throw exception    
         return nested_json
 
 
-def py_helper_dcgm_field_values_since_callback(gpuId, values, numValues,
-                                               userData):
+def py_helper_dcgm_field_values_since_callback(gpuId, values, numValues, userData):
 
     userData = ctypes.cast(userData, ctypes.py_object).value
     userData._ProcessValues(gpuId, values[0:numValues])
     return 0
 
+helper_dcgm_field_values_since_callback = dcgm_agent.dcgmFieldValueEnumeration_f(py_helper_dcgm_field_values_since_callback)
 
-helper_dcgm_field_values_since_callback =\
-    dcgm_agent.dcgmFieldValueEnumeration_f(
-        py_helper_dcgm_field_values_since_callback
-        )
-
-
-def py_helper_dcgm_field_values_since_callback_v2(entityGroupId, entityId,
-                                                  values, numValues, userData):
+def py_helper_dcgm_field_values_since_callback_v2(entityGroupId, entityId, values, numValues, userData):
     userData = ctypes.cast(userData, ctypes.py_object).value
     userData._ProcessValues(entityGroupId, entityId, values[0:numValues])
     return 0
 
+helper_dcgm_field_values_since_callback_v2 = dcgm_agent.dcgmFieldValueEntityEnumeration_f(py_helper_dcgm_field_values_since_callback_v2)
 
-helper_dcgm_field_values_since_callback_v2 =\
-    dcgm_agent.dcgmFieldValueEntityEnumeration_f(
-        py_helper_dcgm_field_values_since_callback_v2)
-
-
+'''
+Helper class for handling field value update callbacks and storing them in a .values member variable
+'''
 class DcgmFieldValueCollection:
-    """
-    Helper class for handling field value update callbacks and storing them
-    in a .values member variable
-    """
-
     def __init__(self, handle, groupId):
-        self.values = {}
-        # 2D dictionary of [gpuId][fieldId](DcgmFieldValueTimeSeries)
+        self.values = {} #2D dictionary of [gpuId][fieldId](DcgmFieldValueTimeSeries)
         self._handle = handle
         self._groupId = groupId
         self._numValuesSeen = 0
+        self._nextSinceTimestamp = 0
 
+    '''
+    Helper function called by the callback of dcgm_agent.dcgmGetValuesSince to process individual field values
+    '''
     def _ProcessValues(self, gpuId, values):
-        """
-        Helper function called by the callback of
-        dcgm_agent.dcgmGetValuesSince to process individual field values
-        """
         self._numValuesSeen += len(values)
 
         if gpuId not in self.values:
             self.values[gpuId] = {}
 
         for rawValue in values:
-            # Convert to python-friendly value
+            #Convert to python-friendly value
             value = DcgmFieldValue(rawValue)
 
             if value.fieldId not in self.values[gpuId]:
@@ -183,159 +163,135 @@ class DcgmFieldValueCollection:
 
             self.values[gpuId][value.fieldId].InsertValue(value)
 
-    def GetLatestValues(self, fieldGroup):
-        """
-        Get the latest values for a fieldGroup and store them to the .values
-        member variable
+    '''
+    Get the latest values for a fieldGroup and store them to the .values member variable
 
-        Note: This class does not automatically watch fieldGroup. You must do
-        that ahead of time with dcgmGroup.samples.WatchFields()
-        """
-        ret = dcgm_agent.dcgmGetLatestValues(
-            self._handle, self._groupId, fieldGroup.fieldGroupId,
-            helper_dcgm_field_values_since_callback, self)
-        # Will throw exception on error
+    Note: This class does not automatically watch fieldGroup. You must do that ahead of time with dcgmGroup.samples.WatchFields()
+    '''
+    def GetLatestValues(self, fieldGroup):
+        ret = dcgm_agent.dcgmGetLatestValues(self._handle, self._groupId, fieldGroup.fieldGroupId, helper_dcgm_field_values_since_callback, self)
+        #Will throw exception on error
         dcgm_structs._dcgmCheckReturn(ret)
+
+    '''
+    Method to cause more field values to be retrieved from DCGM. Returns the
+    number of field values that were retrieved.
+    '''
+    def GetAllSinceLastCall(self, fieldGroup):
+        beforeCount = self._numValuesSeen
+        self._nextSinceTimestamp = dcgm_agent.dcgmGetValuesSince(self._handle, self._groupId, fieldGroup.fieldGroupId, self._nextSinceTimestamp, helper_dcgm_field_values_since_callback, self)
+        afterCount = self._numValuesSeen
+        return afterCount - beforeCount
 
     def GetLatestValues_v2(self, fieldGroup):
-        ret = dcgm_agent.dcgmGetLatestValues_v2(
-            self._handle, self._groupId, fieldGroup.fieldGroupId,
-            helper_dcgm_field_values_since_callback_v2, self)
-        # Will throw exception on error
+        ret = dcgm_agent.dcgmGetLatestValues_v2(self._handle, self._groupId, fieldGroup.fieldGroupId, helper_dcgm_field_values_since_callback_v2, self)
+        #Will throw exception on error
         dcgm_structs._dcgmCheckReturn(ret)
 
+    '''
+    Method to cause more field values to be retrieved from DCGM. Returns the number of field values that were retrieved
+    '''
+    def GetAllSinceLastCall_v2(self, fieldGroup):
+        beforeCount = self._numValuesSeen
+        self._nextSinceTimestamp = dcgm_agent.dcgmGetValuesSince_v2(self._handle, self._groupId, fieldGroup.fieldGroupId, self._nextSinceTimestamp, helper_dcgm_field_values_since_entity_callback, self)
+        afterCount = self._numValuesSeen
+        return afterCount - beforeCount
+        
+
+    '''
+    Empty .values{} so that old data is no longer present in this structure.
+    This can be used to prevent .values from growing over time
+    '''
     def EmptyValues(self):
-        """
-        Empty .values{} so that old data is no longer present in this
-        structure. This can be used to prevent .values from growing over time
-        """
         self.values = {}
         self._numValuesSeen = 0
 
 
+'''
+Helper class for watching a field group and storing fields values returned from it
+'''
 class DcgmFieldGroupWatcher(DcgmFieldValueCollection):
-    """
-    Helper class for watching a field group and storing fields values returned
-    from it
-    """
+    '''
+    Constructor
 
-    def __init__(self, handle, groupId, fieldGroup, operationMode, updateFreq,
-                 maxKeepAge, maxKeepSamples, startTimestamp):
-        """
-        handle :
-            DCGM handle from dcgm_agent.dcgmInit()
-        groupId :
-            a DCGM group ID returned from dcgm_agent.dcgmGroupCreate
-        fieldGroup :
-            DcgmFieldGroup() instance to watch fields for
-        operationMode :
-            a dcgm_structs.DCGM_OPERATION_MODE_? constant for if the host
-            engine is running in lock step or auto mode
-        updateFreq :
-            how often to update each field in usec
-        maxKeepAge :
-            how long DCGM should keep values for in seconds
-        maxKeepSamples :
-            is the maximum number of samples DCGM should ever cache for each
-            field
-        startTimestamp :
-            a base timestamp we should start from when first reading
-            values. This can be used to resume a previous instance of a
-            DcgmFieldGroupWatcher by using its _nextSinceTimestamp. 0=start
-            with all cached data
-        """
+    handle is a DCGM handle from dcgm_agent.dcgmInit()
+    groupId is a valid DCGM group ID returned from dcgm_agent.dcgmGroupCreate
+    fieldGroup is the DcgmFieldGroup() instance to watch fields for
+    operationMode is a dcgm_structs.DCGM_OPERATION_MODE_? constant for if the host engine is running in lock step or auto mode
+    updateFreq is how often to update each field in usec
+    maxKeepAge is how long DCGM should keep values for in seconds
+    maxKeepSamples is the maximum number of samples DCGM should ever cache for each field
+    startTimestamp is a base timestamp we should start from when first reading values. This can be used to resume a
+                   previous instance of a DcgmFieldGroupWatcher by using its _nextSinceTimestamp.
+                   0=start with all cached data
+    '''
+    def __init__(self, handle, groupId, fieldGroup, operationMode, updateFreq, maxKeepAge, maxKeepSamples, startTimestamp):
         self._fieldGroup = fieldGroup
-        self._oprationMode = operationMode
+        self._operationMode = operationMode
         self._updateFreq = updateFreq
         self._maxKeepAge = maxKeepAge
         self._maxKeepSamples = maxKeepSamples
         DcgmFieldValueCollection.__init__(self, handle, groupId)
 
-        # Start from beginning of time
-        self._nextSinceTimestamp = 0
+        self._nextSinceTimestamp = 0 #Start from beginning of time
         if startTimestamp > 0:
             self._nextSinceTimestamp = startTimestamp
         self._numValuesSeen = 0
 
-        # Start watches
+        #Start watches
         self._WatchFieldGroup()
 
+    '''
+    Initiate the host engine watch on the fields
+    '''
     def _WatchFieldGroup(self):
-        """
-        Initiate the host engine watch on the fields
-        """
-        ret = dcgm_agent.dcgmWatchFields(self._handle, self._groupId,
-                                         self._fieldGroup, self._updateFreq,
-                                         self._maxKeepAge, self._maxKeepSamples)
-        # Will throw exception on error
-        dcgm_structs._dcgmCheckReturn(ret)
+        ret = dcgm_agent.dcgmWatchFields(self._handle, self._groupId, self._fieldGroup.fieldGroupId, self._updateFreq, self._maxKeepAge, self._maxKeepSamples)
+        dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-        # Force an update of the fields so that we can fetch initial values
+        # Force an update of the fields so that we can fetch initial values.
         ret = dcgm_agent.dcgmUpdateAllFields(self._handle, 1)
-        # Will throw exception on error
-        dcgm_structs._dcgmCheckReturn(ret)
+        dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-        # initial update will fetch from startTimestamp
-        self.GetMore()
+        # Initial update will fetch from startTimestamp.
+        self.GetAllSinceLastCall()
 
-    def GetMore(self):
-        """
-        Method to cause more field values to be retrieved from DCGM.
-
-        Returns
-        -------
-        int
-            the number of field values that were retrieved
-        """
-        beforeCount = self._numValuesSeen
-
-        # If we're in manual mode, force an update
-        if self._oprationMode == dcgm_structs.DCGM_OPERATION_MODE_MANUAL:
+    '''
+    Method to cause more field values to be retrieved from DCGM. Returns the
+    number of field values that were retrieved
+    '''
+    def GetAllSinceLastCall(self):
+        #If we're in manual mode, force an update
+        if self._operationMode == dcgm_structs.DCGM_OPERATION_MODE_MANUAL:
             ret = dcgm_agent.dcgmUpdateAllFields(self._handle, 1)
-            # Will throw exception on error
-            dcgm_structs._dcgmCheckReturn(ret)
+            dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-        self._nextSinceTimestamp = dcgm_agent.dcgmGetValuesSince(
-            self._handle, self._groupId, self._fieldGroup,
-            self._nextSinceTimestamp, helper_dcgm_field_values_since_callback,
-            self)
-        afterCount = self._numValuesSeen
-        return afterCount - beforeCount
+        return super().GetAllSinceLastCall(self._fieldGroup)
 
-
-def py_helper_dcgm_field_values_since_entity_callback(entityGroupId, entityId,
-                                                      values, numValues,
-                                                      userData):
+    
+def py_helper_dcgm_field_values_since_entity_callback(entityGroupId, entityId, values, numValues, userData):
 
     userData = ctypes.cast(userData, ctypes.py_object).value
     userData._ProcessValues(entityGroupId, entityId, values[0:numValues])
     return 0
 
+helper_dcgm_field_values_since_entity_callback = dcgm_agent.dcgmFieldValueEntityEnumeration_f(py_helper_dcgm_field_values_since_entity_callback)
 
-helper_dcgm_field_values_since_entity_callback = \
-    dcgm_agent.dcgmFieldValueEntityEnumeration_f(
-        py_helper_dcgm_field_values_since_entity_callback)
-
-
+'''
+Helper class for handling field value update callbacks and storing them in a .values member variable
+'''
 class DcgmFieldValueEntityCollection:
-    """
-    Helper class for handling field value update callbacks and storing them
-    in a .values member variable
-    """
-
     def __init__(self, handle, groupId):
-        # 3D dictionary of
-        # [entityGroupId][entityId][fieldId](DcgmFieldValueTimeSeries)
-        self.values = {}
+        self.values = {} #3D dictionary of [entityGroupId][entityId][fieldId](DcgmFieldValueTimeSeries)
         self._handle = handle
         self._groupId = groupId
         self._numValuesSeen = 0
+        self._nextSinceTimestamp = 0
+        
 
+    '''
+    Helper function called by the callback of dcgm_agent.dcgmGetValuesSince to process individual field values
+    '''
     def _ProcessValues(self, entityGroupId, entityId, values):
-        """
-        Helper function called by the callback of
-        dcgm_agent.dcgmGetValuesSince to process individual field values
-        """
         self._numValuesSeen += len(values)
 
         if entityGroupId not in self.values:
@@ -345,121 +301,145 @@ class DcgmFieldValueEntityCollection:
             self.values[entityGroupId][entityId] = {}
 
         for rawValue in values:
-            # Convert to python-friendly value
+            #Convert to python-friendly value
             value = DcgmFieldValue(rawValue)
 
             if value.fieldId not in self.values[entityGroupId][entityId]:
-                self.values[entityGroupId][entityId][
-                    value.fieldId] = DcgmFieldValueTimeSeries()
+                self.values[entityGroupId][entityId][value.fieldId] = DcgmFieldValueTimeSeries()
 
-            self.values[entityGroupId][entityId][value.fieldId].InsertValue(
-                value)
+            self.values[entityGroupId][entityId][value.fieldId].InsertValue(value)
 
+    '''
+    Get the latest values for a fieldGroup and store them to the .values member variable
+
+    Note: This class does not automatically watch fieldGroup. You must do that ahead of time with dcgmGroup.samples.WatchFields()
+    '''
     def GetLatestValues(self, fieldGroup):
-        """
-        Get the latest values for a fieldGroup and store them to the
-        .values member variable
-
-        Note: This class does not automatically watch fieldGroup. You must do
-        that ahead of time with dcgmGroup.samples.WatchFields()
-        """
-        ret = dcgm_agent.dcgmGetLatestValues_v2(
-            self._handle, self._groupId, fieldGroup.fieldGroupId,
-            helper_dcgm_field_values_since_entity_callback, self)
-        # Will throw exception on error
+        ret = dcgm_agent.dcgmGetLatestValues_v2(self._handle, self._groupId, fieldGroup.fieldGroupId, helper_dcgm_field_values_since_entity_callback, self)
+        #Will throw exception on error
         dcgm_structs._dcgmCheckReturn(ret)
 
+    '''
+    Method to cause more field values to be retrieved from DCGM. Returns the
+    number of field values that were retrieved.
+    '''
+    def GetAllSinceLastCall(self, fieldGroup):
+        beforeCount = self._numValuesSeen
+        self._nextSinceTimestamp = dcgm_agent.dcgmGetValuesSince_v2(self._handle, self._groupId, fieldGroup.fieldGroupId, self._nextSinceTimestamp, helper_dcgm_field_values_since_entity_callback, self)
+        afterCount = self._numValuesSeen
+        return afterCount - beforeCount
+        
+    
+    '''
+    Empty .values{} so that old data is no longer present in this structure.
+    This can be used to prevent .values from growing over time
+    '''
     def EmptyValues(self):
-        """
-        Empty .values{} so that old data is no longer present in this
-        structure. This can be used to prevent .values from growing over time
-        """
         self.values = {}
         self._numValuesSeen = 0
 
 
+'''
+Helper class for watching a field group and storing fields values returned from it
+'''
 class DcgmFieldGroupEntityWatcher(DcgmFieldValueEntityCollection):
-    """
-    Helper class for watching a field group and storing fields values
-    returned from it
-    """
+    '''
+    Constructor
 
-    def __init__(self, handle, groupId, fieldGroup, operationMode, updateFreq,
-                 maxKeepAge, maxKeepSamples, startTimestamp):
-        """
-        Constructor
-
-        handle :
-            a DCGM handle from dcgm_agent.dcgmInit()
-        groupId :
-            a valid DCGM group ID returned from dcgm_agent.dcgmGroupCreate
-        fieldGroup :
-            DcgmFieldGroup() instance to watch fields for
-        operationMode :
-            is a dcgm_structs.DCGM_OPERATION_MODE_? constant for if the host
-            engine is running in lock step or auto mode
-        updateFreq :
-            how often to update each field in usec
-        maxKeepAge :
-            how long DCGM should keep values for in seconds
-        maxKeepSamples :
-            the maximum number of samples DCGM should ever cache for each field
-        startTimestamp :
-            a base timestamp we should start from when first reading values.
-            This can be used to resume a previous instance of a
-            DcgmFieldGroupWatcher by using its _nextSinceTimestamp. 0=start
-            with all cached data
-        """
+    handle is a DCGM handle from dcgm_agent.dcgmInit()
+    groupId is a valid DCGM group ID returned from dcgm_agent.dcgmGroupCreate
+    fieldGroup is the DcgmFieldGroup() instance to watch fields for
+    operationMode is a dcgm_structs.DCGM_OPERATION_MODE_? constant for if the host engine is running in lock step or auto mode
+    updateFreq is how often to update each field in usec
+    maxKeepAge is how long DCGM should keep values for in seconds
+    maxKeepSamples is the maximum number of samples DCGM should ever cache for each field
+    startTimestamp is a base timestamp we should start from when first reading values. This can be used to resume a
+                   previous instance of a DcgmFieldGroupWatcher by using its _nextSinceTimestamp.
+                   0=start with all cached data
+    '''
+    def __init__(self, handle, groupId, fieldGroup, operationMode, updateFreq, maxKeepAge, maxKeepSamples, startTimestamp):
         self._fieldGroup = fieldGroup
-        self._oprationMode = operationMode
+        self._operationMode = operationMode
         self._updateFreq = updateFreq
         self._maxKeepAge = maxKeepAge
         self._maxKeepSamples = maxKeepSamples
         DcgmFieldValueEntityCollection.__init__(self, handle, groupId)
 
-        # Start from beginning of time
-        self._nextSinceTimestamp = 0
+        self._nextSinceTimestamp = 0 #Start from beginning of time
         if startTimestamp > 0:
             self._nextSinceTimestamp = startTimestamp
         self._numValuesSeen = 0
 
-        # Start watches
+        #Start watches
         self._WatchFieldGroup()
 
+    '''
+    Initiate the host engine watch on the fields
+    '''
     def _WatchFieldGroup(self):
-        """
-        Initiate the host engine watch on the fields
-        """
-        ret = dcgm_agent.dcgmWatchFields(self._handle, self._groupId,
-                                         self._fieldGroup.fieldGroupId,
-                                         self._updateFreq, self._maxKeepAge,
-                                         self._maxKeepSamples)
-        # Will throw exception on error
-        dcgm_structs._dcgmCheckReturn(ret)
+        ret = dcgm_agent.dcgmWatchFields(self._handle, self._groupId, self._fieldGroup.fieldGroupId, self._updateFreq, self._maxKeepAge, self._maxKeepSamples)
+        dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-        # Force an update of the fields so that we can fetch initial values
+        # Force an update of the fields so that we can fetch initial values.
         ret = dcgm_agent.dcgmUpdateAllFields(self._handle, 1)
-        # Will throw exception on error
-        dcgm_structs._dcgmCheckReturn(ret)
-        # initial update will fetch from startTimestamp
-        self.GetMore()
+        dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-    def GetMore(self):
-        """
-        Method to cause more field values to be retrieved from DCGM. Returns
-        the number of field values that were retrieved
-        """
-        beforeCount = self._numValuesSeen
+        # Initial update will fetch from startTimestamp.
+        self.GetAllSinceLastCall()
 
-        # If we're in manual mode, force an update
-        if self._oprationMode == dcgm_structs.DCGM_OPERATION_MODE_MANUAL:
+    '''
+    Method to cause more field values to be retrieved from DCGM. Returns the
+    number of field values that were retrieved
+    '''
+    def GetAllSinceLastCall(self):
+        #If we're in manual mode, force an update
+        if self._operationMode == dcgm_structs.DCGM_OPERATION_MODE_MANUAL:
             ret = dcgm_agent.dcgmUpdateAllFields(self._handle, 1)
-            # Will throw exception on error
-            dcgm_structs._dcgmCheckReturn(ret)
+            dcgm_structs._dcgmCheckReturn(ret) #Will throw exception on error
 
-        self._nextSinceTimestamp = dcgm_agent.dcgmGetValuesSince_v2(
-            self._handle, self._groupId, self._fieldGroup.fieldGroupId,
-            self._nextSinceTimestamp,
-            helper_dcgm_field_values_since_entity_callback, self)
-        afterCount = self._numValuesSeen
-        return afterCount - beforeCount
+        return super().GetAllSinceLastCall(self._fieldGroup)
+
+#Test program for demonstrating how this module works
+# def main():
+#     operationMode = dcgm_structs.DCGM_OPERATION_MODE_AUTO
+#     timeStep = 1.0
+
+#     dcgm_structs._dcgmInit()
+#     dcgm_agent.dcgmInit() #Will throw an exception on error
+#     handle = dcgm_agent.dcgmStartEmbedded(operationMode)
+#     handleObj = pydcgm.DcgmHandle(handle=handle)
+#     groupId = dcgm_structs.DCGM_GROUP_ALL_GPUS
+#     fieldIds = [dcgm_fields.DCGM_FI_DEV_SM_CLOCK, dcgm_fields.DCGM_FI_DEV_MEM_CLOCK]
+
+#     fieldGroup = pydcgm.DcgmFieldGroup(handleObj, "my_field_group", fieldIds)
+
+#     updateFreq = int(timeStep * 1000000.0)
+#     maxKeepAge = 3600.0 #1 hour
+#     maxKeepSamples = 0 #unlimited. maxKeepAge will enforce quota
+#     startTimestamp = 0 #beginning of time
+
+#     dfcw = DcgmFieldGroupWatcher(handle, groupId, fieldGroup, operationMode, updateFreq, maxKeepAge, maxKeepSamples, startTimestamp)
+#     dfcw2 = DcgmFieldGroupEntityWatcher(handle, groupId, fieldGroup, operationMode, updateFreq, maxKeepAge, maxKeepSamples, startTimestamp)
+
+#     while(True):
+#         newUpdateCount = dfcw.GetAllSinceLastCall()
+#         newUpdateCount2 = dfcw2.GetAllSinceLastCall()
+#         print("Got %d and %d new field value updates" % (newUpdateCount, newUpdateCount2))
+#         for gpuId in list(dfcw.values.keys()):
+#             print("gpuId %d" % gpuId)
+#             for fieldId in list(dfcw.values[gpuId].keys()):
+#                 print("    fieldId %d: %d values. latest timestamp %d" % \
+#                       (fieldId, len(dfcw.values[gpuId][fieldId]), dfcw.values[gpuId][fieldId][-1].ts))
+
+#         for entityGroupId in list(dfcw2.values.keys()):
+#             print("entityGroupId %d" % entityGroupId)
+#             for entityId in list(dfcw2.values[entityGroupId].keys()):
+#                 print("    entityId %d" % entityId)
+#                 for fieldId in list(dfcw2.values[entityGroupId][entityId].keys()):
+#                     print("        fieldId %d: %d values. latest timestamp %d" % \
+#                           (fieldId, len(dfcw2.values[entityGroupId][entityId][fieldId]), dfcw2.values[entityGroupId][entityId][fieldId][-1].ts))
+
+#         time.sleep(timeStep)
+
+# if __name__ == "__main__":
+#     main()

--- a/components/model_analyzer/dcgm/dcgm_fields.py
+++ b/components/model_analyzer/dcgm/dcgm_fields.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ # Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+##
+# Python bindings for the internal API of DCGM library (dcgm_fields.h)
+##
 
 from ctypes import *
 from ctypes.util import find_library
@@ -20,17 +23,16 @@ from . import dcgm_structs
 dcgmFP = dcgm_structs._dcgmGetFunctionPointer
 
 # Field Types are a single byte. List these in ASCII order
-DCGM_FT_BINARY = 'b'  # Blob of binary data representing a structure
-DCGM_FT_DOUBLE = 'd'  # 8-byte double precision
-DCGM_FT_INT64 = 'i'  # 8-byte signed integer
-DCGM_FT_STRING = 's'  # Null-terminated ASCII Character string
-DCGM_FT_TIMESTAMP = 't'  # 8-byte signed integer usec since 1970
+DCGM_FT_BINARY      = 'b' # Blob of binary data representing a structure
+DCGM_FT_DOUBLE      = 'd' # 8-byte double precision 
+DCGM_FT_INT64       = 'i' # 8-byte signed integer 
+DCGM_FT_STRING      = 's' # Null-terminated ASCII Character string 
+DCGM_FT_TIMESTAMP   = 't' # 8-byte signed integer usec since 1970 
 
 # Field scope. What are these fields associated with
-DCGM_FS_GLOBAL = 0  # Field is global (ex: driver version)
-DCGM_FS_ENTITY = 1  # Field is associated with an entity (GPU, VGPU, ..etc)
-# Field is associated with a device. Deprecated. Use DCGM_FS_ENTITY
-DCGM_FS_DEVICE = DCGM_FS_ENTITY
+DCGM_FS_GLOBAL	    = 0              # Field is global (ex: driver version)
+DCGM_FS_ENTITY      = 1              # Field is associated with an entity (GPU, VGPU, ..etc)
+DCGM_FS_DEVICE      = DCGM_FS_ENTITY # Field is associated with a device. Deprecated. Use DCGM_FS_ENTITY
 
 # DCGM_FI_DEV_CLOCK_THROTTLE_REASONS is a bitmap of why the clock is throttled.
 # These macros are masks for relevant throttling, and are a 1:1 map to the NVML
@@ -42,15 +44,14 @@ DCGM_CLOCKS_THROTTLE_REASON_GPU_IDLE = 0x0000000000000001
 # GPU clocks are limited by current setting of applications clocks
 DCGM_CLOCKS_THROTTLE_REASON_CLOCKS_SETTING = 0x0000000000000002
 
-# SW Power Scaling algorithm is reducing the clocks below requested clocks
+# SW Power Scaling algorithm is reducing the clocks below requested clocks 
 DCGM_CLOCKS_THROTTLE_REASON_SW_POWER_CAP = 0x0000000000000004
 
 # HW Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
 #
 # This is an indicator of:
 #  - temperature being too high
-#  - External Power Brake Assertion is triggered
-#    (e.g. by the system power supply)
+#  - External Power Brake Assertion is triggered (e.g. by the system power supply)
 #  - Power draw is too high and Fast Trigger protection is reducing the clocks
 #  - May be also reported during PState or clock change
 #  - This behavior may be removed in a later release.
@@ -73,643 +74,528 @@ DCGM_CLOCKS_THROTTLE_REASON_SYNC_BOOST = 0x0000000000000010
 #  - Current memory temperature above the Memory Max Operating Temperature
 DCGM_CLOCKS_THROTTLE_REASON_SW_THERMAL = 0x0000000000000020
 
-# HW Thermal Slowdown (reducing the core clocks by a factor of 2 or more) is
-# engaged
+# HW Thermal Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
 #
 # This is an indicator of:
 #  - temperature being too high
 DCGM_CLOCKS_THROTTLE_REASON_HW_THERMAL = 0x0000000000000040
 
-# HW Power Brake Slowdown (reducing the core clocks by a factor of 2 or more)
-# is engaged
+# HW Power Brake Slowdown (reducing the core clocks by a factor of 2 or more) is engaged
 #
 # This is an indicator of:
-#  - External Power Brake Assertion being triggered (e.g. by the system power
-#  supply)
+#  - External Power Brake Assertion being triggered (e.g. by the system power supply)
 DCGM_CLOCKS_THROTTLE_REASON_HW_POWER_BRAKE = 0x0000000000000080
 
 # GPU clocks are limited by current setting of Display clocks
 DCGM_CLOCKS_THROTTLE_REASON_DISPLAY_CLOCKS = 0x0000000000000100
 
-# Field entity groups. Which type of entity is this field or field value
-# associated with
+#Field entity groups. Which type of entity is this field or field value associated with
+DCGM_FE_NONE   = 0 # Field is not associated with an entity. Field scope should be DCGM_FS_GLOBAL
+DCGM_FE_GPU    = 1 # Field is associated with a GPU entity
+DCGM_FE_VGPU   = 2 # Field is associated with a VGPU entity
+DCGM_FE_SWITCH = 3 # Field is associated with a Switch entity
+DCGM_FE_GPU_I  = 4 # Field is associated with a GPU Instance entity
+DCGM_FE_GPU_CI = 5 # Field is associated with a GPU Compute Instance entity
+DCGM_FE_LINK   = 6 # Field is associated with an NVLINK
 
-# Field is not associated with an entity. Field scope should be DCGM_FS_GLOBAL
-DCGM_FE_NONE = 0
-DCGM_FE_GPU = 1  # Field is associated with a GPU entity
-DCGM_FE_VGPU = 2  # Field is associated with a VGPU entity
-DCGM_FE_SWITCH = 3  # Field is associated with a Switch entity
-DCGM_FE_GPU_I = 4  # Field is associated with a GPU Instance entity
-DCGM_FE_GPU_CI = 5  # Field is associated with a GPU Compute Instance entity
+c_dcgm_field_eid_t = c_uint32 #Represents an identifier for an entity within a field entity. For instance, this is the gpuId for DCGM_FE_GPU.
 
-# Represents an identifier for an entity within a field entity. For instance,
-# this is the gpuId for DCGM_FE_GPU.
-c_dcgm_field_eid_t = c_uint32
+#System attributes
+DCGM_FI_UNKNOWN                 = 0
+DCGM_FI_DRIVER_VERSION          = 1   #Driver Version
+DCGM_FI_NVML_VERSION            = 2   #Underlying NVML version
+DCGM_FI_PROCESS_NAME            = 3   #Process Name. Will be nv-hostengine or your process's name in embedded mode
+DCGM_FI_DEV_COUNT               = 4   #Number of Devices on the node
+DCGM_FI_CUDA_DRIVER_VERSION     = 5   #Cuda Driver Version as an integer. CUDA 11.1 = 11100
+#Device attributes
+DCGM_FI_DEV_NAME                = 50  #Name of the GPU device
+DCGM_FI_DEV_BRAND               = 51  #Device Brand
+DCGM_FI_DEV_NVML_INDEX          = 52  #NVML index of this GPU
+DCGM_FI_DEV_SERIAL              = 53  #Device Serial Number
+DCGM_FI_DEV_UUID                = 54  #UUID corresponding to the device
+DCGM_FI_DEV_MINOR_NUMBER        = 55  #Device node minor number /dev/nvidia#
+DCGM_FI_DEV_OEM_INFOROM_VER     = 56  #OEM inforom version
+DCGM_FI_DEV_PCI_BUSID           = 57  #PCI attributes for the device
+DCGM_FI_DEV_PCI_COMBINED_ID     = 58  #The combined 16-bit device id and 16-bit vendor id
+DCGM_FI_DEV_PCI_SUBSYS_ID       = 59  #The 32-bit Sub System Device ID
+DCGM_FI_GPU_TOPOLOGY_PCI        = 60  #Topology of all GPUs on the system via PCI (static)
+DCGM_FI_GPU_TOPOLOGY_NVLINK     = 61  #Topology of all GPUs on the system via NVLINK (static)
+DCGM_FI_GPU_TOPOLOGY_AFFINITY   = 62  #Affinity of all GPUs on the system (static)
+DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY = 63 #Cuda compute capability for the device
+DCGM_FI_DEV_COMPUTE_MODE        = 65  #Compute mode for the device
+DCGM_FI_DEV_PERSISTENCE_MODE    = 66  #Persistence mode for the device
+DCGM_FI_DEV_MIG_MODE            = 67  #MIG mode for the device
+DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR = 68  #String value for CUDA_VISIBLE_DEVICES for the device
+DCGM_FI_DEV_MIG_MAX_SLICES      = 69  #The maximum number of slices this GPU supports
+DCGM_FI_DEV_CPU_AFFINITY_0      = 70  #Device CPU affinity. part 1/8 = cpus 0 - 63
+DCGM_FI_DEV_CPU_AFFINITY_1      = 71  #Device CPU affinity. part 1/8 = cpus 64 - 127
+DCGM_FI_DEV_CPU_AFFINITY_2      = 72  #Device CPU affinity. part 2/8 = cpus 128 - 191
+DCGM_FI_DEV_CPU_AFFINITY_3      = 73  #Device CPU affinity. part 3/8 = cpus 192 - 255
+DCGM_FI_DEV_CC_MODE             = 74  #Device CC/APM mode
+DCGM_FI_DEV_MIG_ATTRIBUTES      = 75  #MIG device attributes
+DCGM_FI_DEV_MIG_GI_INFO         = 76  #GPU instance profile information
+DCGM_FI_DEV_MIG_CI_INFO         = 77  #Compute instance profile information
+DCGM_FI_DEV_ECC_INFOROM_VER     = 80  #ECC inforom version
+DCGM_FI_DEV_POWER_INFOROM_VER   = 81  #Power management object inforom version
+DCGM_FI_DEV_INFOROM_IMAGE_VER   = 82  #Inforom image version
+DCGM_FI_DEV_INFOROM_CONFIG_CHECK = 83 #Inforom configuration checksum
+DCGM_FI_DEV_INFOROM_CONFIG_VALID = 84 #Reads the infoROM from the flash and verifies the checksums
+DCGM_FI_DEV_VBIOS_VERSION       = 85  #VBIOS version of the device
+DCGM_FI_DEV_BAR1_TOTAL          = 90  #Total BAR1 of the GPU
+DCGM_FI_SYNC_BOOST              = 91  #Deprecated - Sync boost settings on the node
+DCGM_FI_DEV_BAR1_USED           = 92  #Used BAR1 of the GPU in MB
+DCGM_FI_DEV_BAR1_FREE           = 93  #Free BAR1 of the GPU in MB
+#Clocks and power
+DCGM_FI_DEV_SM_CLOCK            = 100 #SM clock for the device
+DCGM_FI_DEV_MEM_CLOCK           = 101 #Memory clock for the device
+DCGM_FI_DEV_VIDEO_CLOCK         = 102 #Video encoder/decoder clock for the device
+DCGM_FI_DEV_APP_SM_CLOCK        = 110 #SM Application clocks
+DCGM_FI_DEV_APP_MEM_CLOCK       = 111 #Memory Application clocks
+DCGM_FI_DEV_CLOCK_THROTTLE_REASONS = 112 #Current clock throttle reasons (bitmask of DCGM_CLOCKS_THROTTLE_REASON_*)
+DCGM_FI_DEV_MAX_SM_CLOCK        = 113 #Maximum supported SM clock for the device
+DCGM_FI_DEV_MAX_MEM_CLOCK       = 114 #Maximum supported Memory clock for the device
+DCGM_FI_DEV_MAX_VIDEO_CLOCK     = 115 #Maximum supported Video encoder/decoder clock for the device
+DCGM_FI_DEV_AUTOBOOST           = 120 #Auto-boost for the device (1 = enabled. 0 = disabled)
+DCGM_FI_DEV_SUPPORTED_CLOCKS    = 130 #Supported clocks for the device
+DCGM_FI_DEV_MEMORY_TEMP         = 140 #Memory temperature for the device
+DCGM_FI_DEV_GPU_TEMP            = 150 #Current temperature readings for the device, in degrees C
+DCGM_FI_DEV_MEM_MAX_OP_TEMP     = 151 #Maximum operating temperature for the memory of this GPU
+DCGM_FI_DEV_GPU_MAX_OP_TEMP     = 152 #Maximum operating temperature for this GPU
+DCGM_FI_DEV_POWER_USAGE         = 155 #Power usage for the device in Watts
+DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION = 156 #Total energy consumption for the GPU in mJ since the driver was last reloaded
+DCGM_FI_DEV_SLOWDOWN_TEMP       = 158 #Slowdown temperature for the device
+DCGM_FI_DEV_SHUTDOWN_TEMP       = 159 #Shutdown temperature for the device
+DCGM_FI_DEV_POWER_MGMT_LIMIT    = 160 #Current Power limit for the device
+DCGM_FI_DEV_POWER_MGMT_LIMIT_MIN = 161 #Minimum power management limit for the device
+DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX = 162 #Maximum power management limit for the device
+DCGM_FI_DEV_POWER_MGMT_LIMIT_DEF = 163 #Default power management limit for the device
+DCGM_FI_DEV_ENFORCED_POWER_LIMIT = 164 #Effective power limit that the driver enforces after taking into account all limiters
+DCGM_FI_DEV_PSTATE               = 190 #Performance state (P-State) 0-15. 0=highest
+DCGM_FI_DEV_FAN_SPEED            = 191 #Fan speed for the device in percent 0-100
+#Device utilization and telemetry
+DCGM_FI_DEV_PCIE_TX_THROUGHPUT  = 200 #Deprecated - PCIe Tx utilization information
+DCGM_FI_DEV_PCIE_RX_THROUGHPUT  = 201 #Deprecated - PCIe Rx utilization information
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER = 202 #PCIe replay counter
+DCGM_FI_DEV_GPU_UTIL            = 203 #GPU Utilization
+DCGM_FI_DEV_MEM_COPY_UTIL       = 204 #Memory Utilization
+DCGM_FI_DEV_ACCOUNTING_DATA     = 205 #Process accounting stats
+DCGM_FI_DEV_ENC_UTIL            = 206 #Encoder utilization
+DCGM_FI_DEV_DEC_UTIL            = 207 #Decoder utilization
+# Fields 210, 211, 220, and 221 are internal-only. see dcgm_fields_internal.py 
+DCGM_FI_DEV_XID_ERRORS          = 230 #XID errors. The value is the specific XID error
+DCGM_FI_DEV_PCIE_MAX_LINK_GEN   = 235 #PCIe Max Link Generation
+DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH = 236 #PCIe Max Link Width
+DCGM_FI_DEV_PCIE_LINK_GEN       = 237 #PCIe Current Link Generation
+DCGM_FI_DEV_PCIE_LINK_WIDTH     = 238 #PCIe Current Link Width
+#Violation counters
+DCGM_FI_DEV_POWER_VIOLATION     = 240 #Power Violation time in usec
+DCGM_FI_DEV_THERMAL_VIOLATION   = 241 #Thermal Violation time in usec
+DCGM_FI_DEV_SYNC_BOOST_VIOLATION = 242 #Sync Boost Violation time in usec
+DCGM_FI_DEV_BOARD_LIMIT_VIOLATION = 243 #Board Limit Violation time in usec.
+DCGM_FI_DEV_LOW_UTIL_VIOLATION    = 244 #Low Utilization Violation time in usec.
+DCGM_FI_DEV_RELIABILITY_VIOLATION = 245 #Reliability Violation time in usec.
+DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION = 246 #App Clocks Violation time in usec.
+DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION = 247 #Base Clocks Violation time in usec.
+#Framebuffer usage
+DCGM_FI_DEV_FB_TOTAL            = 250 #Total framebuffer memory in MB
+DCGM_FI_DEV_FB_FREE             = 251 #Total framebuffer used in MB
+DCGM_FI_DEV_FB_USED             = 252 #Total framebuffer free in MB
+DCGM_FI_DEV_FB_RESERVED         = 253 #Total framebuffer reserved in MB
+#Device ECC Counters
+DCGM_FI_DEV_ECC_CURRENT         = 300 #Current ECC mode for the device
+DCGM_FI_DEV_ECC_PENDING         = 301 #Pending ECC mode for the device
+DCGM_FI_DEV_ECC_SBE_VOL_TOTAL   = 310 #Total single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_TOTAL   = 311 #Total double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_TOTAL   = 312 #Total single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_TOTAL   = 313 #Total double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_SBE_VOL_L1      = 314 #L1 cache single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_L1      = 315 #L1 cache double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_VOL_L2      = 316 #L2 cache single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_L2      = 317 #L2 cache double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_VOL_DEV     = 318 #Device memory single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_DEV     = 319 #Device memory double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_VOL_REG     = 320 #Register file single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_REG     = 321 #Register file double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_VOL_TEX     = 322 #Texture memory single bit volatile ecc errors
+DCGM_FI_DEV_ECC_DBE_VOL_TEX     = 323 #Texture memory double bit volatile ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_L1      = 324 #L1 cache single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_L1      = 325 #L1 cache double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_L2      = 326 #L2 cache single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_L2      = 327 #L2 cache double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_DEV     = 328 #Device memory single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_DEV     = 329 #Device memory double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_REG     = 330 #Register File single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_REG     = 331 #Register File double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_SBE_AGG_TEX     = 332 #Texture memory single bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_ECC_DBE_AGG_TEX     = 333 #Texture memory double bit aggregate (persistent) ecc errors
+DCGM_FI_DEV_RETIRED_SBE         = 390 #Number of retired pages because of single bit errors
+DCGM_FI_DEV_RETIRED_DBE         = 391 #Number of retired pages because of double bit errors
+DCGM_FI_DEV_RETIRED_PENDING     = 392 #Number of pages pending retirement
+#Row remapper fields (Ampere and newer)
+DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS = 393 #Number of remapped rows for uncorrectable errors
+DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS   = 394 #Number of remapped rows for correctable errors
+DCGM_FI_DEV_ROW_REMAP_FAILURE           = 395 #Whether remapping of rows has failed
+DCGM_FI_DEV_ROW_REMAP_PENDING           = 396 #Whether remapping of rows is pending
 
-#
-# System attributes
-#
-DCGM_FI_UNKNOWN = 0
-# Driver Version
-DCGM_FI_DRIVER_VERSION = 1
-# Underlying NVML version
-DCGM_FI_NVML_VERSION = 2
-# Process Name. Will be nv-hostengine or your process's name in embedded mode
-DCGM_FI_PROCESS_NAME = 3
-# Number of Devices on the node
-DCGM_FI_DEV_COUNT = 4
+#Device NvLink Bandwidth and Error Counters
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 = 400 #NV Link flow control CRC  Error Counter for Lane 0
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 = 401 #NV Link flow control CRC  Error Counter for Lane 1
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 = 402 #NV Link flow control CRC  Error Counter for Lane 2
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 = 403 #NV Link flow control CRC  Error Counter for Lane 3
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 = 404 #NV Link flow control CRC  Error Counter for Lane 4
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 = 405 #NV Link flow control CRC  Error Counter for Lane 5
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = 409 #NV Link flow control CRC  Error Counter total for all Lanes
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 = 410 #NV Link data CRC Error Counter for Lane 0
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 = 411 #NV Link data CRC Error Counter for Lane 1
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 = 412 #NV Link data CRC Error Counter for Lane 2
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 = 413 #NV Link data CRC Error Counter for Lane 3
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 = 414 #NV Link data CRC Error Counter for Lane 4
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 = 415 #NV Link data CRC Error Counter for Lane 5
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = 419 #NV Link data CRC Error Counter total for all Lanes
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0   = 420 #NV Link Replay Error Counter for Lane 0
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1   = 421 #NV Link Replay Error Counter for Lane 1
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2   = 422 #NV Link Replay Error Counter for Lane 2
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3   = 423 #NV Link Replay Error Counter for Lane 3
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4   = 424 #NV Link Replay Error Counter for Lane 4
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5   = 425 #NV Link Replay Error Counter for Lane 3
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL = 429 #NV Link Replay Error Counter total for all Lanes
 
-#
-# Device attributes
-#
-# Name of the GPU device
-DCGM_FI_DEV_NAME = 50
-# Device Brand
-DCGM_FI_DEV_BRAND = 51
-# NVML index of this GPU
-DCGM_FI_DEV_NVML_INDEX = 52
-# Device Serial Number
-DCGM_FI_DEV_SERIAL = 53
-# UUID corresponding to the device
-DCGM_FI_DEV_UUID = 54
-# Device node minor number /dev/nvidia#
-DCGM_FI_DEV_MINOR_NUMBER = 55
-# OEM inforom version
-DCGM_FI_DEV_OEM_INFOROM_VER = 56
-# PCI attributes for the device
-DCGM_FI_DEV_PCI_BUSID = 57
-# The combined 16-bit device id and 16-bit vendor id
-DCGM_FI_DEV_PCI_COMBINED_ID = 58
-# The 32-bit Sub System Device ID
-DCGM_FI_DEV_PCI_SUBSYS_ID = 59
-# Topology of all GPUs on the system via PCI (static)
-DCGM_FI_GPU_TOPOLOGY_PCI = 60
-# Topology of all GPUs on the system via NVLINK (static)
-DCGM_FI_GPU_TOPOLOGY_NVLINK = 61
-# Affinity of all GPUs on the system (static)
-DCGM_FI_GPU_TOPOLOGY_AFFINITY = 62
-# Compute mode for the device
-DCGM_FI_DEV_COMPUTE_MODE = 65
-# Persistence mode for the device
-DCGM_FI_DEV_PERSISTENCE_MODE = 66
-# MIG mode for the device
-DCGM_FI_DEV_MIG_MODE = 67
-# String value for CUDA_VISIBLE_DEVICES for the device
-DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR = 68
-# Device CPU affinity. part 1/8 = cpus 0 - 63
-DCGM_FI_DEV_CPU_AFFINITY_0 = 70
-# Device CPU affinity. part 1/8 = cpus 64 - 127
-DCGM_FI_DEV_CPU_AFFINITY_1 = 71
-# Device CPU affinity. part 2/8 = cpus 128 - 191
-DCGM_FI_DEV_CPU_AFFINITY_2 = 72
-# Device CPU affinity. part 3/8 = cpus 192 - 255
-DCGM_FI_DEV_CPU_AFFINITY_3 = 73
-# ECC inforom version
-DCGM_FI_DEV_ECC_INFOROM_VER = 80
-# Power management object inforom version
-DCGM_FI_DEV_POWER_INFOROM_VER = 81
-# Inforom image version
-DCGM_FI_DEV_INFOROM_IMAGE_VER = 82
-# Inforom configuration checksum
-DCGM_FI_DEV_INFOROM_CONFIG_CHECK = 83
-# Reads the infoROM from the flash and verifies the checksums
-DCGM_FI_DEV_INFOROM_CONFIG_VALID = 84
-# VBIOS version of the device
-DCGM_FI_DEV_VBIOS_VERSION = 85
-# Total BAR1 of the GPU
-DCGM_FI_DEV_BAR1_TOTAL = 90
-# Deprecated - Sync boost settings on the node
-DCGM_FI_SYNC_BOOST = 91
-# Used BAR1 of the GPU in MB
-DCGM_FI_DEV_BAR1_USED = 92
-# Free BAR1 of the GPU in MB
-DCGM_FI_DEV_BAR1_FREE = 93
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 = 430 #NV Link Recovery Error Counter for Lane 0
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 = 431 #NV Link Recovery Error Counter for Lane 1
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 = 432 #NV Link Recovery Error Counter for Lane 2
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 = 433 #NV Link Recovery Error Counter for Lane 3
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 = 434 #NV Link Recovery Error Counter for Lane 4
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 = 435 #NV Link Recovery Error Counter for Lane 5
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL = 439 #NV Link Recovery Error Counter total for all Lanes
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L0            = 440 #NV Link Bandwidth Counter for Lane 0
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L1            = 441 #NV Link Bandwidth Counter for Lane 1
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L2            = 442 #NV Link Bandwidth Counter for Lane 2
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L3            = 443 #NV Link Bandwidth Counter for Lane 3
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L4            = 444 #NV Link Bandwidth Counter for Lane 4
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L5            = 445 #NV Link Bandwidth Counter for Lane 5
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL         = 449 #NV Link Bandwidth Counter total for all Lanes
+DCGM_FI_DEV_GPU_NVLINK_ERRORS              = 450 #GPU NVLink error information
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6  = 451
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7  = 452
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8  = 453
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9  = 454
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10 = 455
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11 = 456
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L12 = 406
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L13 = 407
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L14 = 408
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L15 = 481
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L16 = 482
+DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L17 = 483
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6  = 457
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7  = 458
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8  = 459
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9  = 460
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10 = 461
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11 = 462
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L12 = 416
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L13 = 417
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L14 = 418
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L15 = 484
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L16 = 485
+DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L17 = 486
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6    = 463
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7    = 464
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8    = 465
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9    = 466
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10   = 467
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11   = 468
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L12   = 426
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L13   = 427
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L14   = 428
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L15   = 487
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L16   = 488
+DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L17   = 489
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6  = 469
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7  = 470
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8  = 471
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9  = 472
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10 = 473
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11 = 474
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L12 = 436
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L13 = 437
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L14 = 438
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L15 = 491
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L16 = 492
+DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L17 = 493
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L6  = 475
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L7  = 476
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L8  = 477
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L9  = 478
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L10 = 479
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L11 = 480
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L12 = 446
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L13 = 447
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L14 = 448
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L15 = 494
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L16 = 495
+DCGM_FI_DEV_NVLINK_BANDWIDTH_L17 = 496
 
-#
-# Clocks and power
-#
-# SM clock for the device
-DCGM_FI_DEV_SM_CLOCK = 100
-# Memory clock for the device
-DCGM_FI_DEV_MEM_CLOCK = 101
-# Video encoder/decoder clock for the device
-DCGM_FI_DEV_VIDEO_CLOCK = 102
-# SM Application clocks
-DCGM_FI_DEV_APP_SM_CLOCK = 110
-# Memory Application clocks
-DCGM_FI_DEV_APP_MEM_CLOCK = 111
-# Current clock throttle reasons (bitmask of DCGM_CLOCKS_THROTTLE_REASON_*)
-DCGM_FI_DEV_CLOCK_THROTTLE_REASONS = 112
-# Maximum supported SM clock for the device
-DCGM_FI_DEV_MAX_SM_CLOCK = 113
-# Maximum supported Memory clock for the device
-DCGM_FI_DEV_MAX_MEM_CLOCK = 114
-# Maximum supported Video encoder/decoder clock for the device
-DCGM_FI_DEV_MAX_VIDEO_CLOCK = 115
-# Auto-boost for the device (1 = enabled. 0 = disabled)
-DCGM_FI_DEV_AUTOBOOST = 120
-# Supported clocks for the device
-DCGM_FI_DEV_SUPPORTED_CLOCKS = 130
-# Memory temperature for the device
-DCGM_FI_DEV_MEMORY_TEMP = 140
-# Current temperature readings for the device, in degrees C
-DCGM_FI_DEV_GPU_TEMP = 150
-# Power usage for the device in Watts
-DCGM_FI_DEV_POWER_USAGE = 155
-# Total energy consumption for the GPU in mJ since the driver was last reloaded
-DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION = 156
-# Slowdown temperature for the device
-DCGM_FI_DEV_SLOWDOWN_TEMP = 158
-# Shutdown temperature for the device
-DCGM_FI_DEV_SHUTDOWN_TEMP = 159
-# Current Power limit for the device
-DCGM_FI_DEV_POWER_MGMT_LIMIT = 160
-# Minimum power management limit for the device
-DCGM_FI_DEV_POWER_MGMT_LIMIT_MIN = 161
-# Maximum power management limit for the device
-DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX = 162
-# Default power management limit for the device
-DCGM_FI_DEV_POWER_MGMT_LIMIT_DEF = 163
-# Effective power limit that the driver enforces after taking into account all
-# limiters
-DCGM_FI_DEV_ENFORCED_POWER_LIMIT = 164
-# Performance state (P-State) 0-15. 0=highest
-DCGM_FI_DEV_PSTATE = 190
-# Fan speed for the device in percent 0-100
-DCGM_FI_DEV_FAN_SPEED = 191
+#Device Attributes associated with virtualization
+DCGM_FI_DEV_VIRTUAL_MODE                   = 500  #Operating mode of the GPU
+DCGM_FI_DEV_SUPPORTED_TYPE_INFO            = 501  #Includes Count and Supported vGPU type information
+DCGM_FI_DEV_CREATABLE_VGPU_TYPE_IDS        = 502  #Includes Count and List of Creatable vGPU type IDs
+DCGM_FI_DEV_VGPU_INSTANCE_IDS              = 503  #Includes Count and List of vGPU instance IDs
+DCGM_FI_DEV_VGPU_UTILIZATIONS              = 504  #Utilization values for vGPUs running on the device
+DCGM_FI_DEV_VGPU_PER_PROCESS_UTILIZATION   = 505  #Utilization values for processes running within vGPU VMs using the device
+DCGM_FI_DEV_ENC_STATS                      = 506  #Current encoder statistics for a given device
+DCGM_FI_DEV_FBC_STATS                      = 507  #Statistics of current active frame buffer capture sessions on a given device
+DCGM_FI_DEV_FBC_SESSIONS_INFO              = 508  #Information about active frame buffer capture sessions on a target device
+DCGM_FI_DEV_SUPPORTED_VGPU_TYPE_IDS        = 509  #Includes Count and currently Supported vGPU types on a device
+DCGM_FI_DEV_VGPU_TYPE_INFO                 = 510  #Includes Static info of vGPU types supported on a device
+DCGM_FI_DEV_VGPU_TYPE_NAME                 = 511  #Includes the name of a vGPU type supported on a device
+DCGM_FI_DEV_VGPU_TYPE_CLASS                = 512  #Includes the class of a vGPU type supported on a device
+DCGM_FI_DEV_VGPU_TYPE_LICENSE              = 513  #Includes the license info for a vGPU type supported on a device
+#Related to vGPU Instance IDs
+DCGM_FI_DEV_VGPU_VM_ID                   = 520  #vGPU VM ID
+DCGM_FI_DEV_VGPU_VM_NAME                 = 521  #vGPU VM name
+DCGM_FI_DEV_VGPU_TYPE                    = 522  #vGPU type of the vGPU instance
+DCGM_FI_DEV_VGPU_UUID                    = 523  #UUID of the vGPU instance
+DCGM_FI_DEV_VGPU_DRIVER_VERSION          = 524  #Driver version of the vGPU instance
+DCGM_FI_DEV_VGPU_MEMORY_USAGE            = 525  #Memory usage of the vGPU instance
+DCGM_FI_DEV_VGPU_LICENSE_STATUS          = 526  #License status of the vGPU
+DCGM_FI_DEV_VGPU_FRAME_RATE_LIMIT        = 527  #Frame rate limit of the vGPU instance
+DCGM_FI_DEV_VGPU_ENC_STATS               = 528  #Current encoder statistics of the vGPU instance
+DCGM_FI_DEV_VGPU_ENC_SESSIONS_INFO       = 529  #Information about all active encoder sessions on the vGPU instance
+DCGM_FI_DEV_VGPU_FBC_STATS               = 530  #Statistics of current active frame buffer capture sessions on the vGPU instance
+DCGM_FI_DEV_VGPU_FBC_SESSIONS_INFO       = 531  #Information about active frame buffer capture sessions on the vGPU instance
+DCGM_FI_DEV_VGPU_INSTANCE_LICENSE_STATE  = 532  #License state information of the vGPU instance
+DCGM_FI_DEV_VGPU_PCI_ID                  = 533  #PCI Id of the vGPU instance
+DCGM_FI_DEV_VGPU_VM_GPU_INSTANCE_ID      = 534  #GPU Instance Id of the vGPU instance
+#Internal fields reserve the range 600..699
+#below fields related to NVSwitch
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P00             = 700
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P00             = 701
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P00            = 702
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P00             = 703
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P01             = 704
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P01             = 705
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P01            = 706
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P01             = 707
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P02             = 708
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P02             = 709
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P02            = 710
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P02             = 711
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P03             = 712
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P03             = 713
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P03            = 714
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P03             = 715
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P04             = 716
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P04             = 717
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P04            = 718
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P04             = 719
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P05             = 720
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P05             = 721
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P05            = 722
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P05             = 723
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P06             = 724
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P06             = 725
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P06            = 726
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P06             = 727
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P07             = 728
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P07             = 729
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P07            = 730
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P07             = 731
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P08             = 732
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P08             = 733
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P08            = 734
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P08             = 735
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P09             = 736
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P09             = 737
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P09            = 738
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P09             = 739
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P10             = 740
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P10             = 741
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P10            = 742
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P10             = 743
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P11             = 744
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P11             = 745
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P11            = 746
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P11             = 747
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P12             = 748
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P12             = 749
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P12            = 750
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P12             = 751
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P13             = 752
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P13             = 753
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P13            = 754
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P13             = 755
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P14             = 756
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P14             = 757
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P14            = 758
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P14             = 759
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P15             = 760
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P15             = 761
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P15            = 762
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P15             = 763
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P16             = 764
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P16             = 765
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P16            = 766
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P16             = 767
+DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P17             = 768
+DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P17             = 769
+DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P17            = 770
+DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P17             = 771
+DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_TX          = 780
+DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_RX          = 781
+DCGM_FI_DEV_NVSWITCH_LINK_FATAL_ERRORS           = 782
+DCGM_FI_DEV_NVSWITCH_LINK_NON_FATAL_ERRORS       = 783
+DCGM_FI_DEV_NVSWITCH_LINK_REPLAY_ERRORS          = 784
+DCGM_FI_DEV_NVSWITCH_LINK_RECOVERY_ERRORS        = 785
+DCGM_FI_DEV_NVSWITCH_LINK_FLIT_ERRORS            = 786
+DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS             = 787
+DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS             = 788
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC0        = 789
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC1        = 790
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC2        = 791
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC3        = 792
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC0     = 793
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC1     = 794
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC2     = 795
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC3     = 796
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC0       = 797
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC1       = 798
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC2       = 799
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC3       = 800
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC0      = 801
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC1      = 802
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC2      = 803
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC3      = 804
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC0      = 805
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC1      = 806
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC2      = 807
+DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC3      = 808
+DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE0       = 809
+DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE1       = 810
+DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE2       = 811
+DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE3       = 812
+DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE0       = 813
+DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE1       = 814
+DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE2       = 815
+DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE3       = 816
+DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS                = 856
+DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS            = 857
+DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT         = 858
+DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SLOWDOWN  = 859
+DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SHUTDOWN  = 860
+DCGM_FI_DEV_NVSWITCH_THROUGHPUT_TX               = 861
+DCGM_FI_DEV_NVSWITCH_THROUGHPUT_RX               = 862
 
-#
-# Device utilization and telemetry
-#
-# Deprecated - PCIe Tx utilization information
-DCGM_FI_DEV_PCIE_TX_THROUGHPUT = 200
-# Deprecated - PCIe Rx utilization information
-DCGM_FI_DEV_PCIE_RX_THROUGHPUT = 201
-# PCIe replay counter
-DCGM_FI_DEV_PCIE_REPLAY_COUNTER = 202
-# GPU Utilization
-DCGM_FI_DEV_GPU_UTIL = 203
-# Memory Utilization
-DCGM_FI_DEV_MEM_COPY_UTIL = 204
-# Process accounting stats
-DCGM_FI_DEV_ACCOUNTING_DATA = 205
-# Encoder utilization
-DCGM_FI_DEV_ENC_UTIL = 206
-# Decoder utilization
-DCGM_FI_DEV_DEC_UTIL = 207
-# Memory utilization samples
-DCGM_FI_DEV_MEM_COPY_UTIL_SAMPLES = 210
-# SM utilization samples
-DCGM_FI_DEV_GPU_UTIL_SAMPLES = 211
-# Graphics processes running on the GPU.
-DCGM_FI_DEV_GRAPHICS_PIDS = 220
-# Compute processes running on the GPU.
-DCGM_FI_DEV_COMPUTE_PIDS = 221
-# XID errors. The value is the specific XID error
-DCGM_FI_DEV_XID_ERRORS = 230
-# PCIe Max Link Generation
-DCGM_FI_DEV_PCIE_MAX_LINK_GEN = 235
-# PCIe Max Link Width
-DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH = 236
-# PCIe Current Link Generation
-DCGM_FI_DEV_PCIE_LINK_GEN = 237
-# PCIe Current Link Width
-DCGM_FI_DEV_PCIE_LINK_WIDTH = 238
+'''
+Profiling Fields
+'''
+DCGM_FI_PROF_GR_ENGINE_ACTIVE                    = 1001 #Ratio of time the graphics engine is active. The graphics engine is 
+                                                        #active if a graphics/compute context is bound and the graphics pipe or 
+                                                        #compute pipe is busy.
 
-#
-# Violation counters
-#
-# Power Violation time in usec
-DCGM_FI_DEV_POWER_VIOLATION = 240
-# Thermal Violation time in usec
-DCGM_FI_DEV_THERMAL_VIOLATION = 241
-# Sync Boost Violation time in usec
-DCGM_FI_DEV_SYNC_BOOST_VIOLATION = 242
-# Board Limit Violation time in usec.
-DCGM_FI_DEV_BOARD_LIMIT_VIOLATION = 243
-# Low Utilization Violation time in usec.
-DCGM_FI_DEV_LOW_UTIL_VIOLATION = 244
-# Reliability Violation time in usec.
-DCGM_FI_DEV_RELIABILITY_VIOLATION = 245
-# App Clocks Violation time in usec.
-DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION = 246
-# Base Clocks Violation time in usec.
-DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION = 247
+DCGM_FI_PROF_SM_ACTIVE                           = 1002 #The ratio of cycles an SM has at least 1 warp assigned 
+                                                        #(computed from the number of cycles and elapsed cycles) 
 
-#
-# Framebuffer usage
-#
-# Total framebuffer memory in MB
-DCGM_FI_DEV_FB_TOTAL = 250
-# Total framebuffer used in MB
-DCGM_FI_DEV_FB_FREE = 251
-# Total framebuffer free in MB
-DCGM_FI_DEV_FB_USED = 252
+DCGM_FI_PROF_SM_OCCUPANCY                        = 1003 #The ratio of number of warps resident on an SM. 
+                                                        #(number of resident as a ratio of the theoretical 
+                                                        #maximum number of warps per elapsed cycle)
 
-#
-# Device ECC Counters
-#
-# Current ECC mode for the device
-DCGM_FI_DEV_ECC_CURRENT = 300
-# Pending ECC mode for the device
-DCGM_FI_DEV_ECC_PENDING = 301
-# Total single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_TOTAL = 310
-# Total double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_TOTAL = 311
-# Total single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_TOTAL = 312
-# Total double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_TOTAL = 313
-# L1 cache single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_L1 = 314
-# L1 cache double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_L1 = 315
-# L2 cache single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_L2 = 316
-# L2 cache double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_L2 = 317
-# Device memory single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_DEV = 318
-# Device memory double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_DEV = 319
-# Register file single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_REG = 320
-# Register file double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_REG = 321
-# Texture memory single bit volatile ecc errors
-DCGM_FI_DEV_ECC_SBE_VOL_TEX = 322
-# Texture memory double bit volatile ecc errors
-DCGM_FI_DEV_ECC_DBE_VOL_TEX = 323
-# L1 cache single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_L1 = 324
-# L1 cache double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_L1 = 325
-# L2 cache single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_L2 = 326
-# L2 cache double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_L2 = 327
-# Device memory single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_DEV = 328
-# Device memory double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_DEV = 329
-# Register File single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_REG = 330
-# Register File double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_REG = 331
-# Texture memory single bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_SBE_AGG_TEX = 332
-# Texture memory double bit aggregate (persistent) ecc errors
-DCGM_FI_DEV_ECC_DBE_AGG_TEX = 333
-# Number of retired pages because of single bit errors
-DCGM_FI_DEV_RETIRED_SBE = 390
-# Number of retired pages because of double bit errors
-DCGM_FI_DEV_RETIRED_DBE = 391
-# Number of pages pending retirement
-DCGM_FI_DEV_RETIRED_PENDING = 392
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE                  = 1004 #The ratio of cycles the any tensor pipe is active
+                                                        #(off the peak sustained elapsed cycles)
 
-#
-# Row remapper fields (Ampere and newer)
-#
-# Number of remapped rows for uncorrectable errors
-DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS = 393
-# Number of remapped rows for correctable errors
-DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS = 394
-# Whether remapping of rows has failed
-DCGM_FI_DEV_ROW_REMAP_FAILURE = 395
+DCGM_FI_PROF_DRAM_ACTIVE                         = 1005 #The ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PIPE_FP64_ACTIVE                    = 1006 #Ratio of cycles the fp64 pipe is active.
+DCGM_FI_PROF_PIPE_FP32_ACTIVE                    = 1007 #Ratio of cycles the fp32 pipe is active.
+DCGM_FI_PROF_PIPE_FP16_ACTIVE                    = 1008 #Ratio of cycles the fp16 pipe is active. This does not include HMMA.
+DCGM_FI_PROF_PCIE_TX_BYTES                       = 1009 #The number of bytes of active PCIe tx (transmit) data including both header and payload.
+DCGM_FI_PROF_PCIE_RX_BYTES                       = 1010 #The number of bytes of active PCIe rx (read) data including both header and payload.
+DCGM_FI_PROF_NVLINK_TX_BYTES                     = 1011 #The number of bytes of active NvLink tx (transmit) data including both header and payload.
+DCGM_FI_PROF_NVLINK_RX_BYTES                     = 1012 #The number of bytes of active NvLink rx (receive) data including both header and payload.
+DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE             = 1013 #The ratio of cycles the IMMA tensor pipe is active (off the peak sustained elapsed cycles)
+DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE             = 1014 #The ratio of cycles the HMMA tensor pipe is active (off the peak sustained elapsed cycles)
+DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE             = 1015 #The ratio of cycles the tensor (DFMA) pipe is active (off the peak sustained elapsed cycles)
+DCGM_FI_PROF_PIPE_INT_ACTIVE                     = 1016 #Ratio of cycles the integer pipe is active.
 
-#
-# Device NvLink Bandwidth and Error Counters
-#
-# NV Link flow control CRC  Error Counter for Lane 0
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 = 400
-# NV Link flow control CRC  Error Counter for Lane 1
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 = 401
-# NV Link flow control CRC  Error Counter for Lane 2
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 = 402
-# NV Link flow control CRC  Error Counter for Lane 3
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 = 403
-# NV Link flow control CRC  Error Counter for Lane 4
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 = 404
-# NV Link flow control CRC  Error Counter for Lane 5
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 = 405
-# NV Link flow control CRC  Error Counter total for all Lanes
-DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL = 409
-# NV Link data CRC Error Counter for Lane 0
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 = 410
-# NV Link data CRC Error Counter for Lane 1
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 = 411
-# NV Link data CRC Error Counter for Lane 2
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 = 412
-# NV Link data CRC Error Counter for Lane 3
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 = 413
-# NV Link data CRC Error Counter for Lane 4
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 = 414
-# NV Link data CRC Error Counter for Lane 5
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 = 415
-# NV Link data CRC Error Counter total for all Lanes
-DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL = 419
-# NV Link Replay Error Counter for Lane 0
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0 = 420
-# NV Link Replay Error Counter for Lane 1
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1 = 421
-# NV Link Replay Error Counter for Lane 2
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2 = 422
-# NV Link Replay Error Counter for Lane 3
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3 = 423
-# NV Link Replay Error Counter for Lane 4
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4 = 424
-# NV Link Replay Error Counter for Lane 3
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5 = 425
-# NV Link Replay Error Counter total for all Lanes
-DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL = 429
-# NV Link Recovery Error Counter for Lane 0
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 = 430
-# NV Link Recovery Error Counter for Lane 1
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 = 431
-# NV Link Recovery Error Counter for Lane 2
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 = 432
-# NV Link Recovery Error Counter for Lane 3
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 = 433
-# NV Link Recovery Error Counter for Lane 4
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 = 434
-# NV Link Recovery Error Counter for Lane 5
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 = 435
-# NV Link Recovery Error Counter total for all Lanes
-DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL = 439
-# NV Link Bandwidth Counter for Lane 0
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L0 = 440
-# NV Link Bandwidth Counter for Lane 1
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L1 = 441
-# NV Link Bandwidth Counter for Lane 2
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L2 = 442
-# NV Link Bandwidth Counter for Lane 3
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L3 = 443
-# NV Link Bandwidth Counter for Lane 4
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L4 = 444
-# NV Link Bandwidth Counter for Lane 5
-DCGM_FI_DEV_NVLINK_BANDWIDTH_L5 = 445
-# NV Link Bandwidth Counter total for all Lanes
-DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL = 449
-# GPU NVLink error information
-DCGM_FI_DEV_GPU_NVLINK_ERRORS = 450
+#Ratio of cycles each of the NVDEC engines are active.
+DCGM_FI_PROF_NVDEC0_ACTIVE = 1017
+DCGM_FI_PROF_NVDEC1_ACTIVE = 1018
+DCGM_FI_PROF_NVDEC2_ACTIVE = 1019
+DCGM_FI_PROF_NVDEC3_ACTIVE = 1020
+DCGM_FI_PROF_NVDEC4_ACTIVE = 1021
+DCGM_FI_PROF_NVDEC5_ACTIVE = 1022
+DCGM_FI_PROF_NVDEC6_ACTIVE = 1023
+DCGM_FI_PROF_NVDEC7_ACTIVE = 1024
 
-#
-# Device Attributes associated with virtualization
-#
-# Operating mode of the GPU
-DCGM_FI_DEV_VIRTUAL_MODE = 500
-# Includes Count and Supported vGPU type information
-DCGM_FI_DEV_SUPPORTED_TYPE_INFO = 501
-# Includes Count and List of Creatable vGPU type IDs
-DCGM_FI_DEV_CREATABLE_VGPU_TYPE_IDS = 502
-# Includes Count and List of vGPU instance IDs
-DCGM_FI_DEV_VGPU_INSTANCE_IDS = 503
-# Utilization values for vGPUs running on the device
-DCGM_FI_DEV_VGPU_UTILIZATIONS = 504
-# Utilization values for processes running within vGPU VMs using the device
-DCGM_FI_DEV_VGPU_PER_PROCESS_UTILIZATION = 505
-# Current encoder statistics for a given device
-DCGM_FI_DEV_ENC_STATS = 506
-# Statistics of current active frame buffer capture sessions on a given device
-DCGM_FI_DEV_FBC_STATS = 507
-# Information about active frame buffer capture sessions on a target device
-DCGM_FI_DEV_FBC_SESSIONS_INFO = 508
+#Ratio of cycles each of the NVJPG engines are active.
+DCGM_FI_PROF_NVJPG0_ACTIVE = 1025
+DCGM_FI_PROF_NVJPG1_ACTIVE = 1026
+DCGM_FI_PROF_NVJPG2_ACTIVE = 1027
+DCGM_FI_PROF_NVJPG3_ACTIVE = 1028
+DCGM_FI_PROF_NVJPG4_ACTIVE = 1029
+DCGM_FI_PROF_NVJPG5_ACTIVE = 1030
+DCGM_FI_PROF_NVJPG6_ACTIVE = 1031
+DCGM_FI_PROF_NVJPG7_ACTIVE = 1032
 
-#
-# Related to vGPU Instance IDs
-#
-# vGPU VM ID
-DCGM_FI_DEV_VGPU_VM_ID = 520
-# vGPU VM name
-DCGM_FI_DEV_VGPU_VM_NAME = 521
-# vGPU type of the vGPU instance
-DCGM_FI_DEV_VGPU_TYPE = 522
-# UUID of the vGPU instance
-DCGM_FI_DEV_VGPU_UUID = 523
-# Driver version of the vGPU instance
-DCGM_FI_DEV_VGPU_DRIVER_VERSION = 524
-# Memory usage of the vGPU instance
-DCGM_FI_DEV_VGPU_MEMORY_USAGE = 525
-# License status of the vGPU instance
-DCGM_FI_DEV_VGPU_LICENSE_STATUS = 526
-# Frame rate limit of the vGPU instance
-DCGM_FI_DEV_VGPU_FRAME_RATE_LIMIT = 527
-# Current encoder statistics of the vGPU instance
-DCGM_FI_DEV_VGPU_ENC_STATS = 528
-# Information about all active encoder sessions on the vGPU instance
-DCGM_FI_DEV_VGPU_ENC_SESSIONS_INFO = 529
-# Statistics of current active frame buffer capture sessions on the vGPU
-# instance
-DCGM_FI_DEV_VGPU_FBC_STATS = 530
-# Information about active frame buffer capture sessions on the vGPU instance
-DCGM_FI_DEV_VGPU_FBC_SESSIONS_INFO = 531
+#Ratio of cycles each of the NVOFA engines are active.
+DCGM_FI_PROF_NVOFA0_ACTIVE = 1033
 
-# Internal fields reserve the range 600..699
-# below fields related to NVSwitch
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P00 = 700
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P00 = 701
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P00 = 702
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P00 = 703
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P01 = 704
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P01 = 705
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P01 = 706
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P01 = 707
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P02 = 708
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P02 = 709
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P02 = 710
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P02 = 711
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P03 = 712
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P03 = 713
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P03 = 714
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P03 = 715
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P04 = 716
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P04 = 717
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P04 = 718
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P04 = 719
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P05 = 720
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P05 = 721
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P05 = 722
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P05 = 723
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P06 = 724
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P06 = 725
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P06 = 726
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P06 = 727
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P07 = 728
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P07 = 729
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P07 = 730
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P07 = 731
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P08 = 732
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P08 = 733
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P08 = 734
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P08 = 735
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P09 = 736
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P09 = 737
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P09 = 738
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P09 = 739
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P10 = 740
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P10 = 741
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P10 = 742
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P10 = 743
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P11 = 744
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P11 = 745
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P11 = 746
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P11 = 747
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P12 = 748
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P12 = 749
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P12 = 750
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P12 = 751
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P13 = 752
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P13 = 753
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P13 = 754
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P13 = 755
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P14 = 756
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P14 = 757
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P14 = 758
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P14 = 759
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P15 = 760
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P15 = 761
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P15 = 762
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P15 = 763
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P16 = 764
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P16 = 765
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P16 = 766
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P16 = 767
-DCGM_FI_DEV_NVSWITCH_LATENCY_LOW_P17 = 768
-DCGM_FI_DEV_NVSWITCH_LATENCY_MED_P17 = 769
-DCGM_FI_DEV_NVSWITCH_LATENCY_HIGH_P17 = 770
-DCGM_FI_DEV_NVSWITCH_LATENCY_MAX_P17 = 771
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P00 = 780
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P00 = 781
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P01 = 782
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P01 = 783
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P02 = 784
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P02 = 785
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P03 = 786
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P03 = 787
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P04 = 788
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P04 = 789
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P05 = 790
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P05 = 791
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P06 = 792
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P06 = 793
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P07 = 794
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P07 = 795
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P08 = 796
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P08 = 797
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P09 = 798
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P09 = 799
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P10 = 800
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P10 = 801
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P11 = 802
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P11 = 803
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P12 = 804
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P12 = 805
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P13 = 806
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P13 = 807
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P14 = 808
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P14 = 809
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P15 = 810
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P15 = 811
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P16 = 812
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P16 = 813
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_0_P17 = 814
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_0_P17 = 815
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P00 = 820
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P00 = 821
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P01 = 822
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P01 = 823
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P02 = 824
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P02 = 825
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P03 = 826
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P03 = 827
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P04 = 828
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P04 = 829
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P05 = 830
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P05 = 831
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P06 = 832
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P06 = 833
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P07 = 834
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P07 = 835
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P08 = 836
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P08 = 837
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P09 = 838
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P09 = 839
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P10 = 840
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P10 = 841
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P11 = 842
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P11 = 843
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P12 = 844
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P12 = 845
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P13 = 846
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P13 = 847
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P14 = 848
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P14 = 849
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P15 = 850
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P15 = 851
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P16 = 852
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P16 = 853
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_TX_1_P17 = 854
-DCGM_FI_DEV_NVSWITCH_BANDWIDTH_RX_1_P17 = 855
-DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS = 856
-DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS = 857
+'''
+The per-link number of bytes of active NvLink TX (transmit) or RX (transmit) data including both header and payload.
+For example: DCGM_FI_PROF_NVLINK_L0_TX_BYTES -> L0 TX
+To get the bandwidth for a link, add the RX and TX value together like 
+total = DCGM_FI_PROF_NVLINK_L0_TX_BYTES + DCGM_FI_PROF_NVLINK_L0_RX_BYTES
+'''
+DCGM_FI_PROF_NVLINK_L0_TX_BYTES  = 1040
+DCGM_FI_PROF_NVLINK_L0_RX_BYTES  = 1041
+DCGM_FI_PROF_NVLINK_L1_TX_BYTES  = 1042
+DCGM_FI_PROF_NVLINK_L1_RX_BYTES  = 1043
+DCGM_FI_PROF_NVLINK_L2_TX_BYTES  = 1044
+DCGM_FI_PROF_NVLINK_L2_RX_BYTES  = 1045
+DCGM_FI_PROF_NVLINK_L3_TX_BYTES  = 1046
+DCGM_FI_PROF_NVLINK_L3_RX_BYTES  = 1047
+DCGM_FI_PROF_NVLINK_L4_TX_BYTES  = 1048
+DCGM_FI_PROF_NVLINK_L4_RX_BYTES  = 1049
+DCGM_FI_PROF_NVLINK_L5_TX_BYTES  = 1050
+DCGM_FI_PROF_NVLINK_L5_RX_BYTES  = 1051
+DCGM_FI_PROF_NVLINK_L6_TX_BYTES  = 1052
+DCGM_FI_PROF_NVLINK_L6_RX_BYTES  = 1053
+DCGM_FI_PROF_NVLINK_L7_TX_BYTES  = 1054
+DCGM_FI_PROF_NVLINK_L7_RX_BYTES  = 1055
+DCGM_FI_PROF_NVLINK_L8_TX_BYTES  = 1056
+DCGM_FI_PROF_NVLINK_L8_RX_BYTES  = 1057
+DCGM_FI_PROF_NVLINK_L9_TX_BYTES  = 1058
+DCGM_FI_PROF_NVLINK_L9_RX_BYTES  = 1059
+DCGM_FI_PROF_NVLINK_L10_TX_BYTES = 1060
+DCGM_FI_PROF_NVLINK_L10_RX_BYTES = 1061
+DCGM_FI_PROF_NVLINK_L11_TX_BYTES = 1062
+DCGM_FI_PROF_NVLINK_L11_RX_BYTES = 1063
+DCGM_FI_PROF_NVLINK_L12_TX_BYTES = 1064
+DCGM_FI_PROF_NVLINK_L12_RX_BYTES = 1065
+DCGM_FI_PROF_NVLINK_L13_TX_BYTES = 1066
+DCGM_FI_PROF_NVLINK_L13_RX_BYTES = 1067
+DCGM_FI_PROF_NVLINK_L14_TX_BYTES = 1068
+DCGM_FI_PROF_NVLINK_L14_RX_BYTES = 1069
+DCGM_FI_PROF_NVLINK_L15_TX_BYTES = 1070
+DCGM_FI_PROF_NVLINK_L15_RX_BYTES = 1071
+DCGM_FI_PROF_NVLINK_L16_TX_BYTES = 1072
+DCGM_FI_PROF_NVLINK_L16_RX_BYTES = 1073
+DCGM_FI_PROF_NVLINK_L17_TX_BYTES = 1074
+DCGM_FI_PROF_NVLINK_L17_RX_BYTES = 1075
 
-#
-# Profiling Fields
-#
-# Ratio of time the graphics engine is active. The graphics engine is active if
-# a graphics/compute context is bound and the graphics pipe or compute pipe is
-# busy.
-DCGM_FI_PROF_GR_ENGINE_ACTIVE = 1001
+DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST = DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+DCGM_FI_PROF_NVLINK_THROUGHPUT_LAST  = DCGM_FI_PROF_NVLINK_L17_RX_BYTES
 
-# The ratio of cycles an SM has at least 1 warp assigned
-DCGM_FI_PROF_SM_ACTIVE = 1002
-# (computed from the number of cycles and elapsed cycles)
-
-# The ratio of number of warps resident on an SM.
-DCGM_FI_PROF_SM_OCCUPANCY = 1003
-# (number of resident as a ratio of the theoretical
-# maximum number of warps per elapsed cycle)
-
-# The ratio of cycles the tensor (HMMA) pipe is active
-DCGM_FI_PROF_PIPE_TENSOR_ACTIVE = 1004
-# (off the peak sustained elapsed cycles)
-
-# The ratio of cycles the device memory interface is active sending or
-# receiving data.
-DCGM_FI_PROF_DRAM_ACTIVE = 1005
-# Ratio of cycles the fp64 pipe is active.
-DCGM_FI_PROF_PIPE_FP64_ACTIVE = 1006
-# Ratio of cycles the fp32 pipe is active.
-DCGM_FI_PROF_PIPE_FP32_ACTIVE = 1007
-# Ratio of cycles the fp16 pipe is active. This does not include HMMA.
-DCGM_FI_PROF_PIPE_FP16_ACTIVE = 1008
-# The number of bytes of active PCIe tx (transmit) data including both header
-# and payload.
-DCGM_FI_PROF_PCIE_TX_BYTES = 1009
-# The number of bytes of active PCIe rx (read) data including both header and
-# payload.
-DCGM_FI_PROF_PCIE_RX_BYTES = 1010
-# The number of bytes of active NvLink tx (transmit) data including both header
-# and payload.
-DCGM_FI_PROF_NVLINK_TX_BYTES = 1011
-# The number of bytes of active NvLink rx (receive) data including both header
-# and payload.
-DCGM_FI_PROF_NVLINK_RX_BYTES = 1012
-
-# greater than maximum fields above. This value can increase in the future
-DCGM_FI_MAX_FIELDS = 1013
+#greater than maximum fields above. This value can increase in the future
+DCGM_FI_MAX_FIELDS              = 1076
 
 
-class struct_c_dcgm_field_meta_t(Structure):
+class struct_c_dcgm_field_meta_t(dcgm_structs._DcgmStructure):
     # struct_c_dcgm_field_meta_t structure
-    pass  # opaque handle
-
-
+    pass # opaque handle
 dcgm_field_meta_t = POINTER(struct_c_dcgm_field_meta_t)
 
 
-class _PrintableStructure(Structure):
+class _PrintableStructure(dcgm_structs._DcgmStructure):
     """
     Abstract class that produces nicer __str__ output than ctypes.Structure.
     e.g. instead of:
@@ -722,13 +608,11 @@ class _PrintableStructure(Structure):
     e.g. class that has _field_ 'hex_value', c_uint could be formatted with
       _fmt_ = {"hex_value" : "%08X"}
     to produce nicer output.
-    Default fomratting string for all fields can be set with key "<default>"
-    like:
+    Default fomratting string for all fields can be set with key "<default>" like:
       _fmt_ = {"<default>" : "%d MHz"} # e.g all values are numbers in MHz.
     If not set it's assumed to be just "%s"
 
-    Exact format of returned str from this class is subject to change in the
-    future.
+    Exact format of returned str from this class is subject to change in the future.
     """
     _fmt_ = {}
 
@@ -752,15 +636,15 @@ dcgmFP = dcgm_structs._dcgmGetFunctionPointer
 SHORTNAME_LENGTH = 10
 UNIT_LENGTH = 4
 
-
 # Structure to hold formatting information for values
 class c_dcgm_field_output_format_t(_PrintableStructure):
-    _fields_ = [('shortName', c_char * SHORTNAME_LENGTH),
-                ('unit', c_char * UNIT_LENGTH), ('width', c_short)]
-
+    _fields_ = [
+        ('shortName', c_char * SHORTNAME_LENGTH),
+        ('unit' , c_char * UNIT_LENGTH),
+        ('width' , c_short)
+    ]
 
 TAG_LENGTH = 48
-
 
 # Structure to represent device information
 class c_dcgm_field_meta_t(_PrintableStructure):
@@ -775,16 +659,13 @@ class c_dcgm_field_meta_t(_PrintableStructure):
     ]
 
 
-# Class for maintaining properties for each sampling type like Power,
-# Utilization and Clock.
+# Class for maintaining properties for each sampling type like Power, Utilization and Clock.
 class pySamplingProperties:
-    """
-    The instance of this class is used to hold information related to each
-    sampling event type.
-    """
+    '''
+    The instance of this class is used to hold information related to each sampling event type.
+    '''
 
-    def __init__(self, name, sampling_type, sample_val_type, timeIntervalIdle,
-                 timeIntervalBoost, min_value, max_value):
+    def __init__(self, name, sampling_type, sample_val_type, timeIntervalIdle, timeIntervalBoost, min_value, max_value):
         self.name = name
         self.sampling_type = sampling_type
         self.timeIntervalIdle = timeIntervalIdle
@@ -793,27 +674,18 @@ class pySamplingProperties:
         self.max_value = max_value
         self.sample_val_type = sample_val_type
 
-
 def DcgmFieldsInit():
     fn = dcgmFP("DcgmFieldsInit")
     ret = fn()
     assert ret == 0, "Got return %d from DcgmFieldsInit" % ret
 
-
 def DcgmFieldGetById(fieldId):
-    """
+    '''
     Get metadata for a field, given its fieldId
 
-    Parameters
-    ----------
-    fieldId :
-        Field ID to get metadata for.
-
-    Returns
-    -------
-    c_dcgm_field_meta_t or None
-        Returns c_dcgm_field_meta_t on success or None on error.
-    """
+    :param fieldId: Field ID to get metadata for
+    :return: c_dcgm_field_meta_t struct on success. None on error.
+    '''
     DcgmFieldsInit()
 
     retVal = c_dcgm_field_meta_t()
@@ -827,27 +699,19 @@ def DcgmFieldGetById(fieldId):
     memmove(addressof(retVal), c_field_meta_ptr, sizeof(retVal))
     return retVal
 
-
 def DcgmFieldGetByTag(tag):
-    """
+    '''
     Get metadata for a field, given its string tag
 
-    Parameters
-    ---------
-    tag :
-        Field tag to get metadata for. Example 'brand'.
-
-    Returns
-    -------
-    c_dcgm_field_meta_t or None
-        Returns c_dcgm_field_meta_t on success or None on error.
-    """
+    :param tag: Field tag to get metadata for. Example 'brand'
+    :return: c_dcgm_field_meta_t struct on success. None on error.
+    '''
     DcgmFieldsInit()
 
     retVal = c_dcgm_field_meta_t()
     fn = dcgmFP("DcgmFieldGetByTag")
     fn.restype = POINTER(c_dcgm_field_meta_t)
-    c_field_meta_ptr = fn(c_char_p(tag))
+    c_field_meta_ptr = fn(c_char_p(tag.encode('utf-8')))
     if not c_field_meta_ptr:
         return None
 
@@ -855,10 +719,10 @@ def DcgmFieldGetByTag(tag):
     memmove(addressof(retVal), c_field_meta_ptr, sizeof(retVal))
     return retVal
 
-
 def DcgmFieldGetTagById(fieldId):
     field = DcgmFieldGetById(fieldId)
     if field:
         return field.tag
     else:
         return None
+

--- a/components/model_analyzer/dcgm/dcgm_fields_internal.py
+++ b/components/model_analyzer/dcgm/dcgm_fields_internal.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+# Python bindings for the internal API of DCGM library (dcgm_fields_internal.hpp)
+##
+
+from ctypes import *
+from ctypes.util import find_library
+from . import dcgm_structs
+
+# Provides access to functions
+dcgmFP = dcgm_structs._dcgmGetFunctionPointer
+
+
+#internal-only fields
+DCGM_FI_DEV_MEM_COPY_UTIL_SAMPLES          = 210 #Memory utilization samples
+DCGM_FI_DEV_GPU_UTIL_SAMPLES               = 211 #SM utilization samples
+DCGM_FI_DEV_GRAPHICS_PIDS                  = 220 #Graphics processes running on the GPU.
+DCGM_FI_DEV_COMPUTE_PIDS                   = 221 #Compute processes running on the GPU.

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -73,11 +73,11 @@ class DCGMMonitor(Monitor):
         # Start DCGM in the embedded mode to use the shared library
         self.dcgm_handle = dcgm_handle = dcgm_agent.dcgmStartEmbedded(
             structs.DCGM_OPERATION_MODE_MANUAL)
-
+        group_name = "torchbench-dcgm-monitor"
         # Create DCGM monitor group
         self.group_id = dcgm_agent.dcgmGroupCreate(dcgm_handle,
                                                    structs.DCGM_GROUP_EMPTY,
-                                                   "triton-monitor")
+                                                   group_name)
         # Add the GPUs to the group
         for gpu in self._gpus:
             dcgm_agent.dcgmGroupAddDevice(dcgm_handle, self.group_id,
@@ -93,15 +93,16 @@ class DCGMMonitor(Monitor):
             raise TorchBenchAnalyzerException(
                 f'{metric} is not supported by Model Analyzer DCGM Monitor')
 
-        self.dcgm_field_group_id = dcgm_agent.dcgmFieldGroupCreate(
-            dcgm_handle, fields, 'triton-monitor')
+        dcgm_field_group_id = dcgm_agent.dcgmFieldGroupCreate(
+            dcgm_handle, fields, group_name)
+        dcgm_filed_group = dcgm_field_helpers.DcgmFieldGroup(dcgm_handle, fields, group_name,  dcgm_field_group_id)
 
         self.group_watcher = dcgm_field_helpers.DcgmFieldGroupWatcher(
-            dcgm_handle, self.group_id, self.dcgm_field_group_id.value,
+            dcgm_handle, self.group_id, dcgm_filed_group,
             structs.DCGM_OPERATION_MODE_MANUAL, frequency, 3600, 0, 0)
 
     def _monitoring_iteration(self):
-        self.group_watcher.GetMore()
+        self.group_watcher.GetAllSinceLastCall()
 
     def _collect_records(self):
         records = []

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -15,7 +15,7 @@
 from .monitor import Monitor
 from ..tb_dcgm_types.gpu_free_memory import GPUFreeMemory
 from ..tb_dcgm_types.gpu_tensoractive import GPUTensorActive
-from ..tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from ..tb_dcgm_types.gpu_peak_memory import GPUPeakMemory
 from ..tb_dcgm_types.gpu_utilization import GPUUtilization
 from ..tb_dcgm_types.gpu_power_usage import GPUPowerUsage
 from ..tb_dcgm_types.gpu_fp32active import GPUFP32Active
@@ -39,7 +39,7 @@ class DCGMMonitor(Monitor):
     # Mapping between the DCGM Fields and Model Analyzer Records
     # For more explainations, please refer to https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html
     model_analyzer_to_dcgm_field = {
-        GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
+        GPUPeakMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
         GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL,
         GPUPowerUsage: dcgm_fields.DCGM_FI_DEV_POWER_USAGE,

--- a/components/model_analyzer/dcgm/dcgm_structs.py
+++ b/components/model_analyzer/dcgm/dcgm_structs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+##
+# Python bindings for "dcgm_structs.h"
+##
 
 from ctypes import *
 from ctypes.util import find_library
@@ -21,160 +24,106 @@ import string
 import json
 from . import dcgm_value as dcgmvalue
 import platform
-import distro
+from inspect import isclass
 
-DCGM_MAX_STR_LENGTH = 256
-DCGM_MAX_NUM_DEVICES = 32  # DCGM 2.0 and newer = 32. DCGM 1.8 and older = 16
-DCGM_MAX_NUM_SWITCHES = 12
-DCGM_NVLINK_MAX_LINKS_PER_GPU = 12
-DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY1 = 6
-DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH = 36
-DCGM_MAX_CLOCKS = 256
-DCGM_MAX_NUM_GROUPS = 64
-DCGM_MAX_BLOB_LENGTH = 4096
-DCGM_MAX_VGPU_INSTANCES_PER_PGPU = 32
-DCGM_VGPU_NAME_BUFFER_SIZE = 64
-DCGM_GRID_LICENSE_BUFFER_SIZE = 128
-DCGM_MAX_VGPU_TYPES_PER_PGPU = 32
-DCGM_DEVICE_UUID_BUFFER_SIZE = 80
-DCGM_MAX_FBC_SESSIONS = 256
+DCGM_MAX_STR_LENGTH                   =   256
+DCGM_MAX_NUM_DEVICES                  =   32 # DCGM 2.0 and newer = 32. DCGM 1.8 and older = 16
+DCGM_MAX_NUM_SWITCHES                 =   12
+DCGM_NVLINK_MAX_LINKS_PER_GPU         =   18
+DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY1 =   6
+DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY2 =   12
+DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH_V1 =   36 # Max NvLinks per NvSwitch pre-Hopper
+DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH    =   64
+DCGM_LANE_MAX_LANES_PER_NVSWICH_LINK  =   4
+DCGM_MAX_CLOCKS                       =   256
+DCGM_MAX_NUM_GROUPS                   =   64
+DCGM_MAX_BLOB_LENGTH                  =   4096
+DCGM_MAX_VGPU_INSTANCES_PER_PGPU      =   32
+DCGM_VGPU_NAME_BUFFER_SIZE            =   64
+DCGM_GRID_LICENSE_BUFFER_SIZE         =   128
+DCGM_MAX_VGPU_TYPES_PER_PGPU          =   32
+DCGM_DEVICE_UUID_BUFFER_SIZE          =   80
+DCGM_MAX_FBC_SESSIONS                 =   256
 
-# When more than one value is returned from a query, which order should it be
-# returned in?
-DCGM_ORDER_ASCENDING = 1
+#When more than one value is returned from a query, which order should it be returned in?
+DCGM_ORDER_ASCENDING  = 1
 DCGM_ORDER_DESCENDING = 2
 
-DCGM_OPERATION_MODE_AUTO = 1
+DCGM_OPERATION_MODE_AUTO   = 1
 DCGM_OPERATION_MODE_MANUAL = 2
 
 DCGM_ENCODER_QUERY_H264 = 0
 DCGM_ENCODER_QUERY_HEVC = 1
 
-DCGM_FBC_SESSION_TYPE_UNKNOWN = 0  # Unknown
-DCGM_FBC_SESSION_TYPE_TOSYS = 1  # FB capture for a system buffer
-DCGM_FBC_SESSION_TYPE_CUDA = 2  # FB capture for a cuda buffer
-DCGM_FBC_SESSION_TYPE_VID = 3  # FB capture for a Vid buffer
-DCGM_FBC_SESSION_TYPE_HWENC = 4  # FB capture for a NVENC HW buffer
+DCGM_FBC_SESSION_TYPE_UNKNOWN = 0   # Unknown
+DCGM_FBC_SESSION_TYPE_TOSYS   = 1   # FB capture for a system buffer
+DCGM_FBC_SESSION_TYPE_CUDA    = 2   # FB capture for a cuda buffer
+DCGM_FBC_SESSION_TYPE_VID     = 3   # FB capture for a Vid buffer
+DCGM_FBC_SESSION_TYPE_HWENC   = 4   # FB capture for a NVENC HW buffer
 
-# C Type mappings #
-# Enums
+## C Type mappings ##
+## Enums
 
 # Return types
 _dcgmReturn_t = c_uint
-# Success
-DCGM_ST_OK = 0
-# A bad parameter was passed to a function
-DCGM_ST_BADPARAM = -1
-# A generic, unspecified error
-DCGM_ST_GENERIC_ERROR = -3
-# An out of memory error occured
-DCGM_ST_MEMORY = -4
-# Setting not configured
-DCGM_ST_NOT_CONFIGURED = -5
-# Feature not supported
-DCGM_ST_NOT_SUPPORTED = -6
-# DCGM Init error
-DCGM_ST_INIT_ERROR = -7
-# When NVML returns error.
-DCGM_ST_NVML_ERROR = -8
-# Object is in pending state of something else
-DCGM_ST_PENDING = -9
-# Object is in undefined state
-DCGM_ST_UNINITIALIZED = -10
-# Requested operation timed out
-DCGM_ST_TIMEOUT = -11
-# Version mismatch between received and understood API
-DCGM_ST_VER_MISMATCH = -12
-# Unknown field id
-DCGM_ST_UNKNOWN_FIELD = -13
-# No data is available
-DCGM_ST_NO_DATA = -14
-DCGM_ST_STALE_DATA = -15
-# The given field is not being updated by the cache manager
-DCGM_ST_NOT_WATCHED = -16
-# We are not permissioned to perform the desired action
-DCGM_ST_NO_PERMISSION = -17
-# GPU is no longer reachable
-DCGM_ST_GPU_IS_LOST = -18
-# GPU requires a reset
-DCGM_ST_RESET_REQUIRED = -19
-# Unable to find function
-DCGM_ST_FUNCTION_NOT_FOUND = -20
-# Connection to the host engine is not valid any longer
-DCGM_ST_CONNECTION_NOT_VALID = -21
-# This GPU is not supported by DCGM
-DCGM_ST_GPU_NOT_SUPPORTED = -22
-# The GPUs of the provided group are not compatible with each other for the
-# requested operation
-DCGM_ST_GROUP_INCOMPATIBLE = -23
-DCGM_ST_MAX_LIMIT = -24
-# DCGM library could not be found
-DCGM_ST_LIBRARY_NOT_FOUND = -25
-# Duplicate key passed to the function
-DCGM_ST_DUPLICATE_KEY = -26
-# GPU is already a part of a sync boost group
-DCGM_ST_GPU_IN_SYNC_BOOST_GROUP = -27
-# GPU is a not a part of sync boost group
-DCGM_ST_GPU_NOT_IN_SYNC_BOOST_GROUP = -28
-# This operation cannot be performed when the host engine is running as
-# non-root
-DCGM_ST_REQUIRES_ROOT = -29
-# DCGM GPU Diagnostic was successfully executed, but reported an error.
-DCGM_ST_NVVS_ERROR = -30
-# An input argument is not large enough
-DCGM_ST_INSUFFICIENT_SIZE = -31
-# The given field ID is not supported by the API being called
-DCGM_ST_FIELD_UNSUPPORTED_BY_API = -32
-# This request is serviced by a module of DCGM that is not currently loaded
-DCGM_ST_MODULE_NOT_LOADED = -33
-# The requested operation could not be completed because the affected resource
-# is in use
-DCGM_ST_IN_USE = -34
-# The specified group is empty and this operation is not valid with an empty
-# group
-DCGM_ST_GROUP_IS_EMPTY = -35
-# Profiling is not supported for this group of GPUs or GPU
-DCGM_ST_PROFILING_NOT_SUPPORTED = -36
-# The third-party Profiling module returned an unrecoverable error
-DCGM_ST_PROFILING_LIBRARY_ERROR = -37
-# The requested profiling metrics cannot be collected in a single pass
-DCGM_ST_PROFILING_MULTI_PASS = -38
-# A diag instance is already running, cannot run a new diag until the current
-# one finishes.
-DCGM_ST_DIAG_ALREADY_RUNNING = -39
-# The DCGM GPU Diagnostic returned JSON that cannot be parsed
-DCGM_ST_DIAG_BAD_JSON = -40
-# Error while launching the DCGM GPU Diagnostic
-DCGM_ST_DIAG_BAD_LAUNCH = -41
-# There is too much variance while training the diagnostic
-DCGM_ST_DIAG_VARIANCE = -42
-# A field value met or exceeded the error threshold.
-DCGM_ST_DIAG_THRESHOLD_EXCEEDED = -43
-# The installed driver version is insufficient for this API
-DCGM_ST_INSUFFICIENT_DRIVER_VERSION = -44
-# The specified GPU instance does not exist
-DCGM_ST_INSTANCE_NOT_FOUND = -45
-# The specified GPU compute instance does not exist
-DCGM_ST_COMPUTE_INSTANCE_NOT_FOUND = -46
-# Couldn't kill a child process within the retries
-DCGM_ST_CHILD_NOT_KILLED = -47
-# Detected an error in a 3rd-party library
-DCGM_ST_3RD_PARTY_LIBRARY_ERROR = -48
-# Not enough resources available
-DCGM_ST_INSUFFICIENT_RESOURCES = -49
+DCGM_ST_OK                          =  0   # Success
+DCGM_ST_BADPARAM                    = -1   # A bad parameter was passed to a function
+DCGM_ST_GENERIC_ERROR               = -3   # A generic, unspecified error
+DCGM_ST_MEMORY                      = -4   # An out of memory error occured
+DCGM_ST_NOT_CONFIGURED              = -5   # Setting not configured
+DCGM_ST_NOT_SUPPORTED               = -6   # Feature not supported
+DCGM_ST_INIT_ERROR                  = -7   # DCGM Init error
+DCGM_ST_NVML_ERROR                  = -8   # When NVML returns error.
+DCGM_ST_PENDING                     = -9   # Object is in pending state of something else
+DCGM_ST_UNINITIALIZED               = -10  # Object is in undefined state
+DCGM_ST_TIMEOUT                     = -11  # Requested operation timed out
+DCGM_ST_VER_MISMATCH                = -12  # Version mismatch between received and understood API
+DCGM_ST_UNKNOWN_FIELD               = -13  # Unknown field id
+DCGM_ST_NO_DATA                     = -14  # No data is available
+DCGM_ST_STALE_DATA                  = -15
+DCGM_ST_NOT_WATCHED                 = -16  # The given field is not being updated by the cache manager
+DCGM_ST_NO_PERMISSION               = -17  # We are not permissioned to perform the desired action
+DCGM_ST_GPU_IS_LOST                 = -18  # GPU is no longer reachable 
+DCGM_ST_RESET_REQUIRED              = -19  # GPU requires a reset 
+DCGM_ST_FUNCTION_NOT_FOUND          = -20  # Unable to find function
+DCGM_ST_CONNECTION_NOT_VALID        = -21  # Connection to the host engine is not valid any longer
+DCGM_ST_GPU_NOT_SUPPORTED           = -22  # This GPU is not supported by DCGM
+DCGM_ST_GROUP_INCOMPATIBLE          = -23  # The GPUs of the provided group are not compatible with each other for the requested operation
+DCGM_ST_MAX_LIMIT                   = -24
+DCGM_ST_LIBRARY_NOT_FOUND           = -25  # DCGM library could not be found
+DCGM_ST_DUPLICATE_KEY               = -26  #Duplicate key passed to the function
+DCGM_ST_GPU_IN_SYNC_BOOST_GROUP     = -27  #GPU is already a part of a sync boost group
+DCGM_ST_GPU_NOT_IN_SYNC_BOOST_GROUP = -28  #GPU is a not a part of sync boost group
+DCGM_ST_REQUIRES_ROOT               = -29  #This operation cannot be performed when the host engine is running as non-root
+DCGM_ST_NVVS_ERROR                  = -30  #DCGM GPU Diagnostic was successfully executed, but reported an error.
+DCGM_ST_INSUFFICIENT_SIZE           = -31  #An input argument is not large enough
+DCGM_ST_FIELD_UNSUPPORTED_BY_API    = -32  #The given field ID is not supported by the API being called
+DCGM_ST_MODULE_NOT_LOADED           = -33  #This request is serviced by a module of DCGM that is not currently loaded
+DCGM_ST_IN_USE                      = -34  #The requested operation could not be completed because the affected resource is in use
+DCGM_ST_GROUP_IS_EMPTY              = -35  # The specified group is empty and this operation is not valid with an empty group
+DCGM_ST_PROFILING_NOT_SUPPORTED     = -36  # Profiling is not supported for this group of GPUs or GPU
+DCGM_ST_PROFILING_LIBRARY_ERROR     = -37  # The third-party Profiling module returned an unrecoverable error
+DCGM_ST_PROFILING_MULTI_PASS        = -38  # The requested profiling metrics cannot be collected in a single pass
+DCGM_ST_DIAG_ALREADY_RUNNING        = -39  # A diag instance is already running, cannot run a new diag until the current one finishes.
+DCGM_ST_DIAG_BAD_JSON               = -40  # The DCGM GPU Diagnostic returned JSON that cannot be parsed
+DCGM_ST_DIAG_BAD_LAUNCH             = -41  # Error while launching the DCGM GPU Diagnostic
+DCGM_ST_DIAG_UNUSED                 = -42  # Unused
+DCGM_ST_DIAG_THRESHOLD_EXCEEDED     = -43  # A field value met or exceeded the error threshold.
+DCGM_ST_INSUFFICIENT_DRIVER_VERSION = -44  # The installed driver version is insufficient for this API
+DCGM_ST_INSTANCE_NOT_FOUND          = -45  # The specified GPU instance does not exist
+DCGM_ST_COMPUTE_INSTANCE_NOT_FOUND  = -46  # The specified GPU compute instance does not exist
+DCGM_ST_CHILD_NOT_KILLED            = -47  # Couldn't kill a child process within the retries
+DCGM_ST_3RD_PARTY_LIBRARY_ERROR     = -48  # Detected an error in a 3rd-party library
+DCGM_ST_INSUFFICIENT_RESOURCES      = -49  # Not enough resources available
+DCGM_ST_PLUGIN_EXCEPTION            = -50  # Exception thrown from a diagnostic plugin
+DCGM_ST_NVVS_ISOLATE_ERROR          = -51  # The diagnostic returned an error that indicates the need for isolation
 
-# All the GPUs on the node are added to the group
-DCGM_GROUP_DEFAULT = 0
-# Creates an empty group
-DCGM_GROUP_EMPTY = 1
-# All NvSwitches of the node are added to the group
-DCGM_GROUP_DEFAULT_NVSWITCHES = 2
-# All GPU instances of the node are added to the group
-DCGM_GROUP_DEFAULT_INSTANCES = 3
-# All compute instances of the node are added to the group
-DCGM_GROUP_DEFAULT_COMPUTE_INSTANCES = 4
-# All entities are added to this default group
-DCGM_GROUP_DEFAULT_ENTITIES = 5
+DCGM_GROUP_DEFAULT = 0  # All the GPUs on the node are added to the group
+DCGM_GROUP_EMPTY   = 1  # Creates an empty group
+DCGM_GROUP_DEFAULT_NVSWITCHES = 2 # All NvSwitches of the node are added to the group
+DCGM_GROUP_DEFAULT_INSTANCES = 3 # All GPU instances of the node are added to the group
+DCGM_GROUP_DEFAULT_COMPUTE_INSTANCES = 4 # All compute instances of the node are added to the group
+DCGM_GROUP_DEFAULT_ENTITIES = 5 # All entities are added to this default group
 
 DCGM_GROUP_ALL_GPUS = 0x7fffffff
 DCGM_GROUP_ALL_NVSWITCHES = 0x7ffffffe
@@ -182,26 +131,17 @@ DCGM_GROUP_ALL_INSTANCES = 0x7ffffffd
 DCGM_GROUP_ALL_COMPUTE_INSTANCES = 0x7ffffffc
 DCGM_GROUP_ALL_ENTITIES = 0x7ffffffb
 
-# Maximum number of entities per entity group
-DCGM_GROUP_MAX_ENTITIES = 64
+DCGM_GROUP_MAX_ENTITIES = 64 #Maximum number of entities per entity group
 
-# The target configuration values to be applied
-DCGM_CONFIG_TARGET_STATE = 0
-# The current configuration state
-DCGM_CONFIG_CURRENT_STATE = 1
+DCGM_CONFIG_TARGET_STATE  = 0          # The target configuration values to be applied
+DCGM_CONFIG_CURRENT_STATE = 1          # The current configuration state
 
-# Represents the power cap to be applied for each member of the group
-DCGM_CONFIG_POWER_CAP_INDIVIDUAL = 0
-# Represents the power budget for the entire group
-DCGM_CONFIG_POWER_BUDGET_GROUP = 1
+DCGM_CONFIG_POWER_CAP_INDIVIDUAL = 0 # Represents the power cap to be applied for each member of the group
+DCGM_CONFIG_POWER_BUDGET_GROUP   = 1 # Represents the power budget for the entire group
 
-# Default compute mode -- multiple contexts per device
-DCGM_CONFIG_COMPUTEMODE_DEFAULT = 0
-# Compute-prohibited mode -- no contexts per device
-DCGM_CONFIG_COMPUTEMODE_PROHIBITED = 1
-# Compute-exclusive-process mode -- only one context per device, usable from
-# multiple threads at a time
-DCGM_CONFIG_COMPUTEMODE_EXCLUSIVE_PROCESS = 2
+DCGM_CONFIG_COMPUTEMODE_DEFAULT = 0          # Default compute mode -- multiple contexts per device
+DCGM_CONFIG_COMPUTEMODE_PROHIBITED = 1       # Compute-prohibited mode -- no contexts per device
+DCGM_CONFIG_COMPUTEMODE_EXCLUSIVE_PROCESS = 2 #* Compute-exclusive-process mode -- only one context per device, usable from multiple threads at a time
 
 DCGM_TOPOLOGY_BOARD = 0x1
 DCGM_TOPOLOGY_SINGLE = 0x2
@@ -222,149 +162,105 @@ DCGM_TOPOLOGY_NVLINK10 = 0x20000
 DCGM_TOPOLOGY_NVLINK11 = 0x40000
 DCGM_TOPOLOGY_NVLINK12 = 0x80000
 
-# Diagnostic per gpu tests - fixed indices for
-# dcgmDiagResponsePerGpu_t.results[]
-DCGM_MEMORY_INDEX = 0
-DCGM_DIAGNOSTIC_INDEX = 1
-DCGM_PCI_INDEX = 2
-DCGM_SM_PERF_INDEX = 3
-DCGM_TARGETED_PERF_INDEX = 4
-DCGM_TARGETED_POWER_INDEX = 5
+# Diagnostic per gpu tests - fixed indices for dcgmDiagResponsePerGpu_t.results[]
+DCGM_MEMORY_INDEX           = 0
+DCGM_DIAGNOSTIC_INDEX       = 1
+DCGM_PCI_INDEX              = 2
+DCGM_SM_STRESS_INDEX        = 3
+DCGM_TARGETED_STRESS_INDEX  = 4
+DCGM_TARGETED_POWER_INDEX   = 5
 DCGM_MEMORY_BANDWIDTH_INDEX = 6
-DCGM_PER_GPU_TEST_COUNT = 7
+DCGM_MEMTEST_INDEX          = 7
+DCGM_PULSE_TEST_INDEX       = 8
+DCGM_UNUSED1_TEST_INDEX     = 9
+DCGM_UNUSED2_TEST_INDEX     = 10
+DCGM_UNUSED3_TEST_INDEX     = 11
+DCGM_UNUSED4_TEST_INDEX     = 12
+DCGM_UNUSED5_TEST_INDEX     = 13
+DCGM_PER_GPU_TEST_COUNT_V7  = 9
+DCGM_PER_GPU_TEST_COUNT_V8  = 13
 
 # DCGM Diag Level One test indices
-DCGM_SWTEST_BLACKLIST = 0
-DCGM_SWTEST_NVML_LIBRARY = 1
-DCGM_SWTEST_CUDA_MAIN_LIBRARY = 2
+DCGM_SWTEST_DENYLIST             = 0
+DCGM_SWTEST_NVML_LIBRARY         = 1
+DCGM_SWTEST_CUDA_MAIN_LIBRARY    = 2
 DCGM_SWTEST_CUDA_RUNTIME_LIBRARY = 3
-DCGM_SWTEST_PERMISSIONS = 4
-DCGM_SWTEST_PERSISTENCE_MODE = 5
-DCGM_SWTEST_ENVIRONMENT = 6
-DCGM_SWTEST_PAGE_RETIREMENT = 7
-DCGM_SWTEST_GRAPHICS_PROCESSES = 8
-DCGM_SWTEST_INFOROM = 9
+DCGM_SWTEST_PERMISSIONS          = 4
+DCGM_SWTEST_PERSISTENCE_MODE     = 5
+DCGM_SWTEST_ENVIRONMENT          = 6
+DCGM_SWTEST_PAGE_RETIREMENT      = 7
+DCGM_SWTEST_GRAPHICS_PROCESSES   = 8
+DCGM_SWTEST_INFOROM              = 9
 
 # This test is only run by itself, so it can use the 0 slot
 DCGM_CONTEXT_CREATE_INDEX = 0
-
 
 class DCGM_INTROSPECT_STATE(object):
     DISABLED = 0
     ENABLED = 1
 
-
 # Lib loading
 dcgmLib = None
 libLoadLock = threading.Lock()
-# Incremented on each dcgmInit and decremented on dcgmShutdown
-_dcgmLib_refcount = 0
+_dcgmLib_refcount = 0 # Incremented on each dcgmInit and decremented on dcgmShutdown
 
 
 class DCGMError(Exception):
-    """
-    Class to return error values for DCGM
-    """
-
+    """ Class to return error values for DCGM """
     _valClassMapping = dict()
     # List of currently known error codes
     _error_code_to_string = {
-        DCGM_ST_OK:
-            "Success",
-        DCGM_ST_BADPARAM:
-            "Bad parameter passed to function",
-        DCGM_ST_GENERIC_ERROR:
-            "Generic unspecified error",
-        DCGM_ST_MEMORY:
-            "Out of memory error",
-        DCGM_ST_NOT_CONFIGURED:
-            "Setting not configured",
-        DCGM_ST_NOT_SUPPORTED:
-            "Feature not supported",
-        DCGM_ST_INIT_ERROR:
-            "DCGM initialization error",
-        DCGM_ST_NVML_ERROR:
-            "NVML error",
-        DCGM_ST_PENDING:
-            "Object is in a pending state",
-        DCGM_ST_UNINITIALIZED:
-            "Object is in an undefined state",
-        DCGM_ST_TIMEOUT:
-            "Timeout",
-        DCGM_ST_VER_MISMATCH:
-            "API version mismatch",
-        DCGM_ST_UNKNOWN_FIELD:
-            "Unknown field",
-        DCGM_ST_NO_DATA:
-            "No data is available",
-        DCGM_ST_STALE_DATA:
-            "Data is considered stale",
-        DCGM_ST_NOT_WATCHED:
-            "Field is not being updated",
-        DCGM_ST_NO_PERMISSION:
-            "Not permissioned",
-        DCGM_ST_GPU_IS_LOST:
-            "GPU is unreachable",
-        DCGM_ST_RESET_REQUIRED:
-            "GPU requires a reset",
-        DCGM_ST_FUNCTION_NOT_FOUND:
-            "Unable to find function",
-        DCGM_ST_CONNECTION_NOT_VALID:
-            "The connection to the host engine is not valid any longer",
-        DCGM_ST_GPU_NOT_SUPPORTED:
-            "This GPU is not supported by DCGM",
-        DCGM_ST_GROUP_INCOMPATIBLE:
-            "GPUs are incompatible with each other for\
-                 the requested operation",
-        DCGM_ST_MAX_LIMIT:
-            "Max limit reached for the object",
-        DCGM_ST_LIBRARY_NOT_FOUND:
-            "DCGM library could not be found",
-        DCGM_ST_DUPLICATE_KEY:
-            "Duplicate key passed to function",
-        DCGM_ST_GPU_IN_SYNC_BOOST_GROUP:
-            "GPU is already a part of a sync boost group",
-        DCGM_ST_GPU_NOT_IN_SYNC_BOOST_GROUP:
-            "GPU is not a part of the sync boost group",
-        DCGM_ST_REQUIRES_ROOT:
-            "This operation is not supported when the host engine\
-                is running as non root",
-        DCGM_ST_NVVS_ERROR:
-            "DCGM GPU Diagnostic returned an error.",
-        DCGM_ST_INSUFFICIENT_SIZE:
-            "An input argument is not large enough",
-        DCGM_ST_FIELD_UNSUPPORTED_BY_API:
-            "The given field ID is not supported by the API being called",
-        DCGM_ST_MODULE_NOT_LOADED:
-            "This request is serviced by a module of DCGM that\
-                is not currently loaded",
-        DCGM_ST_IN_USE:
-            "The requested operation could not be completed because\
-                the affected resource is in use",
-        DCGM_ST_GROUP_IS_EMPTY:
-            "The specified group is empty, and this operation\
-                is incompatible with an empty group",
-        DCGM_ST_PROFILING_NOT_SUPPORTED:
-            "Profiling is not supported for this group of GPUs or GPU",
-        DCGM_ST_PROFILING_LIBRARY_ERROR:
-            "The third-party Profiling module returned an unrecoverable error",
-        DCGM_ST_PROFILING_MULTI_PASS:
-            "The requested profiling metrics\
-                cannot be collected in a single pass",
-        DCGM_ST_DIAG_ALREADY_RUNNING:
-            "A diag instance is already running, cannot\
-                run a new diag until the current one finishes",
-        DCGM_ST_DIAG_BAD_JSON:
-            "The GPU Diagnostic returned Json that cannot be parsed.",
-        DCGM_ST_DIAG_BAD_LAUNCH:
-            "Error while launching the GPU Diagnostic.",
-        DCGM_ST_DIAG_VARIANCE:
-            "The results of training DCGM GPU Diagnostic cannot\
-                be trusted because they vary too much from run to run",
-        DCGM_ST_DIAG_THRESHOLD_EXCEEDED:
-            "A field value met or exceeded the error threshold.",
-        DCGM_ST_INSUFFICIENT_DRIVER_VERSION:
-            "The installed driver version is insufficient for this API"
+        DCGM_ST_OK:                          "Success",
+        DCGM_ST_BADPARAM:                    "Bad parameter passed to function",
+        DCGM_ST_GENERIC_ERROR:               "Generic unspecified error",
+        DCGM_ST_MEMORY:                      "Out of memory error",
+        DCGM_ST_NOT_CONFIGURED:              "Setting not configured",
+        DCGM_ST_NOT_SUPPORTED:               "Feature not supported",
+        DCGM_ST_INIT_ERROR:                  "DCGM initialization error",
+        DCGM_ST_NVML_ERROR:                  "NVML error",
+        DCGM_ST_PENDING:                     "Object is in a pending state",
+        DCGM_ST_UNINITIALIZED:               "Object is in an undefined state",
+        DCGM_ST_TIMEOUT:                     "Timeout",
+        DCGM_ST_VER_MISMATCH:                "API version mismatch",
+        DCGM_ST_UNKNOWN_FIELD:               "Unknown field",
+        DCGM_ST_NO_DATA:                     "No data is available",
+        DCGM_ST_STALE_DATA:                  "Data is considered stale",
+        DCGM_ST_NOT_WATCHED:                 "Field is not being updated",
+        DCGM_ST_NO_PERMISSION:               "Not permissioned",
+        DCGM_ST_GPU_IS_LOST:                 "GPU is unreachable",
+        DCGM_ST_RESET_REQUIRED:              "GPU requires a reset",
+        DCGM_ST_FUNCTION_NOT_FOUND:          "Unable to find function",
+        DCGM_ST_CONNECTION_NOT_VALID:        "The connection to the host engine is not valid any longer",
+        DCGM_ST_GPU_NOT_SUPPORTED:           "This GPU is not supported by DCGM",
+        DCGM_ST_GROUP_INCOMPATIBLE:          "GPUs are incompatible with each other for the requested operation",
+        DCGM_ST_MAX_LIMIT:                   "Max limit reached for the object",
+        DCGM_ST_LIBRARY_NOT_FOUND:           "DCGM library could not be found",
+        DCGM_ST_DUPLICATE_KEY:               "Duplicate key passed to function",
+        DCGM_ST_GPU_IN_SYNC_BOOST_GROUP:     "GPU is already a part of a sync boost group",
+        DCGM_ST_GPU_NOT_IN_SYNC_BOOST_GROUP: "GPU is not a part of the sync boost group",
+        DCGM_ST_REQUIRES_ROOT:               "This operation is not supported when the host engine is running as non root",
+        DCGM_ST_NVVS_ERROR:                  "DCGM GPU Diagnostic returned an error.",
+        DCGM_ST_INSUFFICIENT_SIZE:           "An input argument is not large enough",
+        DCGM_ST_FIELD_UNSUPPORTED_BY_API:    "The given field ID is not supported by the API being called",
+        DCGM_ST_MODULE_NOT_LOADED:           "This request is serviced by a module of DCGM that is not currently loaded",
+        DCGM_ST_IN_USE:                      "The requested operation could not be completed because the affected resource is in use",
+        DCGM_ST_GROUP_IS_EMPTY:              "The specified group is empty, and this operation is incompatible with an empty group",
+        DCGM_ST_PROFILING_NOT_SUPPORTED:     "Profiling is not supported for this group of GPUs or GPU",
+        DCGM_ST_PROFILING_LIBRARY_ERROR:     "The third-party Profiling module returned an unrecoverable error",
+        DCGM_ST_PROFILING_MULTI_PASS:        "The requested profiling metrics cannot be collected in a single pass",
+        DCGM_ST_DIAG_ALREADY_RUNNING:        "A diag instance is already running, cannot run a new diag until the current one finishes",
+        DCGM_ST_DIAG_BAD_JSON:               "The GPU Diagnostic returned Json that cannot be parsed.",
+        DCGM_ST_DIAG_BAD_LAUNCH:             "Error while launching the GPU Diagnostic.",
+        DCGM_ST_DIAG_UNUSED:                 "Unused error code",
+        DCGM_ST_DIAG_THRESHOLD_EXCEEDED:     "A field value met or exceeded the error threshold.",
+        DCGM_ST_INSUFFICIENT_DRIVER_VERSION: "The installed driver version is insufficient for this API",
+        DCGM_ST_INSTANCE_NOT_FOUND:          "The specified GPU instance does not exist",
+        DCGM_ST_COMPUTE_INSTANCE_NOT_FOUND:  "The specified GPU compute instance does not exist",
+        DCGM_ST_CHILD_NOT_KILLED:            "Couldn't kill a child process within the retries",
+        DCGM_ST_3RD_PARTY_LIBRARY_ERROR:     "Detected an error in a 3rd-party library",
+        DCGM_ST_INSUFFICIENT_RESOURCES:      "Not enough resources available",
+        DCGM_ST_PLUGIN_EXCEPTION:            "Exception thrown from a diagnostic plugin",
+        DCGM_ST_NVVS_ISOLATE_ERROR:          "The diagnostic returned an error that indicates the need for isolation",
     }
 
     def __new__(typ, value):
@@ -382,88 +278,177 @@ class DCGMError(Exception):
         msg = None
         try:
             if self.value not in DCGMError._error_code_to_string:
-                DCGMError._error_code_to_string[self.value] = str(
-                    _dcgmErrorString(self.value))
+                DCGMError._error_code_to_string[self.value] = str(_dcgmErrorString(self.value))
             msg = DCGMError._error_code_to_string[self.value]
-        # Ensure we catch all exceptions, otherwise the error code will be
-        # hidden in a traceback
+        # Ensure we catch all exceptions, otherwise the error code will be hidden in a traceback
         except BaseException:
             msg = "DCGM Error with code %d" % self.value
-
+        
         if self.info is not None:
             if msg[-1] == ".":
                 msg = msg[:-1]
-            msg += ": '%s'" % self.info
+            msg += ": '%s'"  % self.info
         return msg
 
     def __eq__(self, other):
         return self.value == other.value
 
+    def __hash__(self):
+        return hash(self.value)
+
     def SetAdditionalInfo(self, msg):
         """
-        Sets msg as additional information returned by the string
-        representation of DCGMError and subclasses. Example output for
-        DCGMError_Uninitialized subclass, with msg set to 'more info msg
-        here' is "DCGMError_Uninitialized: Object is in an undefined state:
-        'more info msg here'".
-
-        Ensure that msg is a string or an object for which the __str__()
-        method does not throw an error
+        Sets msg as additional information returned by the string representation of DCGMError and subclasses.
+        Example output for DCGMError_Uninitialized subclass, with msg set to 'more info msg here' is 
+        "DCGMError_Uninitialized: Object is in an undefined state: 'more info msg here'".
+        
+        Ensure that msg is a string or an object for which the __str__() method does not throw an error
         """
         self.info = msg
-
 
 def dcgmExceptionClass(error_code):
     return DCGMError._valClassMapping.get(error_code)
 
-
 def _extractDCGMErrorsAsClasses():
-    """
+    '''
     Generates a hierarchy of classes on top of DCGMLError class.
 
-    Each DCGM Error gets a new DCGMError subclass. This way try,except blocks
-    can filter appropriate exceptions more easily.
+    Each DCGM Error gets a new DCGMError subclass. This way try,except blocks can filter appropriate
+    exceptions more easily.
 
     DCGMError is a parent class. Each DCGM_ST_* gets it's own subclass.
     e.g. DCGM_ST_UNINITIALIZED will be turned into DCGMError_Uninitialized
-    """
-
+    '''
     this_module = sys.modules[__name__]
-    dcgmErrorsNames = filter(lambda x: x.startswith("DCGM_ST_"),
-                             dir(this_module))
+    dcgmErrorsNames = [x for x in dir(this_module) if x.startswith("DCGM_ST_")]
     for err_name in dcgmErrorsNames:
         # e.g. Turn DCGM_ST_UNINITIALIZED into DCGMError_Uninitialized
-        class_name = "DCGMError_" + string.capwords(
-            err_name.replace("DCGM_ST_", ""), "_").replace("_", "")
+        class_name = "DCGMError_" + string.capwords(err_name.replace("DCGM_ST_", ""), "_").replace("_", "")
         err_val = getattr(this_module, err_name)
-
         def gen_new(val):
-
             def new(typ):
+                # pylint: disable=E1121
                 obj = DCGMError.__new__(typ, val)
                 return obj
-
             return new
-
-        new_error_class = type(class_name, (DCGMError,),
-                               {'__new__': gen_new(err_val)})
+        new_error_class = type(class_name, (DCGMError,), {'__new__': gen_new(err_val)})
         new_error_class.__module__ = __name__
         setattr(this_module, class_name, new_error_class)
         DCGMError._valClassMapping[err_val] = new_error_class
-
-
 _extractDCGMErrorsAsClasses()
 
 
 class struct_c_dcgmUnit_t(Structure):
     # Unit structures
-    pass  # opaque handle
-
-
+    pass # opaque handle
 _dcgmUnit_t = POINTER(struct_c_dcgmUnit_t)
 
+class _WrappedStructure():
+    def __init__(self, obj):
+        self.__dict__["_obj"] = obj
 
-class _PrintableStructure(Structure):
+    def __getattr__(self, key):
+        value = getattr(self._obj, key)
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if isclass(value):
+            return _WrappedStructure(value)
+        return value
+
+    def __getitem__(self, key):
+        value = self._obj[key]
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if isclass(value):
+            return _WrappedStructure(value)
+        return value
+
+    def __setattr__(self, key, raw_value):
+        def find_field_type(fields, key):
+            field = (f[1] for f in fields if f[0] == key)
+            try:
+                return next(field)
+            except StopIteration:
+                return None
+
+        if (key == '_obj'):
+            raise RuntimeError("Cannot set _obj")
+
+        value = raw_value
+        fieldtype = find_field_type(self._obj._fields_, key)
+
+        if fieldtype == c_uint and not isinstance(value, c_uint32):
+            value = int(value)
+        elif fieldtype == c_int and not isinstance(value, c_int32):
+            value = int(value)
+        elif isinstance(raw_value, str):
+            value = raw_value.encode('utf-8')
+
+        self._obj[key] = value
+        return value
+
+
+class _DcgmStructure(Structure):
+    def __getattribute__(self, key):
+        value = super().__getattribute__(key)
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if isclass(value):
+            return _WrappedStructure(value)
+        return value
+
+    def __setattr__(self, key, raw_value):
+        def find_field_type(fields, key):
+            field = (f[1] for f in fields if f[0] == key)
+            try:
+                return next(field)
+            except StopIteration:
+                return None
+
+        value = raw_value
+        fieldtype = find_field_type(self._fields_, key)
+
+        if fieldtype == c_uint and not isinstance(value, c_uint32):
+            value = int(value)
+        elif fieldtype == c_int and not isinstance(value, c_int32):
+            value = int(value)
+        elif isinstance(raw_value, str):
+            value = raw_value.encode('utf-8')
+
+        return super().__setattr__(key, value)
+
+
+class DcgmUnion(Union):
+    def __getattribute__(self, key):
+        value = super().__getattribute__(key)
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        if isclass(value):
+            return _WrappedStructure(value)
+        return value
+
+    def __setattr__(self, key, raw_value):
+        def find_field_type(fields, key):
+            field = (f[1] for f in fields if f[0] == key)
+            try:
+                return next(field)
+            except StopIteration:
+                return None
+
+        value = raw_value
+        fieldtype = find_field_type(self._fields_, key)
+
+        if fieldtype == c_uint and not isinstance(value, c_uint32):
+            value = int(value)
+        elif fieldtype == c_int and not isinstance(value, c_int32):
+            value = int(value)
+        elif isinstance(raw_value, str):
+            value = raw_value.encode('utf-8')
+
+        return super().__setattr__(key, value)
+
+
+class _PrintableStructure(_DcgmStructure):
     """
     Abstract class that produces nicer __str__ output than ctypes.Structure.
     e.g. instead of:
@@ -476,15 +461,12 @@ class _PrintableStructure(Structure):
     e.g. class that has _field_ 'hex_value', c_uint could be formatted with
       _fmt_ = {"hex_value" : "%08X"}
     to produce nicer output.
-    Default fomratting string for all fields can be set with key "<default>"
-    like:
+    Default fomratting string for all fields can be set with key "<default>" like:
       _fmt_ = {"<default>" : "%d MHz"} # e.g all values are numbers in MHz.
     If not set it's assumed to be just "%s"
 
-    Exact format of returned str from this class is subject to change in the
-    future.
+    Exact format of returned str from this class is subject to change in the future.
     """
-
     _fmt_ = {}
 
     def __str__(self):
@@ -498,21 +480,17 @@ class _PrintableStructure(Structure):
             elif "<default>" in self._fmt_:
                 fmt = self._fmt_["<default>"]
             result.append(("%s: " + fmt) % (key, value))
-        return self.__class__.__name__ + "(" + string.join(result, ", ") + ")"
+        return self.__class__.__name__ + "(" + ", ".join(result) + ")"
 
     def FieldsSizeof(self):
         size = 0
-        for s, t in self._fields_:
+        for s,t in self._fields_:
             size = size + sizeof(t)
         return size
 
-
+#JSON serializer for DCGM structures
 class DcgmJSONEncoder(json.JSONEncoder):
-    """
-    JSON serializer for DCGM structures
-    """
-
-    def default(self, o):  # pylint: disable=method-hidden
+    def default(self, o):   # pylint: disable=method-hidden
         if isinstance(o, _PrintableStructure):
             retVal = {}
             for fieldName, fieldType in o._fields_:
@@ -537,29 +515,21 @@ class DcgmJSONEncoder(json.JSONEncoder):
                 retVal.append(subVal)
             return retVal
 
-        # Let the parent class handle this/fail
+        #Let the parent class handle this/fail
         return json.JSONEncoder.default(self, o)
 
-
+# Creates a unique version number for each struct
 def make_dcgm_version(struct, ver):
-    """
-    Creates a unique version number for each struct
-    """
-
     return sizeof(struct) | (ver << 24)
 
-
-# Function access
-# function pointers are cached to prevent unnecessary libLoadLock locking
-_dcgmGetFunctionPointer_cache = dict()
-
-
+# Function access ##
+_dcgmGetFunctionPointer_cache = dict() # function pointers are cached to prevent unnecessary libLoadLock locking
 def _dcgmGetFunctionPointer(name):
     global dcgmLib
 
     if name in _dcgmGetFunctionPointer_cache:
         return _dcgmGetFunctionPointer_cache[name]
-
+    
     libLoadLock.acquire()
     try:
         # ensure library was loaded
@@ -575,18 +545,14 @@ def _dcgmGetFunctionPointer(name):
         libLoadLock.release()
 
 
-#
-# C function wrappers
-#
+# C function wrappers ##
 def _LoadDcgmLibrary(libDcgmPath=None):
     """
     Load the library if it isn't loaded already
-    :param libDcgmPath: Optional path to the libdcgm*.so libraries. Will use
-    system defaults if not specified.
+    :param libDcgmPath: Optional path to the libdcgm*.so libraries. Will use system defaults if not specified.
     :type libDcgmPath: str
     :return: None
     """
-
     global dcgmLib
 
     if dcgmLib is None:
@@ -598,30 +564,21 @@ def _LoadDcgmLibrary(libDcgmPath=None):
             if dcgmLib is None:
                 try:
                     if sys.platform[:3] == "win":
-                        # cdecl calling convention load nvml.dll from
-                        # %ProgramFiles%/NVIDIA Corporation/NVSMI/nvml.dll
-                        dcgmLib = CDLL(
-                            os.path.join(
-                                os.getenv("ProgramFiles", "C:/Program Files"),
-                                "NVIDIA Corporation/NVSMI/dcgm.dll"))
+                        # cdecl calling convention
+                        # load nvml.dll from %ProgramFiles%/NVIDIA Corporation/NVSMI/nvml.dll
+                        dcgmLib = CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/dcgm.dll"))
                     else:
-                        if not libDcgmPath:
-                            dist_name, dist_version, dist_id = \
-                                distro.linux_distribution(
-                                    full_distribution_name=0
-                                )
-                            dist_name = dist_name.lower()
-                            if dist_name in {'ubuntu', 'debian'}:
-                                libDcgmPath = '/usr/lib/{}-linux-gnu'.format(
-                                    platform.machine())
-                            elif dist_name in {
-                                    'fedora', 'redhat', 'centos', 'suse'
-                            }:
-                                libDcgmPath = '/usr/lib64'
+                        if libDcgmPath:
+                            lib_file = os.path.join(libDcgmPath, "libdcgm.so.3")
+                        else:
+                            # Try Debian-based distros
+                            lib_file = '/usr/lib/{}-linux-gnu/libdcgm.so.3'.format(platform.machine())
+                            if not os.path.isfile(lib_file):
+                                # Presume Redhat-based distros
+                                lib_file = '/usr/lib64/libdcgm.so.3'
 
-                        dcgmLib = CDLL(os.path.join(libDcgmPath,
-                                                    "libdcgm.so.2"))
-
+                    dcgmLib = CDLL(lib_file)
+                        
                 except OSError as ose:
                     _dcgmCheckReturn(DCGM_ST_LIBRARY_NOT_FOUND)
                 if dcgmLib is None:
@@ -629,6 +586,8 @@ def _LoadDcgmLibrary(libDcgmPath=None):
         finally:
             # lock is always freed
             libLoadLock.release()
+
+
 
 
 def _dcgmInit(libDcgmPath=None):
@@ -640,12 +599,10 @@ def _dcgmInit(libDcgmPath=None):
     libLoadLock.release()
     return None
 
-
 def _dcgmCheckReturn(ret):
     if ret != DCGM_ST_OK:
         raise DCGMError(ret)
     return ret
-
 
 def _dcgmShutdown():
     # Leave the library loaded, but shutdown the interface
@@ -661,29 +618,40 @@ def _dcgmShutdown():
     libLoadLock.release()
     return None
 
-
 def _dcgmErrorString(result):
     fn = _dcgmGetFunctionPointer("dcgmErrorString")
-    fn.restype = c_char_p  # otherwise return is an int
+    fn.restype = c_char_p # otherwise return is an int
     str = fn(result)
     return str
 
+# Represents a link object. type should be one of DCGM_FE_GPU or
+# DCGM_FE_SWITCH. gpuId or switchID the associated gpu or switch;
+#
+class c_dcgm_link_t(_PrintableStructure):
+    _fields = [
+        ('type', c_uint8),
+        ('index', c_uint8),
+        ('id', c_uint16)
+    ]
 
 class c_dcgmConnectV2Params_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint), ('persistAfterDisconnect', c_uint)]
-
+    _fields_ = [
+        ('version', c_uint),
+        ('persistAfterDisconnect', c_uint)
+    ]
 
 c_dcgmConnectV2Params_version1 = make_dcgm_version(c_dcgmConnectV2Params_v1, 1)
 
-
 class c_dcgmConnectV2Params_v2(_PrintableStructure):
-    _fields_ = [('version', c_uint), ('persistAfterDisconnect', c_uint),
-                ('timeoutMs', c_uint), ('addressIsUnixSocket', c_uint)]
-
+    _fields_ = [
+        ('version', c_uint),
+        ('persistAfterDisconnect', c_uint),
+        ('timeoutMs', c_uint),
+        ('addressIsUnixSocket', c_uint)
+    ]
 
 c_dcgmConnectV2Params_version2 = make_dcgm_version(c_dcgmConnectV2Params_v2, 2)
 c_dcgmConnectV2Params_version = c_dcgmConnectV2Params_version2
-
 
 class c_dcgmHostengineHealth_v1(_PrintableStructure):
     _fields_ = [
@@ -691,61 +659,58 @@ class c_dcgmHostengineHealth_v1(_PrintableStructure):
         ('overallHealth', c_uint),
     ]
 
-
 dcgmHostengineHealth_version1 = make_dcgm_version(c_dcgmHostengineHealth_v1, 1)
 dcgmHostengineHealth_version = dcgmHostengineHealth_version1
 
-
-# Represents memory and proc clocks for a device
+#Represents memory and proc clocks for a device
 class c_dcgmClockSet_v1(_PrintableStructure):
     _fields_ = [
         ('version', c_uint),
-        ('memClock', c_uint),  # Memory Clock
-        ('smClock', c_uint)  # SM Clock
+        ('memClock', c_uint),         #/* Memory Clock */
+        ('smClock',c_uint)          #/* SM Clock */
     ]
 
-
-# Represents a entityGroupId + entityId pair to uniquely identify a given
-# entityId inside a group of entities
+# Represents a entityGroupId + entityId pair to uniquely identify a given entityId inside
+# a group of entities
 # Added in DCGM 1.5.0
 class c_dcgmGroupEntityPair_t(_PrintableStructure):
     _fields_ = [
-        ('entityGroupId', c_uint32),  # Entity Group ID entity belongs to
-        ('entityId', c_uint32)  # Entity ID of the entity
+        ('entityGroupId', c_uint32), #Entity Group ID entity belongs to
+        ('entityId', c_uint32) #Entity ID of the entity
     ]
-
 
 # /**
 #  * Structure to store information for DCGM group (v2)
 #  * Added in DCGM 1.5.0
 #  */
 class c_dcgmGroupInfo_v2(_PrintableStructure):
-    _fields_ = [('version', c_uint), ('count', c_uint),
-                ('groupName', c_char * DCGM_MAX_STR_LENGTH),
-                ('entityList',
-                 c_dcgmGroupEntityPair_t * DCGM_GROUP_MAX_ENTITIES)]
-
-
+    _fields_ = [
+        ('version', c_uint),
+        ('count', c_uint),
+        ('groupName', c_char * DCGM_MAX_STR_LENGTH),
+        ('entityList', c_dcgmGroupEntityPair_t * DCGM_GROUP_MAX_ENTITIES)
+    ]
 c_dcgmGroupInfo_version2 = make_dcgm_version(c_dcgmGroupInfo_v2, 2)
 
-DcgmiMigProfileNone = 0  # No profile (for GPUs)
-DcgmMigProfileGpuInstanceSlice1 = 1  # GPU instance slice 1
-DcgmMigProfileGpuInstanceSlice2 = 2  # GPU instance slice 2
-DcgmMigProfileGpuInstanceSlice3 = 3  # GPU instance slice 3
-DcgmMigProfileGpuInstanceSlice4 = 4  # GPU instance slice 4
-DcgmMigProfileGpuInstanceSlice7 = 5  # GPU instance slice 7
-DcgmMigProfileComputeInstanceSlice1 = 30  # compute instance slice 1
-DcgmMigProfileComputeInstanceSlice2 = 31  # compute instance slice 2
-DcgmMigProfileComputeInstanceSlice3 = 32  # compute instance slice 3
-DcgmMigProfileComputeInstanceSlice4 = 33  # compute instance slice 4
-DcgmMigProfileComputeInstanceSlice7 = 34  # compute instance slice 7
 
+DcgmiMigProfileNone                 = 0  # No profile (for GPUs)
+DcgmMigProfileGpuInstanceSlice1     = 1  # GPU instance slice 1
+DcgmMigProfileGpuInstanceSlice2     = 2  # GPU instance slice 2
+DcgmMigProfileGpuInstanceSlice3     = 3  # GPU instance slice 3
+DcgmMigProfileGpuInstanceSlice4     = 4  # GPU instance slice 4
+DcgmMigProfileGpuInstanceSlice7     = 5  # GPU instance slice 7
+DcgmMigProfileGpuInstanceSlice8     = 6  # GPU instance slice 8
+DcgmMigProfileComputeInstanceSlice1 = 30 # compute instance slice 1
+DcgmMigProfileComputeInstanceSlice2 = 31 # compute instance slice 2
+DcgmMigProfileComputeInstanceSlice3 = 32 # compute instance slice 3
+DcgmMigProfileComputeInstanceSlice4 = 33 # compute instance slice 4
+DcgmMigProfileComputeInstanceSlice7 = 34 # compute instance slice 7 
+DcgmMigProfileComputeInstanceSlice8 = 35 # compute instance slice 8
 
+# /**
+#  * Represents a pair of entity pairings to uniquely identify an entity and its place in the hierarchy.
+#  */
 class c_dcgmMigHierarchyInfo_t(_PrintableStructure):
-    """
-    Represents a pair of entity pairings to uniquely identify an entity and
-    its place in the hierarchy.
-    """
     _fields_ = [
         ('entity', c_dcgmGroupEntityPair_t),
         ('parent', c_dcgmGroupEntityPair_t),
@@ -753,35 +718,50 @@ class c_dcgmMigHierarchyInfo_t(_PrintableStructure):
     ]
 
 
-DCGM_MAX_INSTANCES_PER_GPU = 7
-# There can never be more compute instances per GPU than instances per GPU
-# because a compute instance is part of an instance
-DCGM_MAX_COMPUTE_INSTANCES_PER_GPU = DCGM_MAX_INSTANCES_PER_GPU
-# Currently, there cannot be more than 14 instances + compute instances. There
-# are always 7 compute instances and never more than 7 instances
-DCGM_MAX_TOTAL_INSTANCES = 14
-DCGM_MAX_HIERARCHY_INFO = DCGM_MAX_NUM_DEVICES * DCGM_MAX_TOTAL_INSTANCES
-DCGM_MAX_INSTANCES = DCGM_MAX_NUM_DEVICES * DCGM_MAX_INSTANCES_PER_GPU
-# The maximum compute instances are always the same as the maximum instances
-# because each compute instances is part of an instance
-DCGM_MAX_COMPUTE_INSTANCES = DCGM_MAX_INSTANCES
-
-# Ask the hostengine to wait to process reconfiguring the GPUs
-DCGM_MIG_RECONFIG_DELAY_PROCESSING = 0x1
-
-
-class c_dcgmMigHierarchy_v1(_PrintableStructure):
-    """
-    Structure to store the GPU hierarchy for a system
-    """
+class c_dcgmMigEntityInfo_t(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),
-        ('count', c_uint),
-        ('entityList', c_dcgmMigHierarchyInfo_t * DCGM_MAX_HIERARCHY_INFO),
+        ('gpuUuid', c_char * 128),              # GPU UUID
+        ('nvmlGpuIndex', c_uint),               # GPU index from NVML
+        ('nvmlInstanceId', c_uint),             # GPU instance index within GPU
+        ('nvmlComputeInstanceId', c_uint),      # GPU Compute instance index within GPU instance
+        ('nvmlMigProfileId', c_uint),           # Unique profile ID for GPU or Compute instances
+        ('nvmlProfileSlices', c_uint),          # Number of slices in the MIG profile
     ]
 
 
-c_dcgmMigHierarchy_version1 = make_dcgm_version(c_dcgmMigHierarchy_v1, 1)
+class c_dcgmMigHierarchyInfo_v2(_PrintableStructure):
+    _fields_ = [
+        ('entity', c_dcgmGroupEntityPair_t),
+        ('parent', c_dcgmGroupEntityPair_t),
+        ('info', c_dcgmMigEntityInfo_t),
+    ]
+
+
+DCGM_MAX_INSTANCES_PER_GPU = 8
+# There can never be more compute instances per GPU than instances per GPU because a compute instance
+# is part of an instance
+DCGM_MAX_COMPUTE_INSTANCES_PER_GPU = DCGM_MAX_INSTANCES_PER_GPU
+# Currently, there cannot be more than 14 instances + compute instances. There are always 7 compute instances
+# and never more than 7 instances
+DCGM_MAX_TOTAL_INSTANCES = 14
+DCGM_MAX_HIERARCHY_INFO = DCGM_MAX_NUM_DEVICES * DCGM_MAX_TOTAL_INSTANCES
+DCGM_MAX_INSTANCES = DCGM_MAX_NUM_DEVICES * DCGM_MAX_INSTANCES_PER_GPU
+# The maximum compute instances are always the same as the maximum instances because each compute instances
+# is part of an instance
+DCGM_MAX_COMPUTE_INSTANCES = DCGM_MAX_INSTANCES
+
+DCGM_MIG_RECONFIG_DELAY_PROCESSING = 0x1 # Ask the hostengine to wait to process reconfiguring the GPUs
+
+
+class c_dcgmMigHierarchy_v2(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('count', c_uint),
+        ('entityList', c_dcgmMigHierarchyInfo_v2 * DCGM_MAX_HIERARCHY_INFO)
+    ]
+
+
+c_dcgmMigHierarchy_version2 = make_dcgm_version(c_dcgmMigHierarchy_v2, 2)
 
 
 class c_dcgmDeleteMigEntity_v1(_PrintableStructure):
@@ -792,17 +772,13 @@ class c_dcgmDeleteMigEntity_v1(_PrintableStructure):
         ('flags', c_uint),
     ]
 
-
 c_dcgmDeleteMigEntity_version1 = make_dcgm_version(c_dcgmDeleteMigEntity_v1, 1)
 
-#
-# Enum values for the kinds of MIG creations
-#
-# Create a GPU instance
-DcgmMigCreateGpuInstance = 0
-# Create a compute instance
-DcgmMigCreateComputeInstance = 1
-
+# /**
+#  * Enum values for the kinds of MIG creations
+#  */
+DcgmMigCreateGpuInstance      = 0  # Create a GPU instance 
+DcgmMigCreateComputeInstance  = 1  # Create a compute instance
 
 class c_dcgmCreateMigEntity_v1(_PrintableStructure):
     _fields_ = [
@@ -813,187 +789,244 @@ class c_dcgmCreateMigEntity_v1(_PrintableStructure):
         ('flags', c_uint),
     ]
 
-
 c_dcgmCreateMigEntity_version1 = make_dcgm_version(c_dcgmCreateMigEntity_v1, 1)
 
-
+# /**
+#  * Structure to represent error attributes
+#  */
 class c_dcgmErrorInfo_v1(_PrintableStructure):
-    """
-    Structure to represent error attributes
-    """
-    _fields_ = [('gpuId', c_uint), ('fieldId', c_ushort), ('status', c_int)]
+    _fields_ = [
+        ('gpuId', c_uint),
+        ('fieldId', c_ushort),
+        ('status', c_int)
+    ]
 
+# /**
+#  * Represents list of supported clocks for a device
+#  */
+class  c_dcgmDeviceSupportedClockSets_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('count', c_uint),
+        ('clockSet', c_dcgmClockSet_v1 * DCGM_MAX_CLOCKS)
+    ]
 
-class c_dcgmDeviceSupportedClockSets_v1(_PrintableStructure):
-    """
-    Represents list of supported clocks for a device
-    """
-    _fields_ = [('version', c_uint), ('count', c_uint),
-                ('clockSet', c_dcgmClockSet_v1 * DCGM_MAX_CLOCKS)]
-
-
+# /**
+# * Represents accounting information for a device and pid
+# */
 class c_dcgmDevicePidAccountingStats_v1(_PrintableStructure):
-    """
-    epresents accounting information for a device and pid
-    """
-    _fields_ = [('version', c_uint32), ('pid', c_uint32),
-                ('gpuUtilization', c_uint32), ('memoryUtilization', c_uint32),
-                ('maxMemoryUsage', c_uint64), ('startTimestamp', c_uint64),
-                ('activeTimeUsec', c_uint64)]
+    _fields_ = [
+        ('version', c_uint32),
+        ('pid', c_uint32),
+        ('gpuUtilization', c_uint32),
+        ('memoryUtilization', c_uint32),
+        ('maxMemoryUsage', c_uint64),
+        ('startTimestamp', c_uint64),
+        ('activeTimeUsec', c_uint64)
+    ]
 
+# /**
+#  * Represents thermal information
+#  */
+class  c_dcgmDeviceThermals_v1(_PrintableStructure): 
+    _fields_ = [
+        ('version', c_uint),
+        ('slowdownTemp', c_uint),
+        ('shutdownTemp', c_uint) 
+    ]
 
-class c_dcgmDeviceThermals_v1(_PrintableStructure):
-    """
-    Represents thermal information
-    """
-    _fields_ = [('version', c_uint), ('slowdownTemp', c_uint),
-                ('shutdownTemp', c_uint)]
+# /**
+#  * Represents various power limits
+#  */
+class  c_dcgmDevicePowerLimits_v1(_PrintableStructure): 
+    _fields_ = [
+        ('version', c_uint),
+        ('curPowerLimit', c_uint),
+        ('defaultPowerLimit', c_uint),
+        ('enforcedPowerLimit', c_uint),
+        ('minPowerLimit', c_uint),
+        ('maxPowerLimit', c_uint)
+    ]
 
-
-class c_dcgmDevicePowerLimits_v1(_PrintableStructure):
-    """
-    Represents various power limits
-    """
-    _fields_ = [('version', c_uint), ('curPowerLimit', c_uint),
-                ('defaultPowerLimit', c_uint), ('enforcedPowerLimit', c_uint),
-                ('minPowerLimit', c_uint), ('maxPowerLimit', c_uint)]
-
-
+# /**
+#  * Represents device identifiers
+#  */
 class c_dcgmDeviceIdentifiers_v1(_PrintableStructure):
-    """
-    Represents device identifiers
-    """
-    _fields_ = [('version', c_uint),
-                ('brandName', c_char * DCGM_MAX_STR_LENGTH),
-                ('deviceName', c_char * DCGM_MAX_STR_LENGTH),
-                ('pciBusId', c_char * DCGM_MAX_STR_LENGTH),
-                ('serial', c_char * DCGM_MAX_STR_LENGTH),
-                ('uuid', c_char * DCGM_MAX_STR_LENGTH),
-                ('vbios', c_char * DCGM_MAX_STR_LENGTH),
-                ('inforomImageVersion', c_char * DCGM_MAX_STR_LENGTH),
-                ('pciDeviceId', c_uint32), ('pciSubSystemId', c_uint32),
-                ('driverVersion', c_char * DCGM_MAX_STR_LENGTH),
-                ('virtualizationMode', c_uint32)]
+    _fields_ = [
+        ('version', c_uint),
+        ('brandName', c_char * DCGM_MAX_STR_LENGTH),
+        ('deviceName', c_char * DCGM_MAX_STR_LENGTH),
+        ('pciBusId', c_char * DCGM_MAX_STR_LENGTH),
+        ('serial', c_char * DCGM_MAX_STR_LENGTH),
+        ('uuid', c_char * DCGM_MAX_STR_LENGTH),
+        ('vbios', c_char * DCGM_MAX_STR_LENGTH),
+        ('inforomImageVersion', c_char * DCGM_MAX_STR_LENGTH),
+        ('pciDeviceId', c_uint32),
+        ('pciSubSystemId', c_uint32),
+        ('driverVersion', c_char * DCGM_MAX_STR_LENGTH),
+        ('virtualizationMode', c_uint32)
+    ]
 
+# /**
+#  * Represents memory utilization
+#  */
+class  c_dcgmDeviceMemoryUsage_v1(_PrintableStructure): 
+    _fields_ = [
+        ('version', c_uint),
+        ('bar1Total', c_uint),
+        ('fbTotal', c_uint),
+        ('fbUsed', c_uint),
+        ('fbFree', c_uint)
+    ]
 
-class c_dcgmDeviceMemoryUsage_v1(_PrintableStructure):
-    """
-    Represents memory utilization
-    """
-    _fields_ = [('version', c_uint), ('bar1Total', c_uint), ('fbTotal', c_uint),
-                ('fbUsed', c_uint), ('fbFree', c_uint)]
-
-
-class c_dcgmDeviceVgpuUtilInfo_v1(_PrintableStructure):
-    """
-    Represents utilization values of vGPUs running on the device
-    """
-    _fields_ = [('version', c_uint), ('vgpuId', c_uint), ('smUtil', c_uint),
-                ('memUtil', c_uint), ('encUtil', c_uint), ('decUtil', c_uint)]
-
+# /**
+#  * Represents utilization values of vGPUs running on the device
+#  */
+class  c_dcgmDeviceVgpuUtilInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('vgpuId', c_uint),
+        ('smUtil', c_uint),
+        ('memUtil', c_uint),
+        ('encUtil', c_uint),
+        ('decUtil', c_uint)
+    ]
 
 # /**
 #  * Utilization values for processes running within vGPU VMs using the device
 #  */
-class c_dcgmDeviceVgpuProcessUtilInfo_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint), ('vgpuId', c_uint), ('pid', c_uint),
-                ('processName', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
-                ('smUtil', c_uint), ('memUtil', c_uint), ('encUtil', c_uint),
-                ('decUtil', c_uint)]
-
+class  c_dcgmDeviceVgpuProcessUtilInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('vgpuId', c_uint),
+        ('pid', c_uint),
+        ('processName', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
+        ('smUtil', c_uint),
+        ('memUtil', c_uint),
+        ('encUtil', c_uint),
+        ('decUtil', c_uint)
+    ]
 
 # /**
 #  * Represents current encoder statistics for the given device/vGPU instance
 #  */
-class c_dcgmDeviceEncStats_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint), ('sessionCount', c_uint),
-                ('averageFps', c_uint), ('averageLatency', c_uint)]
+class  c_dcgmDeviceEncStats_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('sessionCount', c_uint),
+        ('averageFps', c_uint),
+        ('averageLatency', c_uint)
+    ]
 
+# /**
+#  * Represents information about active encoder sessions on the given vGPU instance
+#  */
+class  c_dcgmDeviceVgpuEncSessions_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('vgpuId', c_uint),
+        ('sessionId', c_uint),
+        ('pid', c_uint),
+        ('codecType', c_uint),
+        ('hResolution', c_uint),
+        ('vResolution', c_uint),
+        ('averageFps', c_uint),
+        ('averageLatency', c_uint)
+    ]
 
-class c_dcgmDeviceVgpuEncSessions_v1(_PrintableStructure):
-    """
-    Represents information about active encoder sessions on the given vGPU
-    instance
-    """
-    _fields_ = [('version', c_uint), ('vgpuId', c_uint), ('sessionId', c_uint),
-                ('pid', c_uint), ('codecType', c_uint), ('hResolution', c_uint),
-                ('vResolution', c_uint), ('averageFps', c_uint),
-                ('averageLatency', c_uint)]
+# /**
+#  * Represents current frame buffer capture sessions statistics for the given device/vGPU instance
+#  */
+class  c_dcgmDeviceFbcStats_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('sessionCount', c_uint),
+        ('averageFps', c_uint),
+        ('averageLatency', c_uint)
+    ]
 
+# /**
+#  * Represents information about active FBC session on the given device/vGPU instance
+#  */
+class  c_dcgmDeviceFbcSessionInfo_t(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('sessionId', c_uint),
+        ('pid', c_uint),
+        ('vgpuId', c_uint),
+        ('displayOrdinal', c_uint),
+        ('sessionType', c_uint),
+        ('sessionFlags', c_uint),
+        ('hMaxResolution', c_uint),
+        ('vMaxResolution', c_uint),
+        ('hResolution', c_uint),
+        ('vResolution', c_uint),
+        ('averageFps', c_uint),
+        ('averageLatency', c_uint)
+    ]
 
-class c_dcgmDeviceFbcStats_v1(_PrintableStructure):
-    """
-    Represents current frame buffer capture sessions statistics for the given
-    device/vGPU instance
-    """
-    _fields_ = [('version', c_uint), ('sessionCount', c_uint),
-                ('averageFps', c_uint), ('averageLatency', c_uint)]
+# /**
+#  * Represents all the active FBC sessions on the given device/vGPU instance
+#  */
+class  c_dcgmDeviceFbcSessions_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('sessionCount', c_uint),
+        ('sessionInfo', c_dcgmDeviceFbcSessionInfo_t * DCGM_MAX_FBC_SESSIONS)
+    ]
 
+# /**
+#  * Represents static info related to vGPU types supported on the device
+#  */
+class  c_dcgmDeviceVgpuTypeInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('vgpuTypeId', c_uint),
+        ('vgpuTypeName', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
+        ('vgpuTypeClass', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
+        ('vgpuTypeLicense', c_char * DCGM_GRID_LICENSE_BUFFER_SIZE),
+        ('deviceId', c_uint),
+        ('subsystemId', c_uint),
+        ('numDisplayHeads', c_uint),
+        ('maxInstances', c_uint),
+        ('frameRateLimit', c_uint),
+        ('maxResolutionX', c_uint),
+        ('maxResolutionY', c_uint),
+        ('fbTotal', c_uint)
+    ]
 
-class c_dcgmDeviceFbcSessionInfo_t(_PrintableStructure):
-    """
-    Represents information about active FBC session on the given device/vGPU
-    instance
-    """
-    _fields_ = [('version', c_uint), ('sessionId', c_uint), ('pid', c_uint),
-                ('vgpuId', c_uint), ('displayOrdinal', c_uint),
-                ('sessionType', c_uint), ('sessionFlags', c_uint),
-                ('hMaxResolution', c_uint), ('vMaxResolution', c_uint),
-                ('hResolution', c_uint), ('vResolution', c_uint),
-                ('averageFps', c_uint), ('averageLatency', c_uint)]
+class  c_dcgmDeviceVgpuTypeInfo_v2(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('vgpuTypeId', c_uint),
+        ('vgpuTypeName', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
+        ('vgpuTypeClass', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
+        ('vgpuTypeLicense', c_char * DCGM_GRID_LICENSE_BUFFER_SIZE),
+        ('deviceId', c_uint),
+        ('subsystemId', c_uint),
+        ('numDisplayHeads', c_uint),
+        ('maxInstances', c_uint),
+        ('frameRateLimit', c_uint),
+        ('maxResolutionX', c_uint),
+        ('maxResolutionY', c_uint),
+        ('fbTotal', c_uint),
+        ('gpuInstanceProfileId', c_uint)
+    ]
 
+dcgmDeviceVgpuTypeInfo_version2 = make_dcgm_version(c_dcgmDeviceVgpuTypeInfo_v2, 2)
 
-class c_dcgmDeviceFbcSessions_v1(_PrintableStructure):
-    """
-    Represents all the active FBC sessions on the given device/vGPU instance
-    """
-    _fields_ = [('version', c_uint), ('sessionCount', c_uint),
-                ('sessionInfo',
-                 c_dcgmDeviceFbcSessionInfo_t * DCGM_MAX_FBC_SESSIONS)]
-
-
-class c_dcgmDeviceVgpuTypeInfo_v1(_PrintableStructure):
-    """
-    Represents static info related to vGPU types supported on the device
-    """
-    _fields_ = [('version', c_uint), ('vgpuTypeId', c_uint),
-                ('vgpuTypeName', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
-                ('vgpuTypeClass', c_char * DCGM_VGPU_NAME_BUFFER_SIZE),
-                ('vgpuTypeLicense', c_char * DCGM_GRID_LICENSE_BUFFER_SIZE),
-                ('deviceId', c_uint), ('subsystemId', c_uint),
-                ('numDisplayHeads', c_uint), ('maxInstances', c_uint),
-                ('frameRateLimit', c_uint), ('maxResolutionX', c_uint),
-                ('maxResolutionY', c_uint), ('fbTotal', c_uint)]
-
-
-class c_dcgmDeviceSettings_v1(_PrintableStructure):
+class c_dcgmDeviceSettings_v2(_PrintableStructure):
     _fields_ = [
         ('version', c_uint),
         ('persistenceModeEnabled', c_uint),
         ('migModeEnabled', c_uint),
+        ('confidentialComputeMode', c_uint),
     ]
 
-
-class c_dcgmDeviceAttributes_v1(_PrintableStructure):
-    """
-    Represents attributes corresponding to a device
-    """
-    _fields_ = [('version', c_uint),
-                ('clockSets', c_dcgmDeviceSupportedClockSets_v1),
-                ('thermalSettings', c_dcgmDeviceThermals_v1),
-                ('powerLimits', c_dcgmDevicePowerLimits_v1),
-                ('identifiers', c_dcgmDeviceIdentifiers_v1),
-                ('memoryUsage', c_dcgmDeviceMemoryUsage_v1),
-                ('unused', c_char * 208)]
-
-
-dcgmDeviceAttributes_version1 = make_dcgm_version(c_dcgmDeviceAttributes_v1, 1)
-
-
-class c_dcgmDeviceAttributes_v2(_PrintableStructure):
-    """
-    Represents attributes corresponding to a device
-    """
+# /**
+#  * Represents attributes corresponding to a device
+#  */
+class c_dcgmDeviceAttributes_deprecated_v1(_PrintableStructure):
     _fields_ = [
         ('version', c_uint),
         ('clockSets', c_dcgmDeviceSupportedClockSets_v1),
@@ -1001,56 +1034,188 @@ class c_dcgmDeviceAttributes_v2(_PrintableStructure):
         ('powerLimits', c_dcgmDevicePowerLimits_v1),
         ('identifiers', c_dcgmDeviceIdentifiers_v1),
         ('memoryUsage', c_dcgmDeviceMemoryUsage_v1),
-        ('settings', c_dcgmDeviceSettings_v1),
+        ('unused', c_char * 208)
     ]
 
+dcgmDeviceAttributes_deprecated_version1 = make_dcgm_version(c_dcgmDeviceAttributes_deprecated_v1, 1)
 
-dcgmDeviceAttributes_version2 = make_dcgm_version(c_dcgmDeviceAttributes_v2, 2)
-
-
-class c_dcgmVgpuDeviceAttributes_v6(_PrintableStructure):
-    """
-    Represents vGPU attributes corresponding to a device
-    """
+# /**
+#  * Represents attributes corresponding to a device
+#  */
+class c_dcgmDeviceAttributes_v3(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint), ('activeVgpuInstanceCount', c_uint),
+        ('version', c_uint),
+        ('clockSets', c_dcgmDeviceSupportedClockSets_v1),
+        ('thermalSettings', c_dcgmDeviceThermals_v1),
+        ('powerLimits', c_dcgmDevicePowerLimits_v1),
+        ('identifiers', c_dcgmDeviceIdentifiers_v1),
+        ('memoryUsage', c_dcgmDeviceMemoryUsage_v1),
+        ('settings', c_dcgmDeviceSettings_v2),
+    ]
+
+dcgmDeviceAttributes_version3 = make_dcgm_version(c_dcgmDeviceAttributes_v3, 3)
+
+# /**
+#  * Represents attributes info for a MIG device
+#  */
+class c_dcgmDeviceMigAttributesInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('gpuInstanceId', c_uint),
+        ('computeInstanceId', c_uint),
+        ('multiprocessorCount', c_uint),
+        ('sharedCopyEngineCount', c_uint),
+        ('sharedDecoderCount', c_uint),
+        ('sharedEncoderCount', c_uint),
+        ('sharedJpegCount', c_uint),
+        ('sharedOfaCount', c_uint),
+        ('gpuInstanceSliceCount', c_uint),
+        ('computeInstanceSliceCount', c_uint),
+        ('memorySizeMB', c_uint64),
+    ]
+
+dcgmDeviceMigAttributesInfo_version1 = make_dcgm_version(c_dcgmDeviceMigAttributesInfo_v1, 1)
+
+# /**
+#  * Represents attributes for a MIG device
+#  */
+class c_dcgmDeviceMigAttributes_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('migDevicesCount', c_uint),
+        ('migAttributesInfo', c_dcgmDeviceMigAttributesInfo_v1),
+    ]
+
+dcgmDeviceMigAttributes_version1 = make_dcgm_version(c_dcgmDeviceMigAttributes_v1, 1)
+
+# /**
+#  * Represents GPU instance profile information
+#  */
+class c_dcgmGpuInstanceProfileInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('id', c_uint),
+        ('isP2pSupported', c_uint),
+        ('sliceCount', c_uint),
+        ('instanceCount', c_uint),
+        ('multiprocessorCount', c_uint),
+        ('copyEngineCount', c_uint),
+        ('decoderCount', c_uint),
+        ('encoderCount', c_uint),
+        ('jpegCount', c_uint),
+        ('ofaCount', c_uint),
+        ('memorySizeMB', c_uint64),
+    ]
+
+dcgmGpuInstanceProfileInfo_version1 = make_dcgm_version(c_dcgmGpuInstanceProfileInfo_v1, 1)
+
+# /**
+#  * Represents GPU instance profiles
+#  */
+class c_dcgmGpuInstanceProfiles_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('profileCount', c_uint),
+        ('profileInfo', c_dcgmGpuInstanceProfileInfo_v1),
+    ]
+
+dcgmGpuInstanceProfiles_version1 = make_dcgm_version(c_dcgmGpuInstanceProfiles_v1, 1)
+
+# /**
+#  * Represents Compute instance profile information
+#  */
+class c_dcgmComputeInstanceProfileInfo_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('gpuInstanceId', c_uint),
+        ('id', c_uint),
+        ('sliceCount', c_uint),
+        ('instanceCount', c_uint),
+        ('multiprocessorCount', c_uint),
+        ('sharedCopyEngineCount', c_uint),
+        ('sharedDecoderCount', c_uint),
+        ('sharedEncoderCount', c_uint),
+        ('sharedJpegCount', c_uint),
+        ('sharedOfaCount', c_uint),
+    ]
+
+dcgmComputeInstanceProfileInfo_version1 = make_dcgm_version(c_dcgmComputeInstanceProfileInfo_v1, 1)
+
+# /**
+#  * Represents Compute instance profiles
+#  */
+class c_dcgmComputeInstanceProfiles_v1(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('profileCount', c_uint),
+        ('profileInfo', c_dcgmComputeInstanceProfileInfo_v1),
+    ]
+
+dcgmComputeInstanceProfiles_version1 = make_dcgm_version(c_dcgmComputeInstanceProfiles_v1, 1)
+
+# /**
+#  * Represents vGPU attributes corresponding to a device
+#  */
+class c_dcgmVgpuDeviceAttributes_v6(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('activeVgpuInstanceCount', c_uint),
         ('activeVgpuInstanceIds', c_uint * DCGM_MAX_VGPU_INSTANCES_PER_PGPU),
         ('creatableVgpuTypeCount', c_uint),
         ('creatableVgpuTypeIds', c_uint * DCGM_MAX_VGPU_TYPES_PER_PGPU),
         ('supportedVgpuTypeCount', c_uint),
-        ('supportedVgpuTypeInfo',
-         c_dcgmDeviceVgpuTypeInfo_v1 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
-        ('vgpuUtilInfo',
-         c_dcgmDeviceVgpuUtilInfo_v1 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
-        ('gpuUtil', c_uint), ('memCopyUtil', c_uint), ('encUtil', c_uint),
+        ('supportedVgpuTypeInfo', c_dcgmDeviceVgpuTypeInfo_v1 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
+        ('vgpuUtilInfo', c_dcgmDeviceVgpuUtilInfo_v1 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
+        ('gpuUtil', c_uint),
+        ('memCopyUtil', c_uint),
+        ('encUtil', c_uint),
         ('decUtil', c_uint)
     ]
 
+dcgmVgpuDeviceAttributes_version6 = make_dcgm_version(c_dcgmVgpuDeviceAttributes_v6, 1)
 
-dcgmVgpuDeviceAttributes_version6 = make_dcgm_version(
-    c_dcgmVgpuDeviceAttributes_v6, 1)
+class c_dcgmVgpuDeviceAttributes_v7(_PrintableStructure):
+    _fields_ = [
+        ('version', c_uint),
+        ('activeVgpuInstanceCount', c_uint),
+        ('activeVgpuInstanceIds', c_uint * DCGM_MAX_VGPU_INSTANCES_PER_PGPU),
+        ('creatableVgpuTypeCount', c_uint),
+        ('creatableVgpuTypeIds', c_uint * DCGM_MAX_VGPU_TYPES_PER_PGPU),
+        ('supportedVgpuTypeCount', c_uint),
+        ('supportedVgpuTypeInfo', c_dcgmDeviceVgpuTypeInfo_v2 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
+        ('vgpuUtilInfo', c_dcgmDeviceVgpuUtilInfo_v1 * DCGM_MAX_VGPU_TYPES_PER_PGPU),
+        ('gpuUtil', c_uint),
+        ('memCopyUtil', c_uint),
+        ('encUtil', c_uint),
+        ('decUtil', c_uint)
+    ]
 
+dcgmVgpuDeviceAttributes_version7 = make_dcgm_version(c_dcgmVgpuDeviceAttributes_v7, 7)
 
+# /**
+#  * Represents attributes specific to vGPU instance
+#  */
 class c_dcgmVgpuInstanceAttributes_v1(_PrintableStructure):
-    """
-    Represents attributes specific to vGPU instance
-    """
-    _fields_ = [('version', c_uint),
-                ('vmId', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
-                ('vmName', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
-                ('vgpuTypeId', c_uint),
-                ('vgpuUuid', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
-                ('vgpuDriverVersion', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
-                ('fbUsage', c_uint), ('licenseStatus', c_uint),
-                ('frameRateLimit', c_uint)]
+    _fields_ = [
+        ('version', c_uint),
+        ('vmId', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
+        ('vmName', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
+        ('vgpuTypeId', c_uint),
+        ('vgpuUuid', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
+        ('vgpuDriverVersion', c_char * DCGM_DEVICE_UUID_BUFFER_SIZE),
+        ('fbUsage', c_uint),
+        ('licenseStatus', c_uint),
+        ('frameRateLimit', c_uint)
+    ]
 
-
-dcgmVgpuInstanceAttributes_version1 = make_dcgm_version(
-    c_dcgmVgpuInstanceAttributes_v1, 1)
-
+dcgmVgpuInstanceAttributes_version1 = make_dcgm_version(c_dcgmVgpuInstanceAttributes_v1, 1)
 
 class c_dcgmConfigPowerLimit(_PrintableStructure):
-    _fields_ = [('type', c_uint), ('val', c_uint)]
+    _fields_ = [
+
+        ('type', c_uint),
+        ('val', c_uint)
+    ]
 
 
 class c_dcgmConfigPerfStateSettings_t(_PrintableStructure):
@@ -1059,29 +1224,26 @@ class c_dcgmConfigPerfStateSettings_t(_PrintableStructure):
         ('targetClocks', c_dcgmClockSet_v1),
     ]
 
-
 # Structure to represent default configuration for a device
 class c_dcgmDeviceConfig_v1(_PrintableStructure):
     _fields_ = [
         # version must always be first
         ('version', c_uint),
-        ('gpuId', c_uint),
+	    ('gpuId', c_uint),
         ('mEccMode', c_uint),
         ('mComputeMode', c_uint),
         ('mPerfState', c_dcgmConfigPerfStateSettings_t),
         ('mPowerLimit', c_dcgmConfigPowerLimit)
     ]
 
-
 dcgmDeviceConfig_version1 = make_dcgm_version(c_dcgmDeviceConfig_v1, 1)
-
 
 # Structure to represent default vGPU configuration for a device
 class c_dcgmDeviceVgpuConfig_v1(_PrintableStructure):
     _fields_ = [
         # version must always be first
         ('version', c_uint),
-        ('gpuId', c_uint),
+	    ('gpuId', c_uint),
         ('mEccMode', c_uint),
         ('mComputeMode', c_uint),
         ('mPerfState', c_dcgmConfigPerfStateSettings_t),
@@ -1089,18 +1251,16 @@ class c_dcgmDeviceVgpuConfig_v1(_PrintableStructure):
     ]
 
     def SetBlank(self):
-        # Does not set version or gpuId
+        #Does not set version or gpuId
         self.mEccMode = dcgmvalue.DCGM_INT32_BLANK
         self.mPerfState.syncBoost = dcgmvalue.DCGM_INT32_BLANK
-        self.mPerfState.targetClocks.memClock = dcgmvalue.DCGM_INT32_BLANK
+        self.mPerfState.targetClocks.memClock =  dcgmvalue.DCGM_INT32_BLANK
         self.mPerfState.targetClocks.smClock = dcgmvalue.DCGM_INT32_BLANK
         self.mComputeMode = dcgmvalue.DCGM_INT32_BLANK
         self.mPowerLimit.type = DCGM_CONFIG_POWER_CAP_INDIVIDUAL
         self.mPowerLimit.val = dcgmvalue.DCGM_INT32_BLANK
 
-
 dcgmDeviceVgpuConfig_version1 = make_dcgm_version(c_dcgmDeviceVgpuConfig_v1, 1)
-
 
 # Structure to receive update on the list of metrics.
 class c_dcgmPolicyUpdate_v1(_PrintableStructure):
@@ -1110,12 +1270,10 @@ class c_dcgmPolicyUpdate_v1(_PrintableStructure):
         ('power', c_uint)
     ]
 
-
 dcgmPolicyUpdate_version1 = make_dcgm_version(c_dcgmPolicyUpdate_v1, 1)
 
 # Represents a Callback to receive power updates from the host engine
 _dcgmRecvUpdates_t = c_void_p
-
 
 # Define the structure that contains specific policy information
 class c_dcgmPolicyViolation_v1(_PrintableStructure):
@@ -1127,34 +1285,36 @@ class c_dcgmPolicyViolation_v1(_PrintableStructure):
         ('notifyOnMaxRetiredPages', c_uint)
     ]
 
-
 dcgmPolicyViolation_version1 = make_dcgm_version(c_dcgmPolicyViolation_v1, 1)
-
 
 class c_dcgmWatchFieldValue_v1(_PrintableStructure):
     _fields_ = []
 
-
 dcgmWatchFieldValue_version1 = make_dcgm_version(c_dcgmWatchFieldValue_v1, 1)
-
 
 class c_dcgmUnwatchFieldValue_v1(_PrintableStructure):
     _fields_ = []
 
-
-dcgmUnwatchFieldValue_version1 = make_dcgm_version(c_dcgmUnwatchFieldValue_v1,
-                                                   1)
-
+dcgmUnwatchFieldValue_version1 = make_dcgm_version(c_dcgmUnwatchFieldValue_v1, 1)
 
 class c_dcgmUpdateAllFields_v1(_PrintableStructure):
     _fields_ = []
 
-
 dcgmUpdateAllFields_version1 = make_dcgm_version(c_dcgmUpdateAllFields_v1, 1)
 
-dcgmGetMultipleValuesForField_version1 = 1
+dcgmGetMultipleValuesForFieldResponse_version1 = 1
 
-# policy enums
+# policy enums (and table indices)
+DCGM_POLICY_COND_IDX_DBE = 0
+DCGM_POLICY_COND_IDX_PCI = 1
+DCGM_POLICY_COND_IDX_MAX_PAGES_RETIRED = 2
+DCGM_POLICY_COND_IDX_THERMAL = 3
+DCGM_POLICY_COND_IDX_POWER = 4
+DCGM_POLICY_COND_IDX_NVLINK = 5
+DCGM_POLICY_COND_IDX_XID = 6
+DCGM_POLICY_COND_IDX_MAX = 7
+
+# policy enum bitmasks
 DCGM_POLICY_COND_DBE = 0x1
 DCGM_POLICY_COND_PCI = 0x2
 DCGM_POLICY_COND_MAX_PAGES_RETIRED = 0x4
@@ -1170,19 +1330,21 @@ DCGM_POLICY_MODE_MANUAL = 1
 DCGM_POLICY_ISOLATION_NONE = 0
 
 DCGM_POLICY_ACTION_NONE = 0
-DCGM_POLICY_ACTION_GPURESET = 1  # Deprecated
+DCGM_POLICY_ACTION_GPURESET = 1 #Deprecated
 
 DCGM_POLICY_VALID_NONE = 0
 DCGM_POLICY_VALID_SV_SHORT = 1
 DCGM_POLICY_VALID_SV_MED = 2
 DCGM_POLICY_VALID_SV_LONG = 3
+DCGM_POLICY_VALID_SV_XLONG = 4
 
 DCGM_POLICY_FAILURE_NONE = 0
 
 DCGM_DIAG_LVL_INVALID = 0
-DCGM_DIAG_LVL_SHORT = 10
-DCGM_DIAG_LVL_MED = 20
-DCGM_DIAG_LVL_LONG = 30
+DCGM_DIAG_LVL_SHORT   = 10
+DCGM_DIAG_LVL_MED     = 20
+DCGM_DIAG_LVL_LONG    = 30
+DCGM_DIAG_LVL_XLONG   = 40
 
 DCGM_DIAG_RESULT_PASS = 0
 DCGM_DIAG_RESULT_SKIP = 1
@@ -1190,17 +1352,17 @@ DCGM_DIAG_RESULT_WARN = 2
 DCGM_DIAG_RESULT_FAIL = 3
 DCGM_DIAG_RESULT_NOT_RUN = 4
 
-
-class c_dcgmPolicyConditionParmTypes_t(Union):
+class c_dcgmPolicyConditionParmTypes_t(DcgmUnion):
     _fields_ = [
         ('boolean', c_bool),
         ('llval', c_longlong),
     ]
 
-
 class c_dcgmPolicyConditionParms_t(_PrintableStructure):
-    _fields_ = [('tag', c_uint), ('val', c_dcgmPolicyConditionParmTypes_t)]
-
+    _fields_ = [
+        ('tag', c_uint),
+        ('val', c_dcgmPolicyConditionParmTypes_t)
+    ]
 
 class c_dcgmPolicy_v1(_PrintableStructure):
     _fields_ = [
@@ -1215,96 +1377,85 @@ class c_dcgmPolicy_v1(_PrintableStructure):
         ('parms', c_dcgmPolicyConditionParms_t * DCGM_POLICY_COND_MAX)
     ]
 
-
 dcgmPolicy_version1 = make_dcgm_version(c_dcgmPolicy_v1, 1)
-
 
 class c_dcgmPolicyConditionPci_t(_PrintableStructure):
     _fields_ = [
         ("timestamp", c_longlong),  # timestamp of the error
-        ("counter", c_uint)  # value of the PCIe replay counter
+        ("counter", c_uint)         # value of the PCIe replay counter
     ]
-
-
+    
 class c_dcgmPolicyConditionDbe_t(_PrintableStructure):
-    LOCATIONS = {'L1': 0, 'L2': 1, 'DEVICE': 2, 'REGISTER': 3, 'TEXTURE': 4}
-
+    LOCATIONS = {
+        'L1': 0,
+        'L2': 1,
+        'DEVICE': 2,
+        'REGISTER': 3,
+        'TEXTURE': 4
+    }
+    
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("location", c_int),  # location of the error (one of self.LOCATIONS)
-        ("numerrors", c_uint)  # number of errors
+        ("timestamp", c_longlong),  # timestamp of the error 
+        ("location", c_int),        # location of the error (one of self.LOCATIONS)
+        ("numerrors", c_uint)       # number of errors       
     ]
-
-
+    
 class c_dcgmPolicyConditionMpr_t(_PrintableStructure):
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("sbepages", c_uint),  # number of pending pages due to SBE
-        ("dbepages", c_uint)  # number of pending pages due to DBE
+        ("timestamp", c_longlong),  # timestamp of the error             
+        ("sbepages", c_uint),       # number of pending pages due to SBE 
+        ("dbepages", c_uint)        # number of pending pages due to DBE 
     ]
-
 
 class c_dcgmPolicyConditionThermal_t(_PrintableStructure):
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("thermalViolation", c_uint)  # Temperature reached that violated policy
+        ("timestamp", c_longlong),      # timestamp of the error
+        ("thermalViolation", c_uint)    # Temperature reached that violated policy
     ]
-
-
+    
 class c_dcgmPolicyConditionPower_t(_PrintableStructure):
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("powerViolation", c_uint)  # Power value reached that violated policyy
+        ("timestamp", c_longlong),      # timestamp of the error
+        ("powerViolation", c_uint)      # Power value reached that violated policyy
     ]
-
 
 class c_dcgmPolicyConditionNvlink_t(_PrintableStructure):
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("fieldId", c_ushort),  # FieldId of the nvlink error counter
-        ("counter", c_uint)  # Error value reached that violated policyy
+        ("timestamp", c_longlong),      # timestamp of the error
+        ("fieldId", c_ushort),          # FieldId of the nvlink error counter
+        ("counter", c_uint)      # Error value reached that violated policyy
     ]
-
-
 class c_dcgmPolicyConditionXID_t(_PrintableStructure):
     _fields_ = [
-        ("timestamp", c_longlong),  # timestamp of the error
-        ("errnum", c_uint)  # XID error number
+        ("timestamp", c_longlong),      # timestamp of the error
+        ("errnum", c_uint)              # XID error number
     ]
-
-
 class c_dcgmPolicyCallbackResponse_v1(_PrintableStructure):
-
-    class Value(Union):
+    class Value(DcgmUnion):
         # implement more of the fields when a test requires them
         _fields_ = [
-            ("dbe", c_dcgmPolicyConditionDbe_t),  # ECC DBE return structure
-            ("pci",
-             c_dcgmPolicyConditionPci_t),  # PCI replay error return structure
-            ("mpr", c_dcgmPolicyConditionMpr_t
-            ),  # Max retired pages limit return structure
-            ("thermal", c_dcgmPolicyConditionThermal_t
-            ),  # Thermal policy violations return structure
-            ("power", c_dcgmPolicyConditionPower_t
-            ),  # Power policy violations return structure
-            ("nvlink", c_dcgmPolicyConditionNvlink_t
-            ),  # Nvlink policy violations return structure..
-            ("xid", c_dcgmPolicyConditionXID_t
-            )  # XID policy violations return structure
+            ("dbe", c_dcgmPolicyConditionDbe_t),            #  ECC DBE return structure                   
+            ("pci", c_dcgmPolicyConditionPci_t),            #  PCI replay error return structure          
+            ("mpr", c_dcgmPolicyConditionMpr_t),            #  Max retired pages limit return structure   
+            ("thermal", c_dcgmPolicyConditionThermal_t),    #  Thermal policy violations return structure 
+            ("power", c_dcgmPolicyConditionPower_t),        #  Power policy violations return structure   
+            ("nvlink", c_dcgmPolicyConditionNvlink_t),      # Nvlink policy violations return structure..
+            ("xid", c_dcgmPolicyConditionXID_t)             # XID policy violations return structure
         ]
-
+    
     _fields_ = [
         ("version", c_uint),
-        ("condition", c_int),  # an OR'ed list of DCGM_POLICY_COND_*
+        ("condition", c_int),   # an OR'ed list of DCGM_POLICY_COND_*
         ("val", Value)
     ]
 
-
-class c_dcgmFieldValue_v1_value(Union):
-    _fields_ = [('i64', c_int64), ('dbl', c_double),
-                ('str', c_char * DCGM_MAX_STR_LENGTH),
-                ('blob', c_byte * DCGM_MAX_BLOB_LENGTH)]
-
+class c_dcgmFieldValue_v1_value(DcgmUnion):
+    _fields_ = [
+        ('i64', c_int64),
+        ('dbl', c_double),
+        ('str', c_char * DCGM_MAX_STR_LENGTH),
+        ('blob', c_byte * DCGM_MAX_BLOB_LENGTH)
+    ]
 
 # This structure is used to represent value for the field to be queried.
 class c_dcgmFieldValue_v1(_PrintableStructure):
@@ -1318,12 +1469,9 @@ class c_dcgmFieldValue_v1(_PrintableStructure):
         ('value', c_dcgmFieldValue_v1_value)
     ]
 
-
 dcgmFieldValue_version1 = make_dcgm_version(c_dcgmFieldValue_v1, 1)
 
-
-# This structure is used to represent value for the field to be queried
-# (version 2)
+# This structure is used to represent value for the field to be queried (version 2)
 class c_dcgmFieldValue_v2(_PrintableStructure):
     _fields_ = [
         # version must always be first
@@ -1338,39 +1486,39 @@ class c_dcgmFieldValue_v2(_PrintableStructure):
         ('value', c_dcgmFieldValue_v1_value)
     ]
 
-
 dcgmFieldValue_version2 = make_dcgm_version(c_dcgmFieldValue_v2, 2)
 
-# Field value flags used by dcgm_agent.dcgmEntitiesGetLatestValues()
+
+#Field value flags used by dcgm_agent.dcgmEntitiesGetLatestValues()
 DCGM_FV_FLAG_LIVE_DATA = 0x00000001
 
-DCGM_HEALTH_WATCH_PCIE = 0x1
-DCGM_HEALTH_WATCH_NVLINK = 0x2
-DCGM_HEALTH_WATCH_PMU = 0x4
-DCGM_HEALTH_WATCH_MCU = 0x8
-DCGM_HEALTH_WATCH_MEM = 0x10
-DCGM_HEALTH_WATCH_SM = 0x20
-DCGM_HEALTH_WATCH_INFOROM = 0x40
-DCGM_HEALTH_WATCH_THERMAL = 0x80
-DCGM_HEALTH_WATCH_POWER = 0x100
-DCGM_HEALTH_WATCH_DRIVER = 0x200
+DCGM_HEALTH_WATCH_PCIE      = 0x1
+DCGM_HEALTH_WATCH_NVLINK    = 0x2
+DCGM_HEALTH_WATCH_PMU       = 0x4
+DCGM_HEALTH_WATCH_MCU       = 0x8
+DCGM_HEALTH_WATCH_MEM       = 0x10
+DCGM_HEALTH_WATCH_SM        = 0x20
+DCGM_HEALTH_WATCH_INFOROM   = 0x40
+DCGM_HEALTH_WATCH_THERMAL   = 0x80
+DCGM_HEALTH_WATCH_POWER     = 0x100
+DCGM_HEALTH_WATCH_DRIVER    = 0x200
 DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL = 0x400
 DCGM_HEALTH_WATCH_NVSWITCH_FATAL = 0x800
-DCGM_HEALTH_WATCH_ALL = 0xFFFFFFFF
-DCGM_HEALTH_WATCH_COUNT_V1 = 10
-DCGM_HEALTH_WATCH_COUNT_V2 = 12
+DCGM_HEALTH_WATCH_ALL       = 0xFFFFFFFF
+DCGM_HEALTH_WATCH_COUNT_V1     = 10
+DCGM_HEALTH_WATCH_COUNT_V2     = 12
 
 DCGM_HEALTH_RESULT_PASS = 0
 DCGM_HEALTH_RESULT_WARN = 10
 DCGM_HEALTH_RESULT_FAIL = 20
 
-
 class c_dcgmDiagErrorDetail_t(_PrintableStructure):
-    _fields_ = [('msg', c_char * 1024), ('code', c_uint)]
-
+    _fields_ = [
+        ('msg', c_char * 1024),
+        ('code', c_uint)
+    ]
 
 DCGM_HEALTH_WATCH_MAX_INCIDENTS = DCGM_GROUP_MAX_ENTITIES
-
 
 class c_dcgmIncidentInfo_t(_PrintableStructure):
     _fields_ = [
@@ -1380,7 +1528,6 @@ class c_dcgmIncidentInfo_t(_PrintableStructure):
         ('entityInfo', c_dcgmGroupEntityPair_t),
     ]
 
-
 class c_dcgmHealthResponse_v4(_PrintableStructure):
     _fields_ = [
         ('version', c_uint32),
@@ -1389,46 +1536,56 @@ class c_dcgmHealthResponse_v4(_PrintableStructure):
         ('incidents', c_dcgmIncidentInfo_t * DCGM_HEALTH_WATCH_MAX_INCIDENTS),
     ]
 
-
 dcgmHealthResponse_version4 = make_dcgm_version(c_dcgmHealthResponse_v4, 4)
 
-
 class c_dcgmHealthSetParams_v2(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('groupId', c_void_p),
-                ('systems', c_uint32), ('updateInterval', c_int64),
-                ('maxKeepAge', c_double)]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('groupId', c_void_p),
+        ('systems', c_uint32),
+        ('updateInterval', c_int64),
+        ('maxKeepAge', c_double)
+    ]
 
 dcgmHealthSetParams_version2 = make_dcgm_version(c_dcgmHealthSetParams_v2, 2)
 
-
-# Pid info structs
+#Pid info structs
 class c_dcgmStatSummaryInt64_t(_PrintableStructure):
-    _fields_ = [('minValue', c_int64), ('maxValue', c_int64),
-                ('average', c_int64)]
-
+    _fields_ = [
+        ('minValue', c_int64),
+        ('maxValue', c_int64),
+        ('average', c_int64)
+    ]
 
 class c_dcgmStatSummaryInt32_t(_PrintableStructure):
-    _fields_ = [('minValue', c_int32), ('maxValue', c_int32),
-                ('average', c_int32)]
-
+    _fields_ = [
+        ('minValue', c_int32),
+        ('maxValue', c_int32),
+        ('average', c_int32)
+    ]
 
 class c_dcgmStatSummaryFp64_t(_PrintableStructure):
-    _fields_ = [('minValue', c_double), ('maxValue', c_double),
-                ('average', c_double)]
-
+    _fields_ = [
+        ('minValue', c_double),
+        ('maxValue', c_double),
+        ('average', c_double)
+    ]
 
 class c_dcgmProcessUtilInfo_t(_PrintableStructure):
-    _fields_ = [('pid', c_uint), ('smUtil', c_double), ('memUtil', c_double)]
-
+    _fields_ = [
+        ('pid', c_uint),
+        ('smUtil', c_double),
+        ('memUtil', c_double)
+    ]
 
 class c_dcgmHealthResponseInfo_t(_PrintableStructure):
-    _fields_ = [('system', c_uint), ('health', c_uint)]
+    _fields_ = [
+        ('system', c_uint),
+        ('health', c_uint)
+    ]
 
 
 DCGM_MAX_PID_INFO_NUM = 16
-
-
 class c_dcgmPidSingleInfo_t(_PrintableStructure):
     _fields_ = [
         ('gpuId', c_uint32),
@@ -1441,7 +1598,7 @@ class c_dcgmPidSingleInfo_t(_PrintableStructure):
         ('processUtilization', c_dcgmProcessUtilInfo_t),
         ('smUtilization', c_dcgmStatSummaryInt32_t),
         ('memoryUtilization', c_dcgmStatSummaryInt32_t),
-        ('eccSingleBit', c_uint32),  # Deprecated
+        ('eccSingleBit', c_uint32), #Deprecated
         ('eccDoubleBit', c_uint32),
         ('memoryClock', c_dcgmStatSummaryInt32_t),
         ('smClock', c_dcgmStatSummaryInt32_t),
@@ -1463,23 +1620,28 @@ class c_dcgmPidSingleInfo_t(_PrintableStructure):
         ('systems', c_dcgmHealthResponseInfo_t * DCGM_HEALTH_WATCH_COUNT_V1)
     ]
 
-
 class c_dcgmPidInfo_v2(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('pid', c_uint32), ('unused', c_uint32),
-                ('numGpus', c_int32), ('summary', c_dcgmPidSingleInfo_t),
-                ('gpus', c_dcgmPidSingleInfo_t * DCGM_MAX_NUM_DEVICES)]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('pid', c_uint32),
+        ('unused', c_uint32),
+        ('numGpus', c_int32),
+        ('summary', c_dcgmPidSingleInfo_t),
+        ('gpus', c_dcgmPidSingleInfo_t * DCGM_MAX_NUM_DEVICES)
+    ]
 
 dcgmPidInfo_version2 = make_dcgm_version(c_dcgmPidInfo_v2, 2)
 
-
 class c_dcgmRunningProcess_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('pid', c_uint32),
-                ('memoryUsed', c_uint64)]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('pid', c_uint32),
+        ('memoryUsed', c_uint64)
+    ]
 
 dcgmRunningProcess_version1 = make_dcgm_version(c_dcgmRunningProcess_v1, 1)
 
+c_dcgmRunningProcess_t = c_dcgmRunningProcess_v1
 
 class c_dcgmGpuUsageInfo_t(_PrintableStructure):
     _fields_ = [
@@ -1493,16 +1655,16 @@ class c_dcgmGpuUsageInfo_t(_PrintableStructure):
         ('endTime', c_int64),
         ('smUtilization', c_dcgmStatSummaryInt32_t),
         ('memoryUtilization', c_dcgmStatSummaryInt32_t),
-        ('eccSingleBit', c_uint32),  # Deprecated
+        ('eccSingleBit', c_uint32), #Deprecated
         ('eccDoubleBit', c_uint32),
         ('memoryClock', c_dcgmStatSummaryInt32_t),
         ('smClock', c_dcgmStatSummaryInt32_t),
         ('numXidCriticalErrors', c_int32),
         ('xidCriticalErrorsTs', c_int64 * 10),
         ('numComputePids', c_int32),
-        ('computePids', c_dcgmProcessUtilInfo_t * DCGM_MAX_PID_INFO_NUM),
+        ('computePids', c_dcgmProcessUtilInfo_t * DCGM_MAX_PID_INFO_NUM ),
         ('numGraphicsPids', c_int32),
-        ('graphicsPids', c_dcgmProcessUtilInfo_t * DCGM_MAX_PID_INFO_NUM),
+        ('graphicsPids', c_dcgmProcessUtilInfo_t * DCGM_MAX_PID_INFO_NUM ),
         ('maxGpuMemoryUsed', c_int64),
         ('powerViolationTime', c_int64),
         ('thermalViolationTime', c_int64),
@@ -1515,69 +1677,76 @@ class c_dcgmGpuUsageInfo_t(_PrintableStructure):
         ('systems', c_dcgmHealthResponseInfo_t * DCGM_HEALTH_WATCH_COUNT_V1)
     ]
 
-
 class c_dcgmJobInfo_v3(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('numGpus', c_int32),
-                ('summary', c_dcgmGpuUsageInfo_t),
-                ('gpus', c_dcgmGpuUsageInfo_t * DCGM_MAX_NUM_DEVICES)]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('numGpus', c_int32),
+        ('summary', c_dcgmGpuUsageInfo_t),
+        ('gpus', c_dcgmGpuUsageInfo_t * DCGM_MAX_NUM_DEVICES)
+    ]
 
 dcgmJobInfo_version3 = make_dcgm_version(c_dcgmJobInfo_v3, 3)
 
-
 class c_dcgmDiagTestResult_v2(_PrintableStructure):
-    _fields_ = [('result', c_uint), ('error', c_dcgmDiagErrorDetail_t),
-                ('info', c_char * 1024)]
+    _fields_ = [
+        ('result', c_uint),
+        ('error', c_dcgmDiagErrorDetail_t),
+        ('info', c_char * 1024)
+    ]
 
-
-class c_dcgmDiagResponsePerGpu_v2(_PrintableStructure):
-    _fields_ = [('gpuId', c_uint), ('hwDiagnosticReturn', c_uint),
-                ('results', c_dcgmDiagTestResult_v2 * DCGM_PER_GPU_TEST_COUNT)]
-
+class c_dcgmDiagResponsePerGpu_v4(_PrintableStructure):
+    _fields_ = [
+        ('gpuId', c_uint),
+        ('hwDiagnosticReturn', c_uint),
+        ('results', c_dcgmDiagTestResult_v2 * DCGM_PER_GPU_TEST_COUNT_V8)
+    ]
 
 DCGM_SWTEST_COUNT = 10
 LEVEL_ONE_MAX_RESULTS = 16
 
-
-class c_dcgmDiagResponse_v6(_PrintableStructure):
+class c_dcgmDiagResponse_v8(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint), ('gpuCount', c_uint),
+        ('version', c_uint),
+        ('gpuCount', c_uint),
         ('levelOneTestCount', c_uint),
         ('levelOneResults', c_dcgmDiagTestResult_v2 * LEVEL_ONE_MAX_RESULTS),
-        ('perGpuResponses', c_dcgmDiagResponsePerGpu_v2 * DCGM_MAX_NUM_DEVICES),
-        ('systemError', c_dcgmDiagErrorDetail_t), ('trainingMsg', c_char * 1024)
+        ('perGpuResponses', c_dcgmDiagResponsePerGpu_v4 * DCGM_MAX_NUM_DEVICES),
+        ('systemError',     c_dcgmDiagErrorDetail_t),
+        ('_unused',     c_char * 1024)
     ]
 
-
-dcgmDiagResponse_version6 = make_dcgm_version(c_dcgmDiagResponse_v6, 6)
+dcgmDiagResponse_version8 = make_dcgm_version(c_dcgmDiagResponse_v8, 8)
 
 DCGM_AFFINITY_BITMASK_ARRAY_SIZE = 8
 
-
 class c_dcgmDeviceTopologyPath_t(_PrintableStructure):
-    _fields_ = [('gpuId', c_uint32), ('path', c_uint32),
-                ('localNvLinkIds', c_uint32)]
-
+    _fields_ = [
+        ('gpuId', c_uint32),
+        ('path', c_uint32),
+        ('localNvLinkIds', c_uint32)
+    ]
 
 class c_dcgmDeviceTopology_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint32),
-                ('cpuAffinityMask', c_ulong * DCGM_AFFINITY_BITMASK_ARRAY_SIZE),
-                ('numGpus', c_uint32),
-                ('gpuPaths',
-                 c_dcgmDeviceTopologyPath_t * (DCGM_MAX_NUM_DEVICES - 1))]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('cpuAffinityMask', c_ulong * DCGM_AFFINITY_BITMASK_ARRAY_SIZE),
+        ('numGpus', c_uint32),
+        ('gpuPaths', c_dcgmDeviceTopologyPath_t * (DCGM_MAX_NUM_DEVICES - 1))
+    ]
 
 dcgmDeviceTopology_version1 = make_dcgm_version(c_dcgmDeviceTopology_v1, 1)
 
-
 class c_dcgmGroupTopology_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint32),
-                ('groupCpuAffinityMask',
-                 c_ulong * DCGM_AFFINITY_BITMASK_ARRAY_SIZE),
-                ('numaOptimalFlag', c_uint32), ('slowestPath', c_uint32)]
+    _fields_ = [ 
+        ('version', c_uint32),
+        ('groupCpuAffinityMask', c_ulong * DCGM_AFFINITY_BITMASK_ARRAY_SIZE),
+        ('numaOptimalFlag', c_uint32),
+        ('slowestPath', c_uint32)
+    ]   
+
+dcgmGroupTopology_version1 = make_dcgm_version(c_dcgmGroupTopology_v1, 1) 
 
 
-dcgmGroupTopology_version1 = make_dcgm_version(c_dcgmGroupTopology_v1, 1)
 
 # Maximum number of field groups that can exist
 DCGM_MAX_NUM_FIELD_GROUPS = 64
@@ -1585,164 +1754,44 @@ DCGM_MAX_NUM_FIELD_GROUPS = 64
 # Maximum number of field IDs that can be in a single field group
 DCGM_MAX_FIELD_IDS_PER_FIELD_GROUP = 128
 
-
 class c_dcgmFieldGroupInfo_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('numFieldIds', c_uint32),
-                ('fieldGroupId', c_void_p),
-                ('fieldGroupName', c_char * DCGM_MAX_STR_LENGTH),
-                ('fieldIds', c_uint16 * DCGM_MAX_FIELD_IDS_PER_FIELD_GROUP)]
-
+    _fields_ = [
+        ('version', c_uint32),
+        ('numFieldIds', c_uint32),
+        ('fieldGroupId', c_void_p),
+        ('fieldGroupName', c_char * DCGM_MAX_STR_LENGTH),
+        ('fieldIds', c_uint16 * DCGM_MAX_FIELD_IDS_PER_FIELD_GROUP)
+    ]
 
 dcgmFieldGroupInfo_version1 = make_dcgm_version(c_dcgmFieldGroupInfo_v1, 1)
 
 
 class c_dcgmAllFieldGroup_v1(_PrintableStructure):
-    _fields_ = [('version', c_uint32), ('numFieldGroups', c_uint32),
-                ('fieldGroups',
-                 c_dcgmFieldGroupInfo_v1 * DCGM_MAX_NUM_FIELD_GROUPS)]
-
-
-dcgmAllFieldGroup_version1 = make_dcgm_version(c_dcgmAllFieldGroup_v1, 1)
-
-
-class DCGM_INTROSPECT_LVL(object):
-    """
-    Identifies a level to retrieve field introspection info for
-    """
-    INVALID = 0
-    FIELD = 1
-    FIELD_GROUP = 2
-    ALL_FIELDS = 3
-
-
-class c_dcgmIntrospectContext_v1(_PrintableStructure):
-    """
-    Identifies the retrieval context for introspection API calls.
-    """
     _fields_ = [
         ('version', c_uint32),
-        # one of DCGM_INTROSPECT_LVL_?
-        ('introspectLvl', c_int),
-        # Only needed if \ref introspectLvl is FIELD_GROUP
-        ('fieldGroupId', c_void_p)
+        ('numFieldGroups', c_uint32),
+        ('fieldGroups', c_dcgmFieldGroupInfo_v1 * DCGM_MAX_NUM_FIELD_GROUPS)
     ]
 
-
-dcgmIntrospectContext_version1 = make_dcgm_version(c_dcgmIntrospectContext_v1,
-                                                   1)
-
+dcgmAllFieldGroup_version1 = make_dcgm_version(c_dcgmAllFieldGroup_v1, 1)
 
 class c_dcgmIntrospectMemory_v1(_PrintableStructure):
     _fields_ = [
         ('version', c_uint32),
-        (
-            # The total number of bytes being used to store all of the fields
-            # being watched
-            'bytesUsed',
-            c_longlong)
+        ('bytesUsed', c_longlong)  # The total number of bytes being used to store all of the fields being watched
     ]
-
 
 dcgmIntrospectMemory_version1 = make_dcgm_version(c_dcgmIntrospectMemory_v1, 1)
 
-
-class c_dcgmIntrospectFieldsExecTime_v1(_PrintableStructure):
-    _fields_ = [
-        (
-            # version number (dcgmIntrospectFieldsExecTime_version)
-            'version',
-            c_uint32),
-        (
-            # the mean update frequency of all fields
-            'meanUpdateFreqUsec',
-            c_longlong),
-        (
-            # the sum of every field's most recent execution time after they
-            # have been normalized to \ref meanUpdateFreqUsec.
-            # This is roughly how long it takes to update fields every \ref
-            # meanUpdateFreqUsec
-            'recentUpdateUsec',
-            c_double),
-        (
-            # The total amount of time, ever, that has been spent updating all
-            # the fields
-            'totalEverUpdateUsec',
-            c_longlong),
-    ]
-
-
-dcgmIntrospectFieldsExecTime_version1 = make_dcgm_version(
-    c_dcgmIntrospectFieldsExecTime_v1, 1)
-
-
-class c_dcgmIntrospectFullFieldsExecTime_v2(_PrintableStructure):
-    '''
-    Full introspection info for field execution time
-    '''
-    _fields_ = [
-        ('version', c_uint32),
-        ('aggregateInfo', c_dcgmIntrospectFieldsExecTime_v1
-        ),  # info that includes global and device scope
-        ('hasGlobalInfo',
-         c_int),  # 0 means \ref globalInfo is populated, !0 means it's not
-        ('globalInfo', c_dcgmIntrospectFieldsExecTime_v1
-        ),  # info that only includes global field scope
-        ('gpuInfoCount',
-         c_uint),  # count of how many entries in \ref gpuInfo are populated
-        ('gpuIdsForGpuInfo', c_uint * DCGM_MAX_NUM_DEVICES
-        ),  # the GPU ID at a given index identifies which gpu
-        # the corresponding entry in \ref gpuInfo is from
-        ('gpuInfo', c_dcgmIntrospectFieldsExecTime_v1 * DCGM_MAX_NUM_DEVICES
-        ),  # info that is separated by the
-        # GPU ID that the watches were for
-    ]
-
-
-dcgmIntrospectFullFieldsExecTime_version2 = make_dcgm_version(
-    c_dcgmIntrospectFullFieldsExecTime_v2, 2)
-
-
-class c_dcgmIntrospectFullMemory_v1(_PrintableStructure):
-    '''
-    Full introspection info for field memory
-    '''
-    _fields_ = [
-        ('version', c_uint32),
-        ('aggregateInfo', c_dcgmIntrospectMemory_v1
-        ),  # info that includes global and device scope
-        ('hasGlobalInfo',
-         c_int),  # 0 means \ref globalInfo is populated, !0 means it's not
-        ('globalInfo', c_dcgmIntrospectMemory_v1
-        ),  # info that only includes global field scope
-        ('gpuInfoCount',
-         c_uint),  # count of how many entries in \ref gpuInfo are populated
-        ('gpuIdsForGpuInfo', c_uint * DCGM_MAX_NUM_DEVICES
-        ),  # the GPU ID at a given index identifies which gpu
-        # the corresponding entry in \ref gpuInfo is from
-        ('gpuInfo', c_dcgmIntrospectMemory_v1 * DCGM_MAX_NUM_DEVICES
-        ),  # info that is separated by the
-        # GPU ID that the watches were for
-    ]
-
-
-dcgmIntrospectFullMemory_version1 = make_dcgm_version(
-    c_dcgmIntrospectFullMemory_v1, 1)
-
-
 class c_dcgmIntrospectCpuUtil_v1(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint32),  # version number (dcgmIntrospectCpuUtil_version)
-        ('total',
-         c_double),  # fraction of device's CPU resources that were used
-        ('kernel', c_double
-        ),  # fraction of device's CPU resources that were used in kernel mode
-        ('user', c_double
-        ),  # fraction of device's CPU resources that were used in user mode
+        ('version', c_uint32),  #!< version number (dcgmIntrospectCpuUtil_version)                     
+        ('total', c_double),    #!< fraction of device's CPU resources that were used                
+        ('kernel', c_double),   #!< fraction of device's CPU resources that were used in kernel mode 
+        ('user', c_double),     #!< fraction of device's CPU resources that were used in user mode   
     ]
 
-
-dcgmIntrospectCpuUtil_version1 = make_dcgm_version(c_dcgmIntrospectCpuUtil_v1,
-                                                   1)
+dcgmIntrospectCpuUtil_version1 = make_dcgm_version(c_dcgmIntrospectCpuUtil_v1, 1)
 
 DCGM_MAX_CONFIG_FILE_LEN = 10000
 DCGM_MAX_TEST_NAMES = 20
@@ -1755,207 +1804,150 @@ DCGM_PATH_LEN = 128
 DCGM_THROTTLE_MASK_LEN = 50
 
 # Flags options for running the GPU diagnostic
-DCGM_RUN_FLAGS_VERBOSE = 0x0001
+DCGM_RUN_FLAGS_VERBOSE     = 0x0001
 DCGM_RUN_FLAGS_STATSONFAIL = 0x0002
-DCGM_RUN_FLAGS_TRAIN = 0x0004
+# UNUSED
+DCGM_RUN_FLAGS_TRAIN       = 0x0004
+# UNUSED
 DCGM_RUN_FLAGS_FORCE_TRAIN = 0x0008
-# Enable fail early checks for the Targeted Stress, Targeted Power, SM Stress,
-# and Diagnostic tests
-DCGM_RUN_FLAGS_FAIL_EARLY = 0x0010
+DCGM_RUN_FLAGS_FAIL_EARLY  = 0x0010 # Enable fail early checks for the Targeted Stress, Targeted Power, SM Stress, and Diagnostic tests
 
-
-class c_dcgmRunDiag_v6(_PrintableStructure):
+class c_dcgmRunDiag_v7(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),  # version of this message
-        (
-            # flags specifying binary options for running it. Currently verbose
-            # and stats on fail
-            'flags',
-            c_uint),
-        ('debugLevel', c_uint
-        ),  # 0-5 for the debug level the GPU diagnostic will use for logging
-        (
-            # group of GPUs to verify. Cannot be specified together with
-            # gpuList.
-            'groupId',
-            c_void_p),
-        ('validate', c_uint),  # 0-3 for which tests to run. Optional.
-        ('testNames', c_char * DCGM_MAX_TEST_NAMES *
-         DCGM_MAX_TEST_NAMES_LEN),  # Specifed list of test names. Optional.
-        (
-            # Parameters to set for specified tests in the format:
-            # testName.parameterName=parameterValue. Optional.
-            'testParms',
-            c_char * DCGM_MAX_TEST_PARMS * DCGM_MAX_TEST_PARMS_LEN),
-        (
-            # Comma-separated list of gpus. Cannot be specified with the
-            # groupId.
-            'gpuList',
-            c_char * DCGM_GPU_LIST_LEN),
-        ('debugLogFile', c_char * DCGM_PATH_LEN
-        ),  # Alternate name for the debug log file that should be used
-        ('statsPath', c_char * DCGM_PATH_LEN
-        ),  # Path that the plugin's statistics files should be written to
-        ('configFileContents', c_char * DCGM_MAX_CONFIG_FILE_LEN
-        ),  # Contents of nvvs config file (likely yaml)
-        (
-            # Throttle reasons to ignore as either integer mask or csv list of
-            # reasons
-            'throttleMask',
-            c_char * DCGM_THROTTLE_MASK_LEN),
-        ('pluginPath',
-         c_char * DCGM_PATH_LEN),  # Custom path to the diagnostic plugins
-        ('trainingValues', c_uint),  # Number of iterations for training.
-        (
-            # Acceptable training variance as a percentage of the value.
-            # (0-100)
-            'trainingVariance',
-            c_uint),
-        (
-            # Acceptable training tolerance as a percentage of the value.
-            # (0-100)
-            'trainingTolerance',
-            c_uint),
-        ('goldenValuesFile', c_char *
-         DCGM_PATH_LEN),  # The path where the golden values should be recorded
-        (
-            # How often the fail early checks should occur when
-            # DCGM_RUN_FLAGS_FAIL_EARLY is set.
-            'failCheckInterval',
-            c_uint),
+        ('version', c_uint), # version of this message
+        ('flags', c_uint), # flags specifying binary options for running it. Currently verbose and stats on fail
+        ('debugLevel', c_uint), # 0-5 for the debug level the GPU diagnostic will use for logging
+        ('groupId', c_void_p), # group of GPUs to verify. Cannot be specified together with gpuList.
+        ('validate', c_uint), # 0-3 for which tests to run. Optional.
+        ('testNames', c_char * DCGM_MAX_TEST_NAMES * DCGM_MAX_TEST_NAMES_LEN), # Specifed list of test names. Optional.
+        ('testParms', c_char * DCGM_MAX_TEST_PARMS * DCGM_MAX_TEST_PARMS_LEN), # Parameters to set for specified tests in the format: testName.parameterName=parameterValue. Optional.
+        ('fakeGpuList', c_char * DCGM_GPU_LIST_LEN), # Comma-separated list of fake gpus. Cannot be specified with the groupId or gpuList.
+        ('gpuList', c_char * DCGM_GPU_LIST_LEN), # Comma-separated list of gpus. Cannot be specified with the groupId.
+        ('debugLogFile', c_char * DCGM_PATH_LEN), # Alternate name for the debug log file that should be used
+        ('statsPath', c_char * DCGM_PATH_LEN), # Path that the plugin's statistics files should be written to
+        ('configFileContents', c_char * DCGM_MAX_CONFIG_FILE_LEN), # Contents of nvvs config file (likely yaml)
+        ('throttleMask', c_char * DCGM_THROTTLE_MASK_LEN), # Throttle reasons to ignore as either integer mask or csv list of reasons
+        ('pluginPath', c_char * DCGM_PATH_LEN), # Custom path to the diagnostic plugins
+        ('_unusedInt1', c_uint), # Unused
+        ('_unusedInt2', c_uint), # Unused
+        ('_unusedInt3', c_uint), # Unused
+        ('_unusedBuf', c_char * DCGM_PATH_LEN), # Unused
+        ('failCheckInterval', c_uint), # How often the fail early checks should occur when DCGM_RUN_FLAGS_FAIL_EARLY is set.
     ]
 
-
-dcgmRunDiag_version6 = make_dcgm_version(c_dcgmRunDiag_v6, 6)
+dcgmRunDiag_version7 = make_dcgm_version(c_dcgmRunDiag_v7, 7)
 
 # Latest c_dcgmRunDiag class
-c_dcgmRunDiag_t = c_dcgmRunDiag_v6
+c_dcgmRunDiag_t = c_dcgmRunDiag_v7
 
 # Latest version for dcgmRunDiag_t
-dcgmRunDiag_version = dcgmRunDiag_version6
+dcgmRunDiag_version = dcgmRunDiag_version7
 
-# Flags for dcgmGetEntityGroupEntities's flags parameter
-# Only return entities that are supported by DCGM.
-DCGM_GEGE_FLAG_ONLY_SUPPORTED = 0x00000001
 
-# Identifies a GPU NVLink error type returned by DCGM_FI_DEV_GPU_NVLINK_ERRORS
-# NVLink link recovery error occurred
-DCGM_GPU_NVLINK_ERROR_RECOVERY_REQUIRED = 1
-# NVLink link fatal error occurred
-DCGM_GPU_NVLINK_ERROR_FATAL = 2
+#Flags for dcgmGetEntityGroupEntities's flags parameter
+DCGM_GEGE_FLAG_ONLY_SUPPORTED = 0x00000001 #Only return entities that are supported by DCGM.
+
+#Identifies a GPU NVLink error type returned by DCGM_FI_DEV_GPU_NVLINK_ERRORS
+DCGM_GPU_NVLINK_ERROR_RECOVERY_REQUIRED = 1 # NVLink link recovery error occurred
+DCGM_GPU_NVLINK_ERROR_FATAL             = 2 # NVLink link fatal error occurred
 
 # Topology hints for dcgmSelectGpusByTopology()
-DCGM_TOPO_HINT_F_NONE = 0x00000000  # No hints specified
-# Ignore the health of the GPUs when picking GPUs for job execution.
-DCGM_TOPO_HINT_F_IGNOREHEALTH = 0x00000001
-# By default, only healthy GPUs are considered.
-
+DCGM_TOPO_HINT_F_NONE = 0x00000000 # No hints specified
+DCGM_TOPO_HINT_F_IGNOREHEALTH = 0x00000001 # Ignore the health of the GPUs when picking GPUs for job execution.
+                                           # By default, only healthy GPUs are considered.
 
 class c_dcgmTopoSchedHint_v1(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint),  # version of this message
-        ('inputGpuIds', c_uint64),  # bitmask of the GPU ids to choose from
-        ('numGpus', c_uint32),  # the number of GPUs that DCGM should chooose
-        ('hintFlags',
-         c_uint64),  # Hints to ignore certain factors for the scheduling hint
+        ('version', c_uint), # version of this message
+        ('inputGpuIds', c_uint64), # bitmask of the GPU ids to choose from
+        ('numGpus', c_uint32), # the number of GPUs that DCGM should chooose
+        ('hintFlags', c_uint64), # Hints to ignore certain factors for the scheduling hint
     ]
-
 
 dcgmTopoSchedHint_version1 = make_dcgm_version(c_dcgmTopoSchedHint_v1, 1)
 
-# DCGM NvLink link states used by c_dcgmNvLinkGpuLinkStatus_v1 & 2 and
-# c_dcgmNvLinkNvSwitchLinkStatus_t's linkState field
-# NvLink is unsupported by this GPU (Default for GPUs)
-DcgmNvLinkLinkStateNotSupported = 0
-# NvLink is supported for this link but this link is disabled (Default for
-# NvSwitches)
-DcgmNvLinkLinkStateDisabled = 1
-# This NvLink link is down (inactive)
-DcgmNvLinkLinkStateDown = 2
-# This NvLink link is up (active)
-DcgmNvLinkLinkStateUp = 3
+
+#DCGM NvLink link states used by c_dcgmNvLinkGpuLinkStatus_v1 & 2 and c_dcgmNvLinkNvSwitchLinkStatus_t's linkState field
+DcgmNvLinkLinkStateNotSupported = 0 # NvLink is unsupported by this GPU (Default for GPUs)
+DcgmNvLinkLinkStateDisabled     = 1 # NvLink is supported for this link but this link is disabled (Default for NvSwitches)
+DcgmNvLinkLinkStateDown         = 2 # This NvLink link is down (inactive)
+DcgmNvLinkLinkStateUp           = 3 # This NvLink link is up (active)
 
 
-# State of NvLink links for a GPU
+# State of NvLink links for a GPU 
 class c_dcgmNvLinkGpuLinkStatus_v1(_PrintableStructure):
     _fields_ = [
-        ('entityId', c_uint32),  # Entity ID of the GPU (gpuId)
-        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY1
-        ),  # Link state of each link of this GPU
+        ('entityId', c_uint32),   # Entity ID of the GPU (gpuId)
+        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY1),  #Link state of each link of this GPU
     ]
 
-
-# State of NvLink links for a GPU
+# State of NvLink links for a GPU 
 class c_dcgmNvLinkGpuLinkStatus_v2(_PrintableStructure):
     _fields_ = [
-        ('entityId', c_uint32),  # Entity ID of the GPU (gpuId)
-        ('linkState', c_uint32 *
-         DCGM_NVLINK_MAX_LINKS_PER_GPU),  # Link state of each link of this GPU
+        ('entityId', c_uint32),   # Entity ID of the GPU (gpuId)
+        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_GPU_LEGACY2),  #Link state of each link of this GPU
     ]
 
-
-# State of NvLink links for a NvSwitch
-class c_dcgmNvLinkNvSwitchLinkStatus_t(_PrintableStructure):
+class c_dcgmNvLinkGpuLinkStatus_v3(_PrintableStructure):
     _fields_ = [
-        ('entityId', c_uint32),  # Entity ID of the NvSwitch (physicalId)
-        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH
-        )  # Link state of each link of this NvSwitch
+        ('entityId', c_uint32),   # Entity ID of the GPU (gpuId)
+        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_GPU),  #Link state of each link of this GPU
     ]
 
-
-class c_dcgmNvLinkStatus_v1(_PrintableStructure):
-    """
-    NvSwitch link status for all GPUs and NvSwitches in the system
-    """
+#State of NvLink links for a NvSwitch
+class c_dcgmNvLinkNvSwitchLinkStatus_v1(_PrintableStructure):
     _fields_ = [
-        ('version', c_uint32
-        ),  # version of this message. Should be dcgmNvLinkStatus_version1
-        ('numGpus', c_uint32),  # Number of GPUs populated in gpus[]
-        ('gpus', c_dcgmNvLinkGpuLinkStatus_v1 *
-         DCGM_MAX_NUM_DEVICES),  # Per-GPU NvLink link statuses
-        ('numNvSwitches',
-         c_uint32),  # Number of NvSwitches populated in nvSwitches[]
-        ('nvSwitches', c_dcgmNvLinkNvSwitchLinkStatus_t * DCGM_MAX_NUM_SWITCHES
-        )  # Per-NvSwitch NvLink link statuses
+        ('entityId', c_uint32), # Entity ID of the NvSwitch (physicalId)
+        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH_V1) #Link state of each link of this NvSwitch
     ]
-
-
-dcgmNvLinkStatus_version1 = make_dcgm_version(c_dcgmNvLinkStatus_v1, 1)
-
 
 class c_dcgmNvLinkStatus_v2(_PrintableStructure):
     '''
     NvSwitch link status for all GPUs and NvSwitches in the system
     '''
     _fields_ = [
-        ('version', c_uint32
-        ),  # version of this message. Should be dcgmNvLinkStatus_version1
-        ('numGpus', c_uint32),  # Number of GPUs populated in gpus[]
-        ('gpus', c_dcgmNvLinkGpuLinkStatus_v2 *
-         DCGM_MAX_NUM_DEVICES),  # Per-GPU NvLink link statuses
-        ('numNvSwitches',
-         c_uint32),  # Number of NvSwitches populated in nvSwitches[]
-        ('nvSwitches', c_dcgmNvLinkNvSwitchLinkStatus_t * DCGM_MAX_NUM_SWITCHES
-        )  # Per-NvSwitch NvLink link statuses
+        ('version', c_uint32),       # version of this message. Should be dcgmNvLinkStatus_version1
+        ('numGpus', c_uint32),       # Number of GPUs populated in gpus[]
+        ('gpus', c_dcgmNvLinkGpuLinkStatus_v2 * DCGM_MAX_NUM_DEVICES),  #Per-GPU NvLink link statuses
+        ('numNvSwitches', c_uint32), # Number of NvSwitches populated in nvSwitches[]
+        ('nvSwitches', c_dcgmNvLinkNvSwitchLinkStatus_v1 * DCGM_MAX_NUM_SWITCHES) #Per-NvSwitch NvLink link statuses
     ]
-
 
 dcgmNvLinkStatus_version2 = make_dcgm_version(c_dcgmNvLinkStatus_v2, 2)
 
-# Bitmask values for dcgmGetFieldIdSummary
-DCGM_SUMMARY_MIN = 0x00000001
-DCGM_SUMMARY_MAX = 0x00000002
-DCGM_SUMMARY_AVG = 0x00000004
-DCGM_SUMMARY_SUM = 0x00000008
-DCGM_SUMMARY_COUNT = 0x00000010
-DCGM_SUMMARY_INTEGRAL = 0x00000020
-DCGM_SUMMARY_DIFF = 0x00000040
-DCGM_SUMMARY_SIZE = 7
+#State of NvLink links for a NvSwitch
+class c_dcgmNvLinkNvSwitchLinkStatus_v2(_PrintableStructure):
+    _fields_ = [
+        ('entityId', c_uint32), # Entity ID of the NvSwitch (physicalId)
+        ('linkState', c_uint32 * DCGM_NVLINK_MAX_LINKS_PER_NVSWITCH) #Link state of each link of this NvSwitch
+    ]
 
+class c_dcgmNvLinkStatus_v3(_PrintableStructure):
+    '''
+    NvSwitch link status for all GPUs and NvSwitches in the system
+    '''
+    _fields_ = [
+        ('version', c_uint32),       # version of this message. Should be dcgmNvLinkStatus_version1
+        ('numGpus', c_uint32),       # Number of GPUs populated in gpus[]
+        ('gpus', c_dcgmNvLinkGpuLinkStatus_v3 * DCGM_MAX_NUM_DEVICES),  #Per-GPU NvLink link statuses
+        ('numNvSwitches', c_uint32), # Number of NvSwitches populated in nvSwitches[]
+        ('nvSwitches', c_dcgmNvLinkNvSwitchLinkStatus_v2 * DCGM_MAX_NUM_SWITCHES) #Per-NvSwitch NvLink link statuses
+    ]
+
+dcgmNvLinkStatus_version3 = make_dcgm_version(c_dcgmNvLinkStatus_v3, 3)
+
+# Bitmask values for dcgmGetFieldIdSummary
+DCGM_SUMMARY_MIN      = 0x00000001
+DCGM_SUMMARY_MAX      = 0x00000002
+DCGM_SUMMARY_AVG      = 0x00000004
+DCGM_SUMMARY_SUM      = 0x00000008
+DCGM_SUMMARY_COUNT    = 0x00000010
+DCGM_SUMMARY_INTEGRAL = 0x00000020
+DCGM_SUMMARY_DIFF     = 0x00000040
+DCGM_SUMMARY_SIZE     = 7
 
 class c_dcgmSummaryResponse_t(_PrintableStructure):
-
-    class ResponseValue(Union):
+    class ResponseValue(DcgmUnion):
         _fields_ = [
             ('i64', c_int64),
             ('dbl', c_double),
@@ -1966,7 +1958,6 @@ class c_dcgmSummaryResponse_t(_PrintableStructure):
         ('summaryCount', c_uint),
         ('values', ResponseValue * DCGM_SUMMARY_SIZE),
     ]
-
 
 class c_dcgmFieldSummaryRequest_v1(_PrintableStructure):
     _fields_ = [
@@ -1980,113 +1971,65 @@ class c_dcgmFieldSummaryRequest_v1(_PrintableStructure):
         ('response', c_dcgmSummaryResponse_t),
     ]
 
-
-dcgmFieldSummaryRequest_version1 = make_dcgm_version(
-    c_dcgmFieldSummaryRequest_v1, 1)
+dcgmFieldSummaryRequest_version1 = make_dcgm_version(c_dcgmFieldSummaryRequest_v1, 1)
 
 # Module IDs
-DcgmModuleIdCore = 0  # Core DCGM
-DcgmModuleIdNvSwitch = 1  # NvSwitch Module
-DcgmModuleIdVGPU = 2  # VGPU Module
-DcgmModuleIdIntrospect = 3  # Introspection Module
-DcgmModuleIdHealth = 4  # Health Module
-DcgmModuleIdPolicy = 5  # Policy Module
-DcgmModuleIdConfig = 6  # Config Module
-DcgmModuleIdDiag = 7  # GPU Diagnostic Module
-DcgmModuleIdProfiling = 8  # Profiling Module
-DcgmModuleIdCount = 9  # 1 greater than largest ID above
+DcgmModuleIdCore           = 0 # Core DCGM
+DcgmModuleIdNvSwitch       = 1 # NvSwitch Module
+DcgmModuleIdVGPU           = 2 # VGPU Module
+DcgmModuleIdIntrospect     = 3 # Introspection Module
+DcgmModuleIdHealth         = 4 # Health Module
+DcgmModuleIdPolicy         = 5 # Policy Module
+DcgmModuleIdConfig         = 6 # Config Module
+DcgmModuleIdDiag           = 7 # GPU Diagnostic Module
+DcgmModuleIdProfiling      = 8 # Profiling Module
+DcgmModuleIdCount          = 9 # 1 greater than largest ID above
 
 # Module Status
-# Module has not been loaded yet
-DcgmModuleStatusNotLoaded = 0
-# Module has been blacklisted from being loaded
-DcgmModuleStatusBlacklisted = 1
-# Loading the module failed
-DcgmModuleStatusFailed = 2
-# Module has been loaded
-DcgmModuleStatusLoaded = 3
+DcgmModuleStatusNotLoaded   = 0 # Module has not been loaded yet
+DcgmModuleStatusDenylisted  = 1 # Module has been added to the denylist so it can't be loaded
+DcgmModuleStatusFailed      = 2 # Loading the module failed
+DcgmModuleStatusLoaded      = 3 # Module has been loaded
 
 DCGM_MODULE_STATUSES_CAPACITY = 16
 
-
 class c_dcgmModuleGetStatusesModule_t(_PrintableStructure):
     _fields_ = [
-        ('id', c_uint32),  # One of DcgmModuleId*
-        ('status', c_uint32),  # One of DcgmModuleStatus*
+        ('id', c_uint32),     #One of DcgmModuleId*
+        ('status', c_uint32), #One of DcgmModuleStatus*
     ]
-
 
 class c_dcgmModuleGetStatuses_v1(_PrintableStructure):
     _fields_ = [
         ('version', c_uint),
         ('numStatuses', c_uint32),
-        ('statuses',
-         c_dcgmModuleGetStatusesModule_t * DCGM_MODULE_STATUSES_CAPACITY),
+        ('statuses', c_dcgmModuleGetStatusesModule_t * DCGM_MODULE_STATUSES_CAPACITY),
     ]
 
-
-dcgmModuleGetStatuses_version1 = make_dcgm_version(c_dcgmModuleGetStatuses_v1,
-                                                   1)
-
-# Maximum number of metric ID groups that can exist in DCGM
-DCGM_PROF_MAX_NUM_GROUPS = 10
-# Maximum number of field IDs that can be in a single DCGM profiling metric
-# group
-DCGM_PROF_MAX_FIELD_IDS_PER_GROUP = 8
+dcgmModuleGetStatuses_version1 = make_dcgm_version(c_dcgmModuleGetStatuses_v1, 1)
 
 
-class c_dcgmProfMetricGroupInfo_t(_PrintableStructure):
+DCGM_PROF_MAX_NUM_GROUPS_V2          = 10 # Maximum number of metric ID groups that can exist in DCGM
+DCGM_PROF_MAX_FIELD_IDS_PER_GROUP_V2 = 64 # Maximum number of field IDs that can be in a single DCGM profiling metric group
+
+class c_dcgmProfMetricGroupInfo_v2(_PrintableStructure):
     _fields_ = [
         ('majorId', c_ushort),
         ('minorId', c_ushort),
         ('numFieldIds', c_uint32),
-        ('fieldIds', c_ushort * DCGM_PROF_MAX_FIELD_IDS_PER_GROUP),
+        ('fieldIds', c_ushort * DCGM_PROF_MAX_FIELD_IDS_PER_GROUP_V2),
     ]
 
-
-class c_dcgmProfGetMetricGroups_v2(_PrintableStructure):
+class c_dcgmProfGetMetricGroups_v3(_PrintableStructure):
     _fields_ = [
         ('version', c_uint32),
         ('unused', c_uint32),
-        ('groupId', c_void_p),
+        ('gpuId', c_uint32),
         ('numMetricGroups', c_uint32),
-        ('unused1', c_uint32),
-        ('metricGroups',
-         c_dcgmProfMetricGroupInfo_t * DCGM_PROF_MAX_NUM_GROUPS),
+        ('metricGroups', c_dcgmProfMetricGroupInfo_v2 * DCGM_PROF_MAX_NUM_GROUPS_V2),
     ]
 
-
-dcgmProfGetMetricGroups_version1 = make_dcgm_version(
-    c_dcgmProfGetMetricGroups_v2, 2)
-
-
-class c_dcgmProfWatchFields_v1(_PrintableStructure):
-    _fields_ = [
-        ('version', c_uint32),
-        ('groupId', c_void_p),
-        ('numFieldIds', c_uint32),
-        ('fieldIds', c_ushort * 16),
-        ('updateFreq', c_int64),
-        ('maxKeepAge', c_double),
-        ('maxKeepSamples', c_int32),
-        ('flags', c_uint32),
-    ]
-
-
-dcgmProfWatchFields_version1 = make_dcgm_version(c_dcgmProfWatchFields_v1, 1)
-
-
-class c_dcgmProfUnwatchFields_v1(_PrintableStructure):
-    _fields_ = [
-        ('version', c_uint32),
-        ('groupId', c_void_p),
-        ('flags', c_uint32),
-    ]
-
-
-dcgmProfUnwatchFields_version1 = make_dcgm_version(c_dcgmProfUnwatchFields_v1,
-                                                   1)
-
+dcgmProfGetMetricGroups_version3 = make_dcgm_version(c_dcgmProfGetMetricGroups_v3, 3)
 
 class c_dcgmVersionInfo_v2(_PrintableStructure):
     _fields_ = [
@@ -2094,6 +2037,6 @@ class c_dcgmVersionInfo_v2(_PrintableStructure):
         ('rawBuildInfoString', c_char * (DCGM_MAX_STR_LENGTH * 2)),
     ]
 
-
 dcgmVersionInfo_version2 = make_dcgm_version(c_dcgmVersionInfo_v2, 2)
 dcgmVersionInfo_version = dcgmVersionInfo_version2
+

--- a/components/model_analyzer/dcgm/dcgm_value.py
+++ b/components/model_analyzer/dcgm/dcgm_value.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,43 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Base value for integer blank. can be used as an unspecified blank
 DCGM_INT32_BLANK = 0x7ffffff0
 DCGM_INT64_BLANK = 0x7ffffffffffffff0
 
 # Base value for double blank. 2 ** 47. FP 64 has 52 bits of mantissa,
-# so 47 bits can still increment by 1 and represent each value from 0-15
+#so 47 bits can still increment by 1 and represent each value from 0-15
 DCGM_FP64_BLANK = 140737488355328.0
 
 DCGM_STR_BLANK = "<<<NULL>>>"
 
 # Represents an error where data was not found
-DCGM_INT32_NOT_FOUND = (DCGM_INT32_BLANK + 1)
-DCGM_INT64_NOT_FOUND = (DCGM_INT64_BLANK + 1)
-DCGM_FP64_NOT_FOUND = (DCGM_FP64_BLANK + 1.0)
+DCGM_INT32_NOT_FOUND = (DCGM_INT32_BLANK+1)
+DCGM_INT64_NOT_FOUND = (DCGM_INT64_BLANK+1)
+DCGM_FP64_NOT_FOUND = (DCGM_FP64_BLANK+1.0)
 DCGM_STR_NOT_FOUND = "<<<NOT_FOUND>>>"
 
 # Represents an error where fetching the value is not supported
-DCGM_INT32_NOT_SUPPORTED = (DCGM_INT32_BLANK + 2)
-DCGM_INT64_NOT_SUPPORTED = (DCGM_INT64_BLANK + 2)
-DCGM_FP64_NOT_SUPPORTED = (DCGM_FP64_BLANK + 2.0)
+DCGM_INT32_NOT_SUPPORTED = (DCGM_INT32_BLANK+2)
+DCGM_INT64_NOT_SUPPORTED = (DCGM_INT64_BLANK+2)
+DCGM_FP64_NOT_SUPPORTED = (DCGM_FP64_BLANK+2.0)
 DCGM_STR_NOT_SUPPORTED = "<<<NOT_SUPPORTED>>>"
 
-# Represents and error where fetching the value is not allowed with our current
-# credentials
-DCGM_INT32_NOT_PERMISSIONED = (DCGM_INT32_BLANK + 3)
-DCGM_INT64_NOT_PERMISSIONED = (DCGM_INT64_BLANK + 3)
-DCGM_FP64_NOT_PERMISSIONED = (DCGM_FP64_BLANK + 3.0)
+# Represents and error where fetching the value is not allowed with our current credentials
+DCGM_INT32_NOT_PERMISSIONED = (DCGM_INT32_BLANK+3)
+DCGM_INT64_NOT_PERMISSIONED = (DCGM_INT64_BLANK+3)
+DCGM_FP64_NOT_PERMISSIONED = (DCGM_FP64_BLANK+3.0)
 DCGM_STR_NOT_PERMISSIONED = "<<<NOT_PERM>>>"
-
 
 ###############################################################################
 # Functions to check if a value is blank or not
-def DCGM_INT32_IS_BLANK(val):
+def DCGM_INT32_IS_BLANK(val): 
     if val >= DCGM_INT32_BLANK:
         return True
     else:
         return False
-
 
 def DCGM_INT64_IS_BLANK(val):
     if val >= DCGM_INT64_BLANK:
@@ -56,15 +54,13 @@ def DCGM_INT64_IS_BLANK(val):
     else:
         return False
 
-
 def DCGM_FP64_IS_BLANK(val):
     if val >= DCGM_FP64_BLANK:
         return True
     else:
         return False
 
-
-# Looks for <<< at first position and >>> inside string
+#Looks for <<< at first position and >>> inside string
 def DCGM_STR_IS_BLANK(val):
     if 0 != val.find("<<<"):
         return False
@@ -72,21 +68,17 @@ def DCGM_STR_IS_BLANK(val):
         return False
     return True
 
-
+###############################################################################
 class DcgmValue:
-
     def __init__(self, value):
-        # Contains either an integer (int64), string, or double of the actual
-        # value
+        self.value = value #Contains either an integer (int64), string, or double of the actual value
 
-        self.value = value
-
+    ###########################################################################
     def SetFromInt32(self, i32Value):
-        """
-        Handle the special case where our source data was an int32 but is
-        currently stored in a python int (int64), dealing with blanks
-        """
-
+        '''
+        Handle the special case where our source data was an int32 but is currently
+        stored in a python int (int64), dealing with blanks
+        '''
         value = int(i32Value)
 
         if not DCGM_INT32_IS_BLANK(i32Value):
@@ -102,15 +94,14 @@ class DcgmValue:
         else:
             self.value = DCGM_INT64_BLANK
 
+    ###########################################################################
     def IsBlank(self):
-        """
-        Returns True if the currently-stored value is a blank value. False if
-        not
-        """
-
+        '''
+        Returns True if the currently-stored value is a blank value. False if not
+        '''
         if self.value is None:
             return True
-        elif type(self.value) == int or type(self.value) == long:
+        elif type(self.value) == int or type(self.value) == int:
             return DCGM_INT64_IS_BLANK(self.value)
         elif type(self.value) == float:
             return DCGM_FP64_IS_BLANK(self.value)
@@ -119,33 +110,40 @@ class DcgmValue:
         else:
             raise Exception("Unknown type: %s") % str(type(self.value))
 
+    ###########################################################################
     def __str__(self):
         return str(self.value)
 
+    ###########################################################################
 
+###############################################################################
 def self_test():
 
     v = DcgmValue(1.0)
-    assert (not v.IsBlank())
-    assert (v.value == 1.0)
+    assert(not v.IsBlank())
+    assert(v.value == 1.0)
 
     v = DcgmValue(100)
-    assert (not v.IsBlank())
-    assert (v.value == 100)
+    assert(not v.IsBlank())
+    assert(v.value == 100)
 
     v = DcgmValue(DCGM_INT64_NOT_FOUND)
-    assert (v.IsBlank())
+    assert(v.IsBlank())
 
     v = DcgmValue(DCGM_FP64_NOT_FOUND)
-    assert (v.IsBlank())
+    assert(v.IsBlank())
 
     v.SetFromInt32(DCGM_INT32_NOT_SUPPORTED)
-    assert (v.IsBlank())
-    assert (v.value == DCGM_INT64_NOT_SUPPORTED)
+    assert(v.IsBlank())
+    assert(v.value == DCGM_INT64_NOT_SUPPORTED)
 
     print("Tests passed")
     return
 
-
+###############################################################################
 if __name__ == "__main__":
     self_test()
+
+###############################################################################
+
+

--- a/components/model_analyzer/dcgm/monitor.py
+++ b/components/model_analyzer/dcgm/monitor.py
@@ -30,7 +30,7 @@ class Monitor(ABC):
         Parameters
         ----------
         frequency : float
-            How often the metrics should be monitored.
+            How often the metrics should be monitored. It is in seconds.
         metrics : list
             A list of Record objects that will be monitored.
 

--- a/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
@@ -1,0 +1,76 @@
+from functools import total_ordering
+from .record import Record
+
+
+@total_ordering
+class CPUPeakMemory(Record):
+    """
+    The peak memory usage in the CPU.
+    """
+
+    tag = "cpu_peak_memory"
+
+    def __init__(self, value, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the cpu metrtic
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Max " if aggregation_tag else "") + "GPU Memory Usage (MB)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if 
+        this record is less than 
+        the other
+        """
+
+        return self.value() > other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return CPUPeakMemory(value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return CPUPeakMemory(value=(other.value() - self.value()))

--- a/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
@@ -1,9 +1,9 @@
 from functools import total_ordering
-from .record import Record
+from .cpu_record import CPURecord
 
 
 @total_ordering
-class CPUPeakMemory(Record):
+class CPUPeakMemory(CPURecord):
     """
     The peak memory usage in the CPU.
     """
@@ -15,12 +15,13 @@ class CPUPeakMemory(Record):
         Parameters
         ----------
         value : float
-            The value of the cpu metrtic
+            The value of the CPU metrtic
         timestamp : int
             The timestamp for the record in nanoseconds
         """
 
         super().__init__(value, timestamp)
+        
 
     @staticmethod
     def header(aggregation_tag=False):

--- a/components/model_analyzer/tb_dcgm_types/cpu_record.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_record.py
@@ -1,0 +1,26 @@
+from .record import Record
+
+
+class CPURecord(Record):
+    """
+    This is a base class for any
+    CPU based record
+    """
+
+    def __init__(self, value, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the CPU metrtic
+        device_uuid : str
+            A dummy parameter to pass record aggregator.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, timestamp)
+        self._device_uuid = 0x1
+
+    def device_uuid(self):
+        return self._device_uuid

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -62,10 +62,9 @@ class GPUDeviceFactory:
             for device_id in dcgm_device_ids:
                 device_atrributes = dcgm_agent.dcgmGetDeviceAttributes(
                     dcgm_handle, device_id).identifiers
-                pci_bus_id = device_atrributes.pciBusId.decode('utf-8').upper()
-                device_uuid = str(device_atrributes.uuid, encoding='utf-8')
-                device_name = str(device_atrributes.deviceName,
-                                  encoding='utf-8')
+                pci_bus_id = device_atrributes.pciBusId.upper()
+                device_uuid = device_atrributes.uuid
+                device_name = device_atrributes.deviceName
                 gpu_device = GPUDevice(device_name, device_id, pci_bus_id,
                                        device_uuid)
 

--- a/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
@@ -17,12 +17,12 @@ from .gpu_record import GPURecord
 
 
 @total_ordering
-class GPUUsedMemory(GPURecord):
+class GPUPeakMemory(GPURecord):
     """
-    The used memory in the GPU.
+    The peak memory usage in the GPU. Because I didn't specify the aggregate function, the default is MAX inherited from Record Class.
     """
 
-    tag = "gpu_used_memory"
+    tag = "gpu_peak_memory"
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         """
@@ -82,7 +82,7 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
+        return GPUPeakMemory(device_uuid=None,
                              value=(self.value() + other.value()))
 
     def __sub__(self, other):
@@ -91,5 +91,5 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
+        return GPUPeakMemory(device_uuid=None,
                              value=(other.value() - self.value()))

--- a/run.py
+++ b/run.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
             from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
             if check_dcgm():
                 model_flops = 'dcgm'
-    metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()]
+    metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
     if 'gpu_peak_mem' in metrics_needed:
         assert args.device == 'cuda', "gpu_peak_mem is only available for cuda device."
         from components.model_analyzer.TorchBenchAnalyzer import check_dcgm

--- a/run.py
+++ b/run.py
@@ -76,6 +76,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
             gpu_peak_mem_enabled = True
         if (type(model_flops) is str and model_flops.lower() == 'dcgm') or 'flops_dcgm' in metrics_needed:
             model_analyzer.add_metric_gpu_flops()
+            model_flops='dcgm'
         if 'cpu_peak_mem' in metrics_needed:
             model_analyzer.add_metric_cpu_peak_mem()
             cpu_peak_mem_enabled = True

--- a/torchbenchmark/models/soft_actor_critic/envs.py
+++ b/torchbenchmark/models/soft_actor_critic/envs.py
@@ -234,7 +234,7 @@ def load_gym(env_id="CartPole-v1", seed=None, normalize_action_space=True, **_):
         env = NormalizeContinuousActionSpace(env)
     if seed is None:
         seed = random.randint(1, 100000)
-    env.seed(seed)
+    env.reset(seed=seed)
     return env
 
 
@@ -292,7 +292,7 @@ def load_atari(
     env = gym.make(game_id)
     if seed is None:
         seed = random.randint(1, 100000)
-    env.seed(seed)
+    env.reset(seed=seed)
     env = gym.wrappers.AtariPreprocessing(
         env,
         noop_max=noop_max,


### PR DESCRIPTION
Add `--metrics [cpu_peak_mem,gpu_peak_mem,flops_dcgm]` to `run.py`.  Users could specify different combinations of those three metrics such as `--metrics cpu_peak_mem,gpu_peak_mem` to obtain the peak memory usage for CPU and GPU. The output is like the following.

```
GPU Peak Memory:                2.4268 GB
CPU Peak Memory:                4.1475 GB
```