### PR TITLE
Parse opt_args even when dynamo is used

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -15,7 +15,7 @@ def parse_torchdynamo_args(
 ) -> argparse.Namespace:
     # pass in `namespace` arg to add to an existing argparse.Namespace object
 
-    parser = argparse.ArgumentParser(namespace=namespace)
+    parser = argparse.ArgumentParser()
     available_backends = torchdynamo.list_backends()
     parser.add_argument(
         "--torchdynamo", choices=available_backends, help="Specify torchdynamo backends"
@@ -33,7 +33,7 @@ def parse_torchdynamo_args(
         type=distutils.util.strtobool,
         default="true",
     )
-    args, extra_args = parser.parse_known_args(dynamo_args)
+    args, extra_args = parser.parse_known_args(dynamo_args, namespace=namespace)
     return args, extra_args
 
 def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace, precision: str):

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -4,7 +4,7 @@ Support TorchDynamo(https://github.com/facebookresearch/torchdynamo) backends
 import argparse
 import contextlib
 import distutils.util
-from typing import List
+from typing import List, Optional
 import torch._dynamo as torchdynamo
 from torchbenchmark.util.model import is_staged_train_test
 

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -8,8 +8,14 @@ from typing import List
 import torch._dynamo as torchdynamo
 from torchbenchmark.util.model import is_staged_train_test
 
-def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dynamo_args: List[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
+def parse_torchdynamo_args(
+    model: 'torchbenchmark.util.model.BenchmarkModel',
+    dynamo_args: List[str],
+    namespace: Optional[argparse.Namespace] = None
+) -> argparse.Namespace:
+    # pass in `namespace` arg to add to an existing argparse.Namespace object
+
+    parser = argparse.ArgumentParser(namespace=namespace)
     available_backends = torchdynamo.list_backends()
     parser.add_argument(
         "--torchdynamo", choices=available_backends, help="Specify torchdynamo backends"

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -96,14 +96,15 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
         # parse the args
         self.dargs, opt_args = parse_decoration_args(self, self.extra_args)
+        self.opt_args, self.extra_args = parse_opt_args(self, opt_args)
+
         # if the args contain "--torchdynamo", parse torchdynamo args
         if "--torchdynamo" in opt_args:
             self.dynamo = True
             from torchbenchmark.util.backends.torchdynamo import parse_torchdynamo_args
-            self.opt_args, self.extra_args = parse_torchdynamo_args(self, opt_args)
+            self.opt_args, self.extra_args = parse_torchdynamo_args(self, self.extra_args, namespace=self.opt_args)
         else:
             self.dynamo = False
-            self.opt_args, self.extra_args = parse_opt_args(self, opt_args)
 
     # Run the post processing for model acceleration
     def __post__init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1278

Previously we had two versions of opt_args - one generated by dynamo and
one generated by the non-dynamo path. If we add this change, then we'll
be able to add arguments into opt_args that we would like to use in both
dynamo and non-dynamo contexts

Differential Revision: [D41008361](https://our.internmc.facebook.com/intern/diff/D41008361)