### PR TITLE
[ddp+dynamo] Add distributed correctness checks

### DIFF
--- a/torchbenchmark/util/distributed/core_model/trainer.py
+++ b/torchbenchmark/util/distributed/core_model/trainer.py
@@ -2,11 +2,14 @@ from datetime import datetime
 import os
 from pathlib import Path
 from statistics import stdev
+from typing import Optional
 
+import time
 import numpy as np
 import torch
 from torch.cuda import Event
 from torch.profiler import profile, ProfilerActivity, schedule, tensorboard_trace_handler
+from torchbenchmark.util.env_check import same
 from torchbenchmark.util.model import BenchmarkModel
 import torch.distributed as dist
 
@@ -21,6 +24,7 @@ class Trainer():
         self.mode = mode
 
         self.local_rank = int(os.getenv("LOCAL_RANK", -1))
+        self.global_rank = int(os.getenv("RANK", -1))
         self.setup()
 
         # specify the name of the distributed trainer
@@ -35,6 +39,14 @@ class Trainer():
         # create model instance after Trainer setup, so that
         # visible devices won't be revised in model constructor
         self.benchmark: BenchmarkModel = model_class(test="train", device="cuda", batch_size=batch_size, extra_args=extra_args)
+
+        # options: "reference" or "test"
+        self.check_correctness_distributed : Optional[str] = getattr(args, "check_correctness_distributed", None)
+        self.reference_data_path : Optional[str] = getattr(args, "reference_data_path", None)
+
+        # reduce iterations to speed up the tests
+        if self.check_correctness_distributed:
+            self.DEFAULT_MEASURE_ITERATIONS = 2
 
         self.rank = dist.get_rank()
 
@@ -74,6 +86,42 @@ class Trainer():
 
     def measure(self):
         niters = self.DEFAULT_MEASURE_ITERATIONS
+
+        correctness = None
+        if self.check_correctness_distributed is not None:
+            self.benchmark.invoke()
+            if self.global_rank == 0:
+                grad_params = {}
+                for name, param in self.benchmark.model.named_parameters():
+                    if param.requires_grad:
+                        grad_params[name + ".grad"] = param.grad.cpu()
+
+                if self.check_correctness_distributed == "reference":
+                    with open(self.reference_data_path, "wb") as f:
+                        torch.save(grad_params, f)
+                elif self.check_correctness_distributed == "test":
+                    with open(self.reference_data_path, "rb") as f:
+                        ref_params = torch.load(f)
+
+                    def do_correctness_check():
+                        correctness = True
+                        for ref_name, ref_param in ref_params.items():
+                            if ref_name not in grad_params:
+                                correctness = False
+                                print(f"correctness failure: {ref_name} in reference params but not in test params")
+                            test_param = grad_params[ref_name]
+                            atol = rtol = 1e-4
+                            if not same(test_param, ref_param, cos_similarity=False, atol=atol*40, rtol=rtol*40):
+                                correctness=False
+                                print(f"correctness failure: Test model differs from reference model in parameter: {ref_name}")
+
+                        for test_name, test_param in grad_params.items():
+                            if test_name not in ref_params:
+                                correctness = False
+                                print(f"correctness failure: {test_name} in reference params but not in ref params")
+                        return correctness
+
+                    correctness = do_correctness_check()
 
         ######################################
         # 1. warming up CUDACachingAllocator #
@@ -136,6 +184,7 @@ class Trainer():
         return {
             "latency_median" : median_latency,
             "latency_stdev" : stdev_latency,
+            **({"correctness": correctness} if correctness is not None else {}),
         }
 
 

--- a/torchbenchmark/util/distributed/core_model/trainer.py
+++ b/torchbenchmark/util/distributed/core_model/trainer.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from statistics import stdev
 from typing import Optional
 
-import time
 import numpy as np
 import torch
 from torch.cuda import Event

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -123,7 +123,6 @@ class BenchmarkModel(metaclass=PostInitProcessor):
     def __post__init__(self):
         should_check_correctness = check_correctness_p(self, self.opt_args, self.dargs)
         if should_check_correctness:
-            print("CORRECTNESS CHECK dberard")
             self.eager_output = stableness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY, rounds=1)
             if isinstance(self.eager_output, Tuple):
                 self.eager_output = tuple((t.detach() if isinstance(t, torch.Tensor) else t) for t in self.eager_output)

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -91,6 +91,20 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         self.run_contexts = [
             enable_profiling_executor  # force JIT profiling executor to be enabled by default
         ]
