### PR TITLE
add metrics support for CPU GPU peak memory usage

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -1,5 +1,7 @@
 
 from typing import OrderedDict
+
+from .dcgm.cpu_monitor import CPUMonitor
 from .dcgm.dcgm_monitor import DCGMMonitor
 from .tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
 from .tb_dcgm_types.gpu_device_factory import GPUDeviceFactory
@@ -9,11 +11,12 @@ from .tb_dcgm_types.gpu_tensoractive import GPUTensorActive
 from .tb_dcgm_types.gpu_utilization import GPUUtilization
 from .tb_dcgm_types.gpu_power_usage import GPUPowerUsage
 from .tb_dcgm_types.gpu_free_memory import GPUFreeMemory
-from .tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from .tb_dcgm_types.gpu_peak_memory import GPUPeakMemory
 from .tb_dcgm_types.gpu_fp32active import GPUFP32Active
 from .tb_dcgm_types.gpu_dram_active import GPUDRAMActive
 from .tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
 from .tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
+from .tb_dcgm_types.cpu_peak_memory import CPUPeakMemory
 from .tb_dcgm_types.record import RecordType
 from .tb_dcgm_types.record_aggregator import RecordAggregator
 from .tb_dcgm_types.tb_logger import set_logger, LOGGER_NAME
@@ -29,12 +32,13 @@ class ModelAnalyzer:
         # For debug
         # set_logger(logging.DEBUG)
         set_logger()
-        self.gpu_factory = GPUDeviceFactory()
-        self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
-        # the metrics to be collected
+        # delay the initialization to start_monitor
+        self.gpu_factory = None
+        self.gpus = None
+        # the cpu metrics to be collected
         # self.gpu_metrics = [GPUUtilization, GPUPowerUsage,
-        #                     GPUFreeMemory, GPUUsedMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
-        self.gpu_metrics = [GPUFP32Active]
+        #                     GPUFreeMemory, GPUPeakMemory, GPUFP32Active, GPUTensorActive, GPUDRAMActive, GPUPCIERX, GPUPCIETX]
+        self.gpu_metrics = []
         # the final metric results. Its format is {GPU_UUID: {GPUUtilization: }}
         # Example:
         # {'GPU-4177e846-1274-84e3-dcde': 
@@ -44,11 +48,25 @@ class ModelAnalyzer:
         #  }
         self.gpu_metric_value = {}
         self.gpu_monitor = None
+        self.gpu_monitor_started = False
         self.gpu_records = None
         self.config = AnalayzerConfig()
         self.gpu_record_aggregator = RecordAggregator()
         self.export_csv_name = ''
+        # the cpu metrics to be collected. available metrics are [CPUPeakMemory, ]
+        self.cpu_metrics = []
+        self.cpu_monitor = None
+        self.cpu_monitor_started = False
+        self.cpu_records = None
+        self.cpu_record_aggregator = RecordAggregator()
+        self.cpu_metric_value = {}
 
+    def add_metric_gpu_peak_mem(self):
+        self.gpu_metrics.append(GPUPeakMemory)
+    def add_metric_gpu_flops(self):
+        self.gpu_metrics.append(GPUFP32Active)
+    def add_metric_cpu_peak_mem(self):
+        self.cpu_metrics.append(CPUPeakMemory)
 
     def set_export_csv_name(self, export_csv_name=''):
         self.export_csv_name = export_csv_name
@@ -58,35 +76,68 @@ class ModelAnalyzer:
 
     def start_monitor(self):
         try:
-            self.gpu_monitor = DCGMMonitor(
-                self.gpus, self.config.monitoring_interval, self.gpu_metrics)
-            self.gpu_monitor.start_recording_metrics()
+            if self.gpu_metrics:
+                self.gpu_factory = GPUDeviceFactory()
+                self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
+                self.gpu_monitor = DCGMMonitor(
+                    self.gpus, self.config.monitoring_interval, self.gpu_metrics)
+            if self.cpu_metrics:
+                self.cpu_monitor = CPUMonitor(self.config.monitoring_interval, self.cpu_metrics)
+            if self.gpu_metrics:
+                self.gpu_monitor.start_recording_metrics()
+                self.gpu_monitor_started = True
+            if self.cpu_metrics:
+                self.cpu_monitor.start_recording_metrics()
+                self.cpu_monitor_started = True
         except TorchBenchAnalyzerException:
             self._destory_monitor()
             raise
 
     def _destory_monitor(self):
