### PR TITLE
import torch._inductor.config instead of torch._inductor

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -35,13 +35,14 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         dynamo_optimizer = torchdynamo.optimize(torchdynamo.optimizations.backends.fx2trt_compiler_fp16)
     else:
         dynamo_optimizer = torchdynamo.optimize(args.torchdynamo)
+
+    import torch._inductor.config
     # Setup torchinductor.config.triton.mm
     if args.tritonmm == "triton":
-        import torch._inductor.config
         torch._inductor.config.triton.mm = "triton"
         # currently can't pass correctness with use_bmm = True
         # torchinductor.config.triton.use_bmm = True
-    import torch._inductor.config
+
     torch._inductor.config.triton.cudagraphs = bool(args.torchinductor_cudagraph)
 
     if model.test == "train":

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -37,12 +37,12 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
         dynamo_optimizer = torchdynamo.optimize(args.torchdynamo)
     # Setup torchinductor.config.triton.mm
     if args.tritonmm == "triton":
-        import torch._inductor as torchinductor
-        torchinductor.config.triton.mm = "triton"
+        import torch._inductor.config
+        torch._inductor.config.triton.mm = "triton"
         # currently can't pass correctness with use_bmm = True
         # torchinductor.config.triton.use_bmm = True
-    import torch._inductor as torchinductor
-    torchinductor.config.triton.cudagraphs = bool(args.torchinductor_cudagraph)
+    import torch._inductor.config
+    torch._inductor.config.triton.cudagraphs = bool(args.torchinductor_cudagraph)
 
     if model.test == "train":
         if is_staged_train_test(model):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1300

Not really sure why this is needed, but for non-inductor dynamo backends the `triton.cudagraphs` update setting was failing without this update.

Differential Revision: [D41244610](https://our.internmc.facebook.com/intern/diff/D41244610)