+
+        # taken from torchdynamo benchmarks, this further controls randomness settings
+        def deterministic_torch_manual_seed(*args, **kwargs):
+            from torch._C import default_generator
+
+            seed = 1337
+            import torch.cuda
+
+            if not torch.cuda._is_in_bad_fork():
+                torch.cuda.manual_seed_all(seed)
+
+            return default_generator.manual_seed(seed)
+
+        torch.manual_seed = deterministic_torch_manual_seed
         set_random_seed()
         # sanity checks of the options
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
@@ -107,8 +121,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
 
     # Run the post processing for model acceleration
     def __post__init__(self):
-        should_check_correctness = check_correctness_p(self, self.opt_args)
+        should_check_correctness = check_correctness_p(self, self.opt_args, self.dargs)
         if should_check_correctness:
+            print("CORRECTNESS CHECK dberard")
             self.eager_output = stableness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY, rounds=1)
             if isinstance(self.eager_output, Tuple):
                 self.eager_output = tuple((t.detach() if isinstance(t, torch.Tensor) else t) for t in self.eager_output)
@@ -138,6 +153,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             apply_torchdynamo_args(self, self.opt_args, self.dargs.precision)
         else:
             apply_opt_args(self, self.opt_args, self.extra_args)
+        if self.dargs.move_train_models_to_eval:
+            self.model.eval()
         if should_check_correctness:
             # tensorrt or fp16 is known to generate less-accurate results
             # in this case, use more relaxed cosine similarity instead of torch.allclose

--- a/userbenchmark/ddp_experiments/README.md
+++ b/userbenchmark/ddp_experiments/README.md
@@ -58,3 +58,4 @@ Supported options (not-exhaustive):
 * `--trainer torchbenchmark.util.distributed.core_model.trainer.Trainer` to select the trainer (e.g. can use e2e trainer)
 * `--timeout {minutes}` to reduce/increase time slurm job timeout
 * `--partition {train|scavenge|etc}` to choose the slurm job queue
+* `--check_correctness_distributed` will perform correctness checks. The results will be dumped into the stdout log files and also the final pickled result logs. See the stdout logs from rank 0 if you want to investigate what specific logs are failing. The check is implemented in torchbenchmark/util/distributed/core_models/trainer.py.

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -123,6 +123,11 @@ def parse_args(args: List[str]=None):
         default=1,
         help="number of times to repeat the experiments",
     )
+    parser.add_argument(
+        "--check_correctness_distributed",
+        action='store_true',
+        help="Do distributed correctness checks. Don't expect to use the same results for performance tests."
+    )
 
 
     try:
@@ -172,6 +177,20 @@ class FileBarrier:
 
 
 @dataclasses.dataclass
+class ExperimentParams:
+    config: Dict
+    args: Any  # arguments to the distributed trainer
+    model_args: Any  # arguments to the model
+    is_reference: bool  # should this experiment be treated as a reference for correctness?
+
+
+# used for labeling filenames for correctness checks
+def serialize_config(config: Dict):
+    keys = ["nodes", "model_name", "backend", "has_breaks"]
+    return "-".join([f"{k}_{config[k]}" for k in keys])
+
+
+@dataclasses.dataclass
 class JobConfig:
     outer_sync_path: str
 
@@ -181,7 +200,7 @@ class TrainerWrapper(object):
     # Each experiment should be a tuple of (config dict, args, model_args).
     # config: configuration data to attach to the result dict.
     # args & model_args: arguments for core_model.Trainer.
-    def __init__(self, job_config: JobConfig, per_experiment_args: List[Tuple[Dict, Any, Any]]):
+    def __init__(self, job_config: JobConfig, per_experiment_args: List[ExperimentParams]):
         self.job_config = job_config
         self.per_experiment_args = per_experiment_args
         self.timeout = timedelta(45)
@@ -210,8 +229,39 @@ class TrainerWrapper(object):
         job_env = submitit.JobEnvironment()
         barrier = self._get_barrier()
         print(f"This is node {job_env.node}")
-        for (config, args, model_args) in self.per_experiment_args:
+
+        # maps all configs that are expected to have the same output/gradients to the same value.
+        # i.e. we should expect that for a given model_name & number of nodes, we should get the same
+        #      outputs and gradients, regardless of the backend/has_breaks/etc.
+        def reference_key(config):
+            return f"{config['model_name']}-{config['nodes']}"
+        latest_reference_file = {}
+
+        output_dir = self.per_experiment_args[0].args.output_dir
+        base_ref_name = Path(output_dir) / uuid.uuid4().hex
+
+        for experiment_args in self.per_experiment_args:
+            config = experiment_args.config
+            args = experiment_args.args
+            model_args = experiment_args.model_args
+            is_reference = experiment_args.is_reference
             try:
