### PR TITLE
Dynamo option to disable() optimizer.step

### DIFF
--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -64,13 +64,13 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
     if bool(args.dynamo_disable_optimizer_step):
         found_optimizer_step = False
         try:
-            torch._dynamo.disallow_in_graph(model.cfg.optimizer.step)
+            model.cfg.optimizer.step = torch._dynamo.disable(model.cfg.optimizer.step)
             found_optimizer_step = True
         except AttributeError:
             pass
 
         try:
-            torch._dynamo.disallow_in_graph(model.optimizer.step)
+            model.optimizer.step = torch._dynamo.disable(model.optimizer.step)
             found_optimizer_step = True
         except AttributeError:
             pass

--- a/torchbenchmark/util/backends/torchdynamo.py
+++ b/torchbenchmark/util/backends/torchdynamo.py
@@ -5,8 +5,10 @@ import argparse
 import contextlib
 import distutils.util
 from typing import List
+import torch
 import torch._dynamo as torchdynamo
 from torchbenchmark.util.model import is_staged_train_test
+import warnings
 
 def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dynamo_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -32,6 +34,11 @@ def parse_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', dy
         type=distutils.util.strtobool,
         default="false",
     )
+    parser.add_argument(
+        "--dynamo_disable_optimizer_step",
+        type=distutils.util.strtobool,
+        default="false",
+    )
     args, extra_args = parser.parse_known_args(dynamo_args)
     return args, extra_args
 
@@ -53,6 +60,23 @@ def apply_torchdynamo_args(model: 'torchbenchmark.util.model.BenchmarkModel', ar
 
         # used for correctness checks, to avoid triton rand() behaving differently from torch rand().
         torchinductor.config.fallback_random = bool(args.torchinductor_fallback_random)
+
+    if bool(args.dynamo_disable_optimizer_step):
+        found_optimizer_step = False
+        try:
+            torch._dynamo.disallow_in_graph(model.cfg.optimizer.step)
+            found_optimizer_step = True
+        except AttributeError:
+            pass
+
+        try:
+            torch._dynamo.disallow_in_graph(model.optimizer.step)
+            found_optimizer_step = True
+        except AttributeError:
+            pass
+
+        if not found_optimizer_step:
+            warnings.warn("--dynamo_disable_optimizer_step is set to True, but the optimizer could not be found on this model")
 
     if model.test == "train":
         if is_staged_train_test(model):

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -435,6 +435,8 @@ def main():
                             copied_model_args.append("--optimize_dynamo_ddp")
                         if "inductor" in backend_name:
                             copied_model_args.extend(["--torchinductor_cudagraph", "False"])
+                        if backend_name != "eager":
+                            copied_model_args.extend(["--dynamo_disable_optimizer_step", "True"])
 
                         # skip non-distributed correctness checks to avoid extra iterations which can
                         # interfere with distributed correctness checks.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1308

Previously was working around this with `torch._dynamo.disable(self.optimizer.step)()` in the model_factory.py code (e.g. [this branch](https://github.com/pytorch/benchmark/compare/main...davidberard98/skip-dynamo-optimizer)), but we probably don't want to land that. I think this does the same thing, but guarded with a flag.

Test:
```
ADAM_CAPTURABLE=1 python run.py hf_T5_large -t train -d cuda --torchdynamo inductor --torchinductor_cudagraph False --dynamo_disable_optimizer_step True
```

^ takes ~5 minutes, which is a lot slower than the ~30min expected when the optimizer gets compiled.

Differential Revision: [D41326442](https://our.internmc.facebook.com/intern/diff/D41326442)