### PR TITLE
add nvml monitor

### DIFF
--- a/components/model_analyzer/dcgm/nvml_monitor.py
+++ b/components/model_analyzer/dcgm/nvml_monitor.py
@@ -17,7 +17,7 @@ from . import dcgm_fields
 from . import dcgm_field_helpers
 from . import dcgm_structs as structs
 
-import pynvml
+
 
 
 class NVMLMonitor(Monitor):
@@ -47,6 +47,7 @@ class NVMLMonitor(Monitor):
         """
 
         super().__init__(frequency, metrics)
+        import pynvml
         self._nvml = pynvml
         self._nvml.nvmlInit()
         self._metrics = metrics
@@ -75,7 +76,7 @@ class NVMLMonitor(Monitor):
                 atimestamp = time.time_ns()
                 if metric == GPUPeakMemory:
                     info = self._nvml.nvmlDeviceGetMemoryInfo(handle)
-                    # @Yueming TODO: need to update with the latest nvml API
+                    # @Yueming TODO: need to update with the nvml API version 2. Because the nvml API version 1 returns the used memory including the memory allocated by the GPU driver.
                     # used_mem = info.used
                     # reserved_mem = info.reserved
                     # self._records[gpu][metric].append((atimestamp, used_mem - reserved_mem))

--- a/components/model_analyzer/dcgm/nvml_monitor.py
+++ b/components/model_analyzer/dcgm/nvml_monitor.py
@@ -1,0 +1,104 @@
+import time
+from .monitor import Monitor
+from ..tb_dcgm_types.gpu_free_memory import GPUFreeMemory
+from ..tb_dcgm_types.gpu_tensoractive import GPUTensorActive
+from ..tb_dcgm_types.gpu_peak_memory import GPUPeakMemory
+from ..tb_dcgm_types.gpu_utilization import GPUUtilization
+from ..tb_dcgm_types.gpu_power_usage import GPUPowerUsage
+from ..tb_dcgm_types.gpu_fp32active import GPUFP32Active
+from ..tb_dcgm_types.gpu_dram_active import GPUDRAMActive
+from ..tb_dcgm_types.gpu_pcie_rx import GPUPCIERX
+from ..tb_dcgm_types.gpu_pcie_tx import GPUPCIETX
+from ..tb_dcgm_types.da_exceptions import TorchBenchAnalyzerException
+
+
+from . import dcgm_agent
+from . import dcgm_fields
+from . import dcgm_field_helpers
+from . import dcgm_structs as structs
+
+import pynvml
+
+
+class NVMLMonitor(Monitor):
+    """
+    Use NVML to monitor GPU metrics
+    """
+
+    # Mapping between the NVML Fields and Model Analyzer Records
+    # For more explainations, please refer to https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html
+    model_analyzer_to_nvml_field = {
+        GPUPeakMemory: "used",
+        GPUFreeMemory: "free",
+        GPUUtilization: "utilization.gpu",
+        GPUPowerUsage: "power.draw",
+    }
+
+    def __init__(self, gpus, frequency, metrics):
+        """
+        Parameters
+        ----------
+        gpus : list of GPUDevice
+            The gpus to be monitored
+        frequency : int
+            Sampling frequency for the metric
+        metrics : list
+            List of Record types to monitor
+        """
+
+        super().__init__(frequency, metrics)
+        self._nvml = pynvml
+        self._nvml.nvmlInit()
+        self._metrics = metrics
+        # raw records: {gpu: {field: [(timestamp, value), ...]}}
+        self._records = {}
+        self._gpus = gpus
+        # gpu handles: {gpu: handle}
+        self._gpu_handles = {}
+        for gpu in self._gpus:
+            self._gpu_handles[gpu] = self._nvml.nvmlDeviceGetHandleByUUID(gpu.device_uuid())
+            self._records[gpu] = {}
+            for metric in self._metrics:
+                self._records[gpu][metric] = []
+
+    def _monitoring_iteration(self):
+        self._get_gpu_metrics()
+
+    def _get_gpu_metrics(self):
+        """
+        Get the metrics of all the GPUs
+        """
+        for gpu in self._gpus:
+            handle = self._nvml.nvmlDeviceGetHandleByUUID(gpu.device_uuid())
+            for metric in self._metrics:
+                nvml_field = self.model_analyzer_to_nvml_field[metric]
+                atimestamp = time.time_ns()
+                if metric == GPUPeakMemory:
+                    info = self._nvml.nvmlDeviceGetMemoryInfo(handle)
+                    # @Yueming TODO: need to update with the latest nvml API
+                    # used_mem = info.used
+                    # reserved_mem = info.reserved
+                    # self._records[gpu][metric].append((atimestamp, used_mem - reserved_mem))
+                    self._records[gpu][metric].append((atimestamp, float(getattr(info, nvml_field)/1024/1024)))
+                elif metric == GPUFreeMemory:
+                    info = self._nvml.nvmlDeviceGetMemoryInfo(handle)
+                    self._records[gpu][metric].append((atimestamp, float(getattr(info, nvml_field)/1024/1024)))
+                elif metric == GPUUtilization:
+                    info = self._nvml.nvmlDeviceGetUtilizationRates(handle)
+                    self._records[gpu][metric].append((atimestamp, getattr(info, nvml_field)))
+                elif metric == GPUPowerUsage:
+                    info = self._nvml.nvmlDeviceGetPowerUsage(handle)
+                    self._records[gpu][metric].append((atimestamp, info))
+
+    def _collect_records(self):
+        records = []
+        for gpu in self._gpus:
+            for metric_type in self._metrics:
+                for measurement in self._records[gpu][metric_type]:
+                    records.append(metric_type(value=float(measurement[1]),
+                                   timestamp=measurement[0], device_uuid=gpu.device_uuid()))
+        return records
+    
+    def destroy(self):
+        self._nvml.nvmlShutdown()
+        super().destroy()

--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 from numba.cuda.cudadrv import enums
+# @Yueming Hao: TODO: Replace this with nvml API
 from numba import cuda
 from .da_exceptions import TorchBenchAnalyzerException
 

--- a/run.py
+++ b/run.py
@@ -82,7 +82,7 @@ def printResultSummaryTime(result_summary, model_flops=None, model=None, model_a
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
 
 
-def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_dcgm_metrics_file=False, stress=0, metrics_needed=[]):
+def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, model=None, export_dcgm_metrics_file=False, stress=0, metrics_needed=[], metrics_gpu_backend=None):
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
         func()
@@ -105,6 +105,8 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, model_flops=None, num_iter=10, mod
         if 'cpu_peak_mem' in metrics_needed:
             model_analyzer.add_metric_cpu_peak_mem()
             cpu_peak_mem_enabled = True
+        if metrics_gpu_backend == "nvml":
+            model_analyzer.set_gpu_monitor_backend_nvml()
         model_analyzer.start_monitor()
 
     if stress:
@@ -267,6 +269,7 @@ if __name__ == "__main__":
     parser.add_argument("--stress", type=float, default=0, help="Specify execution time (seconds) to stress devices.")
     parser.add_argument("--metrics", type=str,
                         help="Specify metrics [cpu_peak_mem,gpu_peak_mem,flops_dcgm]to be collected. The metrics are separated by comma such as cpu_peak_mem,gpu_peak_mem.")
+    parser.add_argument("--metrics-gpu-backend", type=str, default="dcgm", choices=["dcgm", "nvml"], help="Specify the backend to collect GPU metrics.")
     args, extra_args = parser.parse_known_args()
 
     if args.cudastreams and not args.device == "cuda":
@@ -299,10 +302,16 @@ if __name__ == "__main__":
     metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
     if 'gpu_peak_mem' in metrics_needed:
         assert args.device == 'cuda', "gpu_peak_mem is only available for cuda device."
-        from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
-        if not check_dcgm():
-            print("DCGM is not installed. gpu_peak_mem is not available.")
-            exit(-1)
+        if args.metrics_gpu_backend == 'dcgm':
+            from components.model_analyzer.TorchBenchAnalyzer import check_dcgm
+            if not check_dcgm():
+                print("DCGM initialization failed. gpu_peak_mem is not available.")
+                exit(-1)
+        elif args.metrics_gpu_backend == 'nvml':
+            from components.model_analyzer.TorchBenchAnalyzer import check_nvml
+            if not check_nvml():
+                print("NVML initialization failed. gpu_peak_mem is not available.")
+                exit(-1)
 
     if args.export_dcgm_metrics:
         if not args.flops and not args.metrics:
@@ -318,6 +327,6 @@ if __name__ == "__main__":
         run_one_step_with_cudastreams(test, 10)
     else:
         run_one_step(test, model_flops=model_flops, model=m, export_dcgm_metrics_file=export_dcgm_metrics_file,
-                     stress=args.stress, metrics_needed=metrics_needed)
+                     stress=args.stress, metrics_needed=metrics_needed, metrics_gpu_backend=args.metrics_gpu_backend)
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')


### PR DESCRIPTION
For machines without DCGM installed, we can use [NVIDIA NVML APIs](https://developer.nvidia.com/nvidia-management-library-nvml) to obtain GPU peak memory usage. The runtime version of NVML ships with the NVIDIA display driver, and the SDK provides the appropriate header, stub libraries and sample applications. 

You can use  `pip install nvidia-ml-py` to install the required package.

I add `--metrics-gpu-backend` to let users switch the metrics collection backend between `dcgm` and `nvml`. 