### PR TITLE
[ddp+dynamo] use cpus_per_task=12 instead of 10

### DIFF
--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -321,7 +321,7 @@ def main():
         gpus_per_node=args.ngpus,
         # one task per GPU
         tasks_per_node=args.ngpus,
-        cpus_per_task=10,
+        cpus_per_task=12,
         nodes=args.nodes,
         timeout_min=args.timeout,
         # Below are cluster dependent parameters
@@ -414,7 +414,7 @@ def main():
         gpus_per_node=args.ngpus,
         # one task per GPU
         tasks_per_node=args.ngpus,
-        cpus_per_task=10,
+        cpus_per_task=12,
         nodes=allocation_nodes,
         timeout_min=args.timeout,
         # Below are cluster dependent parameters


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1281

AWS cluster has machines with 96 cpus and 8 gpus, so 12 cpus per task
means we use all the CPUs.

I suspect that we were running into issues with bad CPU affinity when we
had 10 cpus_per_task, because often the 4th rank would be slower than
the other ranks.

Differential Revision: [D41016736](https://our.internmc.facebook.com/intern/diff/D41016736)