-        self.gpu_monitor.destroy()
-        self.gpu_monitor = None
+        if self.gpu_monitor:
+            self.gpu_monitor.destroy()
+            self.gpu_monitor = None
+            self.gpu_monitor_started = False
+        if self.cpu_monitor:
+            self.cpu_monitor.destroy()
+            self.cpu_monitor = None
+            self.cpu_monitor_started = False
     
     def stop_monitor(self):
-        self.gpu_records = self.gpu_monitor.stop_recording_metrics()
+        if self.gpu_monitor:
+            self.gpu_records = self.gpu_monitor.stop_recording_metrics()
+        if self.cpu_monitor:
+            self.cpu_records = self.cpu_monitor.stop_recording_metrics()
+        # This must be called after stop_recording_metrics
         self._destory_monitor()
-        # insert all gpu_records into record_aggregator
-        self.gpu_record_aggregator.insert_all(self.gpu_records)
+        if self.gpu_records:
+            # insert all gpu_records into record_aggregator
+            self.gpu_record_aggregator.insert_all(self.gpu_records)
+        if self.cpu_records:
+            self.cpu_record_aggregator.insert_all(self.cpu_records)
+
     
     def aggregate(self):
         """
         aggregate must be called after stop_monitor.
         """
-        records_groupby_gpu = self.gpu_record_aggregator.groupby(
-            self.gpu_metrics, lambda record: record.device_uuid())
-        
-        for gpu in self.gpus:
-            self.gpu_metric_value[gpu.device_uuid()] = {}
-        for metric_type, metric in records_groupby_gpu.items():
-            for gpu_uuid, metric_value in metric.items():
-                self.gpu_metric_value[gpu_uuid][metric_type] = metric_value
+        if self.gpu_records:
+            records_groupby_gpu = self.gpu_record_aggregator.groupby(
+                self.gpu_metrics, lambda record: record.device_uuid())
+            
+            for gpu in self.gpus:
+                self.gpu_metric_value[gpu.device_uuid()] = {}
+            for metric_type, metric in records_groupby_gpu.items():
+                for gpu_uuid, metric_value in metric.items():
+                    self.gpu_metric_value[gpu_uuid][metric_type] = metric_value
+        if self.cpu_records:
+            records_groupby_cpu = self.cpu_record_aggregator.groupby(
+                self.cpu_metrics, lambda record: record.device_uuid())
+            # detault cpu id is 0x1
+            self.cpu_metric_value[0x1] = {}
+            for metric_type, metric in records_groupby_cpu.items():
+                for cpu_uuid, metric_value in metric.items():
+                    self.cpu_metric_value[cpu_uuid][metric_type] = metric_value
     
     def set_monitoring_interval(self, attempted_interval):
         """
@@ -132,6 +183,8 @@ class ModelAnalyzer:
                         tmp_line = "%s, " % (record_type.tag + '(%)')
                     elif record_type.tag.startswith('gpu_pice'):
                         tmp_line = "%s, " % (record_type.tag + '(bytes)')
+                    elif record_type.tag == 'gpu_peak_memory':
+                        tmp_line = "%s, " % (record_type.tag + '(MB)')
                     else:
                         tmp_line = "%s, " % record_type.tag
                     fout.write(tmp_line)
@@ -182,9 +235,36 @@ class ModelAnalyzer:
             gpu = self.gpu_factory.get_device_by_uuid(gpu_uuid)
             return gpu._sm_count * gpu._fma_count * 2 * gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9
 
+    def calculate_gpu_peak_mem(self, gpu_uuid=None) -> float:
+        """
+        The function to calculate GPU peak memory usage for the first available GPU.
+        @return : a floating number representing GB.
+        """
+        if gpu_uuid:
+            if gpu_uuid in self.gpu_metric_value:
+                gpu = self.gpu_factory.get_device_by_uuid(gpu_uuid)
+                return self.gpu_metric_value[gpu_uuid][GPUPeakMemory].value() / 1024
+            else:
+                raise TorchBenchAnalyzerException("No available GPU with uuid ", gpu_uuid, " found!")
+        if len(self.gpu_metric_value) > 1:
+            logger.warning("There are multiple available GPUs and will only return the first one's peak memory bandwidth.")
+        gpu_uuid = next(iter(self.gpu_metric_value))
+        return self.gpu_metric_value[gpu_uuid][GPUPeakMemory].value() / 1024
+
+    def calculate_cpu_peak_mem(self, cpu_uuid=None) -> float:
+        """
+        The function to calculate CPU peak memory usage.
+        @return : a floating number representing GB.
+        """
+        if len(self.cpu_metric_value) > 1:
+            logger.warning("There are multiple available CPUs and will only return the first one's peak memory bandwidth.")
+        cpu_uuid = next(iter(self.cpu_metric_value))
+        return self.cpu_metric_value[cpu_uuid][CPUPeakMemory].value() / 1024
+
 def check_dcgm():
     try: 
         temp_model_analyzer = ModelAnalyzer()
+        temp_model_analyzer.add_metric_gpu_flops()
         temp_model_analyzer.start_monitor()
         temp_model_analyzer.stop_monitor()
     except DCGMError as e:

--- a/components/model_analyzer/dcgm/cpu_monitor.py
+++ b/components/model_analyzer/dcgm/cpu_monitor.py
@@ -1,0 +1,43 @@
+import os
+import time
+from .monitor import Monitor
+import psutil
+from ..tb_dcgm_types.cpu_peak_memory import CPUPeakMemory
+
+class CPUMonitor(Monitor):
+    """
+    A CPU monitor that uses psutil to monitor CPU usage
+    """
+
+    def __init__(self, frequency, metrics_needed=[]):
+        super().__init__(frequency, metrics_needed)
+        # It is a raw record list. [timestamp, cpu_memory_usage, cpu_available_memory]
+        self._cpu_records = []
+        # the current process is the process which launches and runs the deep learning models.
+        self._monitored_pid = os.getpid()
+
+
+    def _get_cpu_stats(self):
+        """
+        Append a raw record into self._cpu_metric_values.
+        A raw record includes the timestamp in nanosecond, the CPU memory usage, CPU available memory in MB.
+        """
+        server_process = psutil.Process(self._monitored_pid)
+        process_memory_info = server_process.memory_full_info()
+        system_memory_info = psutil.virtual_memory()
+        # Divide by 1024*1024 to convert from bytes to MB
+        a_raw_record = (time.time_ns(), process_memory_info.uss // 1048576, system_memory_info.available // 1048576)
+        return a_raw_record
+        
+    def _monitoring_iteration(self):
+        if CPUPeakMemory in self._metrics:
+            self._cpu_records.append(self._get_cpu_stats())
+
+    def _collect_records(self):
+        """
+        Convert all raw records into corresponding Record type.
+        """
+        records = []
+        for record in self._cpu_records:
+            records.append(CPUPeakMemory(timestamp=record[0], value=record[1]))
+        return records

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -15,7 +15,7 @@
 from .monitor import Monitor
 from ..tb_dcgm_types.gpu_free_memory import GPUFreeMemory
 from ..tb_dcgm_types.gpu_tensoractive import GPUTensorActive
-from ..tb_dcgm_types.gpu_used_memory import GPUUsedMemory
+from ..tb_dcgm_types.gpu_peak_memory import GPUPeakMemory
 from ..tb_dcgm_types.gpu_utilization import GPUUtilization
 from ..tb_dcgm_types.gpu_power_usage import GPUPowerUsage
 from ..tb_dcgm_types.gpu_fp32active import GPUFP32Active
@@ -39,7 +39,7 @@ class DCGMMonitor(Monitor):
     # Mapping between the DCGM Fields and Model Analyzer Records
     # For more explainations, please refer to https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html
     model_analyzer_to_dcgm_field = {
-        GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
+        GPUPeakMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
         GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL,
         GPUPowerUsage: dcgm_fields.DCGM_FI_DEV_POWER_USAGE,

--- a/components/model_analyzer/dcgm/monitor.py
+++ b/components/model_analyzer/dcgm/monitor.py
@@ -30,7 +30,7 @@ class Monitor(ABC):
         Parameters
         ----------
         frequency : float
-            How often the metrics should be monitored.
+            How often the metrics should be monitored. It is in seconds.
         metrics : list
             A list of Record objects that will be monitored.
 

--- a/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_peak_memory.py
@@ -1,43 +1,27 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from functools import total_ordering
-from .gpu_record import GPURecord
+from .cpu_record import CPURecord
 
 
 @total_ordering
-class GPUUsedMemory(GPURecord):
+class CPUPeakMemory(CPURecord):
     """
