### PR TITLE
add metrics support for CPU GPU peak memory usage

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -32,8 +32,9 @@ class ModelAnalyzer:
         # For debug
         # set_logger(logging.DEBUG)
         set_logger()
-        self.gpu_factory = GPUDeviceFactory()
-        self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
+        # delay the initialization to start_monitor
+        self.gpu_factory = None
+        self.gpus = None
         # the cpu metrics to be collected
         # self.gpu_metrics = [GPUUtilization, GPUPowerUsage,
         #                     GPUFreeMemory, GPUPeakMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
@@ -76,6 +77,8 @@ class ModelAnalyzer:
     def start_monitor(self):
         try:
             if self.gpu_metrics:
+                self.gpu_factory = GPUDeviceFactory()
+                self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
                 self.gpu_monitor = DCGMMonitor(
                     self.gpus, self.config.monitoring_interval, self.gpu_metrics)
             if self.cpu_metrics:

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -34,7 +34,7 @@ class ModelAnalyzer:
         # the metrics to be collected
         # self.gpu_metrics = [GPUUtilization, GPUPowerUsage,
         #                     GPUFreeMemory, GPUPeakMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
-        self.gpu_metrics = [GPUFP32Active]
+        self.gpu_metrics = []
         # the final metric results. Its format is {GPU_UUID: {GPUUtilization: }}
         # Example:
         # {'GPU-4177e846-1274-84e3-dcde': 
@@ -53,7 +53,8 @@ class ModelAnalyzer:
 
     def add_metric_gpu_peak_mem(self):
         self.gpu_metrics.append(GPUPeakMemory)
-    
+    def add_metric_gpu_flops(self):
+        self.gpu_metrics.append(GPUFP32Active)
 
     def set_export_csv_name(self, export_csv_name=''):
         self.export_csv_name = export_csv_name
@@ -137,6 +138,8 @@ class ModelAnalyzer:
                         tmp_line = "%s, " % (record_type.tag + '(%)')
                     elif record_type.tag.startswith('gpu_pice'):
                         tmp_line = "%s, " % (record_type.tag + '(bytes)')
+                    elif record_type.tag == 'gpu_peak_memory':
+                        tmp_line = "%s, " % (record_type.tag + '(MB)')
                     else:
                         tmp_line = "%s, " % record_type.tag
                     fout.write(tmp_line)
@@ -207,6 +210,7 @@ class ModelAnalyzer:
 def check_dcgm():
     try: 
         temp_model_analyzer = ModelAnalyzer()
+        temp_model_analyzer.add_metric_gpu_flops()
         temp_model_analyzer.start_monitor()
         temp_model_analyzer.stop_monitor()
     except DCGMError as e:

