### PR TITLE
Allow passing in batch_size as an argument to distributed trainer

### DIFF
--- a/torchbenchmark/util/distributed/core_model/trainer.py
+++ b/torchbenchmark/util/distributed/core_model/trainer.py
@@ -30,9 +30,11 @@ class Trainer():
         ]
         extra_args.extend(model_args)
 
+        batch_size = args.batch_size if hasattr(args, "batch_size") else None
+
         # create model instance after Trainer setup, so that
         # visible devices won't be revised in model constructor
-        self.benchmark: BenchmarkModel = model_class(test="train", device="cuda", batch_size=None, extra_args=extra_args)
+        self.benchmark: BenchmarkModel = model_class(test="train", device="cuda", batch_size=batch_size, extra_args=extra_args)
 
         self.rank = dist.get_rank()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1276

Previously there was no way to specify batch size. Now you can provide
args.batch_size.

Differential Revision: [D40966420](https://our.internmc.facebook.com/intern/diff/D40966420)