### PR TITLE
Move the reference model (for train correctness checks) to cpu before starting tests

### DIFF
--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -116,7 +116,8 @@ def correctness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim
                     found = True
                     # backward typically requires higher error margin.
                     # 400 times bigger may sound too big to be useful but still better than not checking at all.
-                    if not same(param_ref.grad, param.grad, cos_similarity=cos_sim, atol=atol*40, rtol=rtol*40):
+                    # param_ref has already been copied to cpu, so move param.grad to CPU as well
+                    if not same(param_ref.grad, param.grad.cpu(), cos_similarity=cos_sim, atol=atol*40, rtol=rtol*40):
                         print(f"grad of param {name} after running with dynamo doesn't have gradient matching with eager mode")
                         return False
                     break

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -125,7 +125,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                     else:
                         copy_model = self
                     copy_model.invoke()
-                    self.eager_model_after_one_train_iteration = copy_model.model
+                    # move copy_model.model to CPU to avoid CUDA OOM during tests on the actual model.
+                    self.eager_model_after_one_train_iteration = copy_model.model.cpu()
                 except RuntimeError:
                     warnings.warn(UserWarning("Can't copy the model. Skipping train correctness check."))
                 if opt_saved:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1275

On some OSS models we see CUDA OOM if we enable train correctness checks.

For certain models, we can prevent this OOM by copying the reference model to CPU before running the tests.