### PR TITLE
Suppress `pretrained` warnings from torchvision

### DIFF
--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -10,4 +11,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
         super().__init__(model_name="alexnet", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.AlexNet_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/densenet121/__init__.py
+++ b/torchbenchmark/models/densenet121/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -10,4 +11,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="densenet121", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.DenseNet121_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/mnasnet1_0/__init__.py
+++ b/torchbenchmark/models/mnasnet1_0/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="mnasnet1_0", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.MNASNet1_0_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/mobilenet_v2/__init__.py
+++ b/torchbenchmark/models/mobilenet_v2/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="mobilenet_v2", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.MobileNet_V2_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/mobilenet_v3_large/__init__.py
+++ b/torchbenchmark/models/mobilenet_v3_large/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,4 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="mobilenet_v3_large", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.MobileNet_V3_Large_Weights.IMAGENET1K_V1, extra_args=extra_args)

--- a/torchbenchmark/models/resnet152/__init__.py
+++ b/torchbenchmark/models/resnet152/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="resnet152", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.ResNet152_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/resnet18/__init__.py
+++ b/torchbenchmark/models/resnet18/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="resnet18", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.ResNet18_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/resnet50/__init__.py
+++ b/torchbenchmark/models/resnet50/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="resnet50", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.ResNet50_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/resnext50_32x4d/__init__.py
+++ b/torchbenchmark/models/resnext50_32x4d/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="resnext50_32x4d", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.ResNeXt50_32X4D_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -8,4 +9,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="shufflenet_v2_x1_0", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.ShuffleNet_V2_X1_0_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/models/squeezenet1_1/__init__.py
+++ b/torchbenchmark/models/squeezenet1_1/__init__.py
@@ -2,6 +2,7 @@ from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
 import torch.optim as optim
 import torch
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -14,7 +15,8 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="squeezenet1_1", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.SqueezeNet1_1_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)
         self.epoch_size = 16
 
     def train(self):

--- a/torchbenchmark/models/vgg16/__init__.py
+++ b/torchbenchmark/models/vgg16/__init__.py
@@ -1,5 +1,6 @@
 from torchbenchmark.util.framework.vision.model_factory import TorchVisionModel
 from torchbenchmark.tasks import COMPUTER_VISION
+import torchvision.models as models
 
 class Model(TorchVisionModel):
     task = COMPUTER_VISION.CLASSIFICATION
@@ -12,4 +13,5 @@ class Model(TorchVisionModel):
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="vgg16", test=test, device=device, jit=jit,
-                         batch_size=batch_size, extra_args=extra_args)
+                         batch_size=batch_size, weights=models.VGG16_Weights.IMAGENET1K_V1,
+                         extra_args=extra_args)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -15,12 +15,15 @@ class TorchVisionModel(BenchmarkModel):
     # Default eval precision on CUDA device is fp16
     DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 
-    def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
+    def __init__(self, model_name, test, device, jit=False, batch_size=None, weights=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         torch.backends.cudnn.deterministic = False
         torch.backends.cudnn.benchmark = False
 
-        self.model = getattr(models, model_name)(pretrained=True).to(self.device)
+        if weights is None:
+            self.model = getattr(models, model_name)(pretrained=True).to(self.device)
+        else:
+            self.model = getattr(models, model_name)(weights=weights).to(self.device)
         self.example_inputs = (torch.randn((self.batch_size, 3, 224, 224)).to(self.device),)
         if test == "train":
             self.example_outputs = torch.rand_like(self.model(*self.example_inputs))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1280
* #1279

Torchvision has deprecated the `pretrained=...` in favor for `weights=WEIGHTS_ENUM`

Before:
```
  warnings.warn(
/data/users/dberard/vision/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
/data/users/dberard/vision/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=VGG16_Weights.IMAGENET1K_V1`. You can also use `weights=VGG16_Weights.DEFAU LT` to get the most up-to-date weights.
```

Differential Revision: [D41098357](https://our.internmc.facebook.com/intern/diff/D41098357)