-    The used memory in the GPU.
+    The peak memory usage in the CPU.
     """
 
-    tag = "gpu_used_memory"
+    tag = "cpu_peak_memory"
 
-    def __init__(self, value, device_uuid=None, timestamp=0):
+    def __init__(self, value, timestamp=0):
         """
         Parameters
         ----------
         value : float
-            The value of the GPU metrtic
-        device_uuid : str
-            The  GPU device uuid this metric is associated
-            with.
+            The value of the CPU metrtic
         timestamp : int
             The timestamp for the record in nanoseconds
         """
 
-        super().__init__(value, device_uuid, timestamp)
+        super().__init__(value, timestamp)
+        
 
     @staticmethod
     def header(aggregation_tag=False):
@@ -82,8 +66,7 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
-                             value=(self.value() + other.value()))
+        return CPUPeakMemory(value=(self.value() + other.value()))
 
     def __sub__(self, other):
         """
@@ -91,5 +74,4 @@ class GPUUsedMemory(GPURecord):
         to produce a brand new record.
         """
 
-        return GPUUsedMemory(device_uuid=None,
-                             value=(other.value() - self.value()))
+        return CPUPeakMemory(value=(other.value() - self.value()))

--- a/components/model_analyzer/tb_dcgm_types/cpu_record.py
+++ b/components/model_analyzer/tb_dcgm_types/cpu_record.py
@@ -1,0 +1,26 @@
+from .record import Record
+
+
+class CPURecord(Record):
+    """
+    This is a base class for any
+    CPU based record
+    """
+
+    def __init__(self, value, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the CPU metrtic
+        device_uuid : str
+            A dummy parameter to pass record aggregator.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, timestamp)
+        self._device_uuid = 0x1
+
+    def device_uuid(self):
+        return self._device_uuid

--- a/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_peak_memory.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import total_ordering
+from .gpu_record import GPURecord
+
+
+@total_ordering
+class GPUPeakMemory(GPURecord):
+    """
+    The peak memory usage in the GPU. Because I didn't specify the aggregate function, the default is MAX inherited from Record Class.
+    """
+
+    tag = "gpu_peak_memory"
+
+    def __init__(self, value, device_uuid=None, timestamp=0):
+        """
+        Parameters
+        ----------
+        value : float
+            The value of the GPU metrtic
+        device_uuid : str
+            The  GPU device uuid this metric is associated
+            with.
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(value, device_uuid, timestamp)
+
+    @staticmethod
+    def header(aggregation_tag=False):
+        """
+        Parameters
+        ----------
+        aggregation_tag: bool
+            An optional tag that may be displayed 
+            as part of the header indicating that 
+            this record has been aggregated using 
+            max, min or average etc. 
+             
+        Returns
+        -------
+        str
+            The full name of the
+            metric.
+        """
+
+        return ("Max " if aggregation_tag else "") + "GPU Memory Usage (MB)"
+
+    def __eq__(self, other):
+        """
+        Allows checking for
+        equality between two records
+        """
+
+        return self.value() == other.value()
+
+    def __lt__(self, other):
+        """
+        Allows checking if 
+        this record is less than 
+        the other
+        """
+
+        return self.value() > other.value()
+
+    def __add__(self, other):
+        """
+        Allows adding two records together
+        to produce a brand new record.
+        """
+
+        return GPUPeakMemory(device_uuid=None,
+                             value=(self.value() + other.value()))
+
+    def __sub__(self, other):
+        """
+        Allows subtracting two records together
+        to produce a brand new record.
+        """
+
+        return GPUPeakMemory(device_uuid=None,
+                             value=(other.value() - self.value()))