+                key = reference_key(config)
+
+                if args.check_correctness_distributed:
+                    # if this is a reference, dump the gradients into a file for later use.
+                    # if this is not a reference, read the dumped gradients and compare.
+                    if is_reference:
+                        args.check_correctness_distributed = "reference"
+                        args.reference_data_path = f"{base_ref_name}-{serialize_config(config)}"
+                        latest_reference_file[key] = args.reference_data_path
+                    else:
+                        args.check_correctness_distributed = "test"
+                        args.reference_data_path = latest_reference_file[key] if key in latest_reference_file else None
+                else:
+                    args.check_correctness_distributed = None
+
+
                 if job_env.node >= args.nodes:
                     continue
                 result_dict = {**config}
@@ -288,6 +338,10 @@ class TrainerWrapper(object):
             timeout=self.timeout
         )
 
+    def _global_rank(self):
+        job_env = submitit.JobEnvironment()
+        return job_env.global_rank
+
     def _setup_gpu_args(self, args):
         job_env = submitit.JobEnvironment()
         args.output_dir = Path(str(args.output_dir).replace("%j", str(job_env.job_id)))
@@ -363,6 +417,7 @@ def main():
         'torchbenchmark.models.hf_T5.Model': 12,
         'torchbenchmark.models.resnet50.Model': 32,
     }
+    # put eager first to ensure it can be used for reference values.
     model_args_configs = [
         [],  # no args = pure eager baseline
         # ["--torchdynamo", "eager"],  # runs dynamo without a backend
@@ -386,6 +441,7 @@ def main():
                         backend_name = get_backend_name(model_args)
                         if backend_name == "eager" and has_breaks:
                             continue
+                        is_reference = (backend_name == "eager")
                         # copy the model args so we can add more arguments without modifying
                         # the original model_args list.
                         copied_model_args = copy.copy(model_args)
@@ -394,6 +450,13 @@ def main():
                             copied_model_args.append("--optimize_dynamo_ddp")
                         if "inductor" in backend_name:
                             copied_model_args.extend(["--torchinductor_cudagraph", "False"])
+
+                        # skip non-distributed correctness checks to avoid extra iterations which can
+                        # interfere with distributed correctness checks.
+                        copied_model_args.append("--skip_correctness")
+                        if args.check_correctness_distributed:
+                            copied_model_args.append("--move_train_models_to_eval")
+
                         batch_size = model_batch_size[model_name]
                         args_copy = copy.deepcopy(args)
                         args_copy.model = model_name
@@ -407,7 +470,7 @@ def main():
                             "backend": backend_name,
                             "has_breaks": has_breaks,
                         }
-                        experiments.append((config, args_copy, copied_model_args))
+                        experiments.append(ExperimentParams(config, args_copy, copied_model_args, is_reference))
 
     allocation_nodes = max(node_list)
     executor.update_parameters(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1304
* __->__ #1294

DDP+Dynamo experiments run in different processes, and DDP also occurs after the general correctness check - so they need to be handled separately.

Process:
1) When setting up the measurements in `ddp_experiments/__init__.py`, categorize some measurements as "reference" (e.g. the eager measurements) and others as "test". Also assign a file path.
2) For reference measurements, do an initial correctness measurement and dump the results into a file. For test measurements, load the reference measurements from the file and compare the initial correctness measurements.
3) Make sure to run the correctness measurement on all ranks, even if we're only doing the correctness check on rank 0.
4) Make sure to disable non-distributed correctness checks to avoid an additional iteration that might affect dynamo and eager parameters differently.

Currently hf_T5, hf_T5_large, hf_Bert, hf_GPT2_large, and timm_vision_transformer are passing; ~resnet50 is failing. Still investigating the resnet50 issue.~ resnet50 is also failing correctness with `python run.py resnet50 -t train -d cuda --torchdynamo inductor`, so this isn't a DDP-specific problem.

Usage:
```
python userbenchmark/ddp_experiments/__init__.py --job_dir /fsx/path/to/dir/shared/across/cluster --check_correctness_distributed
```

i.e. adding --check_correctness_distributed will add correctness checks. Note that the correctness checks here shouldn't be used if you care about performance; we modify the models with model.eval() to get rid of dropouts, so it's not representative of actual performance. Since we probably don't care about performance anyway when using this option, we also reduce the number of iterations to speed up the test time.

Differential Revision: [D41312110](https://our.internmc.facebook.com/intern/diff/D41312110)