### PR TITLE
Fix e2e hf_bert model

### DIFF
--- a/torchbenchmark/e2e_models/hf_bert/__init__.py
+++ b/torchbenchmark/e2e_models/hf_bert/__init__.py
@@ -8,7 +8,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.utils.data import DataLoader
 from torchbenchmark.util.e2emodel import E2EBenchmarkModel
 from torchbenchmark.tasks import NLP
-from datasets import load_metric
+import evaluate
 from accelerate import Accelerator
 from transformers import (
     AdamW,
@@ -193,9 +193,9 @@ class Model(E2EBenchmarkModel):
         # Steup metrics
         # Get the metric function
         if hf_args.task_name is not None:
-            self.metric = load_metric("glue", hf_args.task_name)
+            self.metric = evaluate.load("glue", hf_args.task_name)
         else:
-            self.metric = load_metric("accuracy")
+            self.metric = evaluate.load("accuracy")
         # Setup class members
         self.hf_args = hf_args
         self.is_regression = is_regression

--- a/torchbenchmark/e2e_models/hf_bert/requirements.txt
+++ b/torchbenchmark/e2e_models/hf_bert/requirements.txt
@@ -5,3 +5,4 @@ scipy
 scikit-learn
 protobuf
 torch
+evaluate

--- a/torchbenchmark/util/framework/transformers/text_classification/args.py
+++ b/torchbenchmark/util/framework/transformers/text_classification/args.py
@@ -25,7 +25,7 @@ def parse_torchbench_args(extra_args):
     # use fp16 mixed precision by default
     parser.add_argument("--fp16", default="amp", choices=["amp", "no"], help="Enable mixed precision")
     parser.add_argument(
-        "--distributed", default="ddp", choices=["ddp", "fsdp", "deepspeed", "none"],
+        "--distributed", default="none", choices=["ddp", "fsdp", "deepspeed", "none"],
         help="distributed training paradigm, by default using DDP"
     )
     tb_args = parser.parse_args(extra_args)


### PR DESCRIPTION
We need to fix hf_bert model to adapt to code changes in upstream and distributed.


Test plan:

```
$ python run_e2e.py hf_bert -t train
{"device": "cuda", "device_num": 1, "test": "train", "num_examples": 8576, "batch_size": 32, "result": {"latency": 5.36891676, "qps": 1597.3427012118548}}
```

```
$ python run_e2e.py hf_bert -t eval
{"device": "cuda", "device_num": 1, "test": "eval", "num_examples": 1043, "batch_size": 1, "result": {"latency": 13.123098491999999, "qps": 79.47818121123038}}
```

Fixes https://github.com/pytorch/benchmark/issues/1289