--- a/run.py
+++ b/run.py
@@ -21,6 +21,7 @@ SUPPORT_DEVICE_LIST = ["cpu", "cuda"]
 if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
     SUPPORT_DEVICE_LIST.append("mps")
 
+
 def run_one_step_with_cudastreams(func, streamcount):
 
     print("Running Utilization Scaling Using Cuda Streams")
@@ -55,20 +56,32 @@ def run_one_step_with_cudastreams(func, streamcount):
         print('{:<20} {:>20}'.format("GPU Time:", "%.3f milliseconds" % start_event.elapsed_time(end_event)), sep='')
 
 
-def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_dcgm_metrics_file=False, stress=0):
+def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_dcgm_metrics_file=False, stress=0, metrics_needed=[]):
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
         func()
 
     result_summary = []
-    dcgm_enabled = False
-    if type(model_flops) is str and model_flops == 'dcgm':
-        dcgm_enabled = True
+    analyzer_enabled = False
+    gpu_peak_mem_enabled = False
+    cpu_peak_mem_enabled = False
+    if (type(model_flops) is str and model_flops.lower() == 'dcgm') or metrics_needed:
+        analyzer_enabled = True
         from components.model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
         model_analyzer = ModelAnalyzer()
         if export_dcgm_metrics_file:
             model_analyzer.set_export_csv_name(export_dcgm_metrics_file)