--- a/components/model_analyzer/dcgm/cpu_monitor.py
+++ b/components/model_analyzer/dcgm/cpu_monitor.py
@@ -1,0 +1,36 @@
+import os
+import time
+from .monitor import Monitor
+import psutil
+from ..tb_dcgm_types.cpu_peak_memory import CPUPeakMemory
+
+class CPUMonitor(Monitor):
+    """
+    A CPU monitor that uses psutil to monitor CPU usage
+    """
+
+    def __init__(self, frequency, metrics_needed=[]):
+        super().__init__(frequency, metrics_needed)
+        self._cpu_records = []
+        # the current process is the process which launches and runs the deep learning models.
+        self._monitored_pid = os.getpid()
+
+
+    def _get_cpu_stats(self):
+        """
+        Append a raw record into self._cpu_metric_values.
+        A raw record includes the timestamp in nanosecond, the CPU memory usage, CPU available memory in MB.
+        """
+        server_process = psutil.Process(self._monitored_pid)
+        process_memory_info = server_process.memory_full_info()
+        system_memory_info = psutil.virtual_memory()
+        # Divide by 1.0e6 to convert from bytes to MB
+        a_raw_record = (time.time_ns(), process_memory_info.uss // 1.0e6, system_memory_info.available // 1.0e6)
+        return a_raw_record
+        
+    def _monitoring_iteration(self):
+        if CPUPeakMemory in self._metrics:
+            self._cpu_records.append(self._get_cpu_stats())
+
+    def _collect_records(self):
+        return self._cpu_records

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -15,7 +15,7 @@
 from .monitor import Monitor
 from ..tb_dcgm_types.gpu_free_memory import GPUFreeMemory
 from ..tb_dcgm_types.gpu_tensoractive import GPUTensorActive
-from ..tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from ..tb_dcgm_types.gpu_peak_memory import GPUPeakMemory
 from ..tb_dcgm_types.gpu_utilization import GPUUtilization
 from ..tb_dcgm_types.gpu_power_usage import GPUPowerUsage
 from ..tb_dcgm_types.gpu_fp32active import GPUFP32Active
@@ -39,7 +39,7 @@ class DCGMMonitor(Monitor):
     # Mapping between the DCGM Fields and Model Analyzer Records
     # For more explainations, please refer to https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html
     model_analyzer_to_dcgm_field = {
-        GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
+        GPUPeakMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
         GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL,
         GPUPowerUsage: dcgm_fields.DCGM_FI_DEV_POWER_USAGE,

--- a/components/model_analyzer/dcgm/monitor.py
+++ b/components/model_analyzer/dcgm/monitor.py
@@ -30,7 +30,7 @@ class Monitor(ABC):
         Parameters
         ----------
         frequency : float
-            How often the metrics should be monitored.
+            How often the metrics should be monitored. It is in seconds.
         metrics : list
             A list of Record objects that will be monitored.
 

--- a/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
@@ -1,0 +1,76 @@
+from functools import total_ordering
+from .record import Record
+
+
+@total_ordering
+class CPUPeakMemory(Record):
+    """
+    The peak memory usage in the CPU.
+    """
+
+    tag = "cpu_peak_memory"
+
+    def __init__(self, value, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the cpu metrtic
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Max " if aggregation_tag else "") + "GPU Memory Usage (MB)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if 
+        this record is less than 
+        the other
+        """
+
+        return self.value() > other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return CPUPeakMemory(value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return CPUPeakMemory(value=(other.value() - self.value()))

--- a/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
@@ -1,9 +1,9 @@
 from functools import total_ordering
-from .record import Record
+from .cpu_record import CPURecord
 
 
 @total_ordering
-class CPUPeakMemory(Record):
+class CPUPeakMemory(CPURecord):
     """
     The peak memory usage in the CPU.
     """
@@ -15,12 +15,13 @@ class CPUPeakMemory(Record):
         Parameters
         ----------
         value : float
-            The value of the cpu metrtic
+            The value of the CPU metrtic
         timestamp : int
             The timestamp for the record in nanoseconds
         """
 
         super().__init__(value, timestamp)
+        
 
     @staticmethod
     def header(aggregation_tag=False):

--- a/components/model_analyzer/tb_dcgm_types/cpu_record.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_record.py
@@ -1,0 +1,26 @@
+from .record import Record
+
+
+class CPURecord(Record):
+    """
+    This is a base class for any
+    CPU based record
+    """
+
+    def __init__(self, value, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the CPU metrtic
+        device_uuid : str
+            A dummy parameter to pass record aggregator.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, timestamp)
+        self._device_uuid = 0x1
+
+    def device_uuid(self):
+        return self._device_uuid

--- a/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
@@ -17,12 +17,12 @@ from .gpu_record import GPURecord
 
 
 @total_ordering
-class GPUUsedMemory(GPURecord):
+class GPUPeakMemory(GPURecord):
     """
-    The used memory in the GPU.
+    The peak memory usage in the GPU. Because I didn't specify the aggregate function, the default is MAX inherited from Record Class.
     """
 
-    tag = "gpu_used_memory"
+    tag = "gpu_peak_memory"
 
     def __init__(self, value, device_uuid=None, timestamp=0):
         """
@@ -82,7 +82,7 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
+        return GPUPeakMemory(device_uuid=None,
                              value=(self.value() + other.value()))
 
     def __sub__(self, other):
@@ -91,5 +91,5 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
+        return GPUPeakMemory(device_uuid=None,
                              value=(other.value() - self.value()))

--- a/run.py
+++ b/run.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
             from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
             if check_dcgm():
                 model_flops = 'dcgm'
-    metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()]
+    metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
     if 'gpu_peak_mem' in metrics_needed:
         assert args.device == 'cuda', "gpu_peak_mem is only available for cuda device."
         from components.model_analyzer.TorchBenchAnalyzer import check_dcgm

--- a/run.py
+++ b/run.py
@@ -76,6 +76,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
             gpu_peak_mem_enabled = True
         if (type(model_flops) is str and model_flops.lower() == 'dcgm') or 'flops_dcgm' in metrics_needed:
             model_analyzer.add_metric_gpu_flops()
+            model_flops='dcgm'
         if 'cpu_peak_mem' in metrics_needed:
             model_analyzer.add_metric_cpu_peak_mem()
             cpu_peak_mem_enabled = True


### PR DESCRIPTION
Add --metrics [cpu_peak_mem,gpu_peak_mem,flops_dcgm] to run.py. Users could specify different combinations of those three metrics such as --metrics cpu_peak_mem,gpu_peak_mem to obtain the peak memory usage for CPU and GPU. The output is like the following.
```
GPU Peak Memory:                2.4268 GB
CPU Peak Memory:                4.1475 GB
```