+        if 'gpu_peak_mem' in metrics_needed:
+            model_analyzer.add_metric_gpu_peak_mem()
+            gpu_peak_mem_enabled = True
+        if (type(model_flops) is str and model_flops.lower() == 'dcgm') or 'flops_dcgm' in metrics_needed:
+            model_analyzer.add_metric_gpu_flops()
+            model_flops='dcgm'
+        if 'cpu_peak_mem' in metrics_needed:
+            model_analyzer.add_metric_cpu_peak_mem()
+            cpu_peak_mem_enabled = True
         model_analyzer.start_monitor()
+
     if stress:
         cur_time = time.time_ns()
         start_time = cur_time
@@ -78,7 +91,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
     _i = 0
     last_it = 0
     first_print_out = True
-    while (not stress and _i < num_iter ) or (stress and cur_time < target_time ) :
+    while (not stress and _i < num_iter) or (stress and cur_time < target_time) :
         if args.device == "cuda":
             torch.cuda.synchronize()
             start_event = torch.cuda.Event(enable_timing=True)
@@ -113,20 +126,22 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
                     print('|{:^20}|{:^20}|{:^20}|'.format("Iterations", "Time/Iteration(ms)", "Rest Time(s)"))
                     first_print_out = False
                 est = (target_time - cur_time) / 1e9
-                time_per_it = (cur_time - last_time) / ( _i - last_it) / 1e6
+                time_per_it = (cur_time - last_time) / (_i - last_it) / 1e6
                 print('|{:^20}|{:^20}|{:^20}|'.format("%d" % _i, "%.2f" % time_per_it , "%d" % int(est)))
                 last_time = cur_time
                 last_it = _i
         _i += 1
-    if dcgm_enabled:
-            model_analyzer.stop_monitor()
+    if analyzer_enabled:
+        model_analyzer.stop_monitor()
 
     if args.device == "cuda":
         gpu_time = np.median(list(map(lambda x: x[0], result_summary)))
         cpu_walltime = np.median(list(map(lambda x: x[1], result_summary)))
         if hasattr(model, "NUM_BATCHES"):
-            print('{:<20} {:>20}'.format("GPU Time per batch:", "%.3f milliseconds" % (gpu_time / model.NUM_BATCHES), sep=''))
-            print('{:<20} {:>20}'.format("CPU Wall Time per batch:", "%.3f milliseconds" % (cpu_walltime / model.NUM_BATCHES), sep=''))
+            print('{:<20} {:>20}'.format("GPU Time per batch:", "%.3f milliseconds" %
+                  (gpu_time / model.NUM_BATCHES), sep=''))
+            print('{:<20} {:>20}'.format("CPU Wall Time per batch:", "%.3f milliseconds" %
+                  (cpu_walltime / model.NUM_BATCHES), sep=''))
         else:
             print('{:<20} {:>20}'.format("GPU Time:", "%.3f milliseconds" % gpu_time, sep=''))
             print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % cpu_walltime, sep=''))
@@ -134,17 +149,25 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
         cpu_walltime = np.median(list(map(lambda x: x[0], result_summary)))
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % cpu_walltime, sep=''))
 
+    if analyzer_enabled:
+        model_analyzer.aggregate()
+
     # if model_flops is not None, output the TFLOPs per sec
     if model_flops:
-        if dcgm_enabled:
-            model_analyzer.aggregate()
+        if analyzer_enabled:
             tflops = model_analyzer.calculate_flops()
-            if export_dcgm_metrics_file:
-                model_analyzer.export_all_records_to_csv()
         else:
             flops, batch_size = model_flops
             tflops = flops * batch_size / (cpu_walltime / 1.0e3) / 1.0e12
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
+    if gpu_peak_mem_enabled:
+        gpu_peak_mem = model_analyzer.calculate_gpu_peak_mem()
+        print('{:<20} {:>20}'.format("GPU Peak Memory:", "%.4f GB" % gpu_peak_mem, sep=''))
+    if cpu_peak_mem_enabled:
+        cpu_peak_mem = model_analyzer.calculate_cpu_peak_mem()
+        print('{:<20} {:>20}'.format("CPU Peak Memory:", "%.4f GB" % cpu_peak_mem, sep=''))
+    if export_dcgm_metrics_file:
+        model_analyzer.export_all_records_to_csv()
 
 
 def profile_one_step(func, nwarmup=WARMUP_ROUNDS):
@@ -219,7 +242,8 @@ if __name__ == "__main__":
     parser.add_argument("--profile-devices", type=_validate_devices,
                         help="Profiling comma separated list of activities such as cpu,cuda.")
     parser.add_argument("--profile-eg", action="store_true", help="Collect execution graph by PARAM")
-    parser.add_argument("--profile-eg-folder", default="./eg_logs", help="Save execution graph traces to this directory.")
+    parser.add_argument("--profile-eg-folder", default="./eg_logs",
+                        help="Save execution graph traces to this directory.")
     parser.add_argument("--cudastreams", action="store_true",
                         help="Utilization test using increasing number of cuda streams.")
     parser.add_argument("--bs", type=int, help="Specify batch size to the test.")
@@ -227,6 +251,8 @@ if __name__ == "__main__":
     parser.add_argument("--export-dcgm-metrics", action="store_true",
                         help="Export all GPU FP32 unit active ratio records to a csv file. The default csv file name is [model_name]_all_metrics.csv.")
     parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
+    parser.add_argument("--metrics", type=str,
+                        help="Specify metrics [cpu_peak_mem,gpu_peak_mem,flops_dcgm]to be collected. The metrics are separated by comma such as cpu_peak_mem,gpu_peak_mem.")
     args, extra_args = parser.parse_known_args()
 
     if args.cudastreams and not args.device == "cuda":
@@ -256,9 +282,18 @@ if __name__ == "__main__":
             from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
             if check_dcgm():
                 model_flops = 'dcgm'
+    metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
+    if 'gpu_peak_mem' in metrics_needed:
+        assert args.device == 'cuda', "gpu_peak_mem is only available for cuda device."
+        from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
+        if not check_dcgm():
+            print("DCGM is not installed. gpu_peak_mem is not available.")
+            exit(-1)
+
     if args.export_dcgm_metrics:
-        if not args.flops:
-            print("You have to specifiy --flops dcgm accompany with --export-dcgm-metrics")
+        if not args.flops and not args.metrics:
+            print(
+                "You have to specifiy --flops dcgm or --metrics metrics_needed accompany with --export-dcgm-metrics")
             exit(-1)
         export_dcgm_metrics_file = "%s_all_metrics.csv" % args.model
     else:
@@ -268,6 +303,7 @@ if __name__ == "__main__":
     elif args.cudastreams:
         run_one_step_with_cudastreams(test, 10)
     else:
-        run_one_step(test, model_flops=model_flops, model=m, export_dcgm_metrics_file=export_dcgm_metrics_file, stress=args.stress)
+        run_one_step(test, model_flops=model_flops, model=m, export_dcgm_metrics_file=export_dcgm_metrics_file,
+                     stress=args.stress, metrics_needed=metrics_needed)
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')


### PR DESCRIPTION
Add --metrics [cpu_peak_mem,gpu_peak_mem,flops_dcgm] to run.py. Users could specify different combinations of those three metrics such as --metrics cpu_peak_mem,gpu_peak_mem to obtain the peak memory usage for CPU and GPU. The output is like the following.
```
GPU Peak Memory:                2.4268 GB
CPU Peak Memory:                4.1475 GB
```