### PR TITLE
Add slurm_exclude arg to distributed userbenchmarks

### DIFF
--- a/torchbenchmark/util/distributed/submit.py
+++ b/torchbenchmark/util/distributed/submit.py
@@ -83,6 +83,13 @@ def parse_args(args: List[str]=None):
         help="distributed training paradigm, by default using DDP",
     )
 
+    parser.add_argument(
+        "--exclude",
+        type=str,
+        default="",
+        help="comma-separated list of nodes to exclude from the slurm allocation",
+    )
+
     try:
         if args:
             return parser.parse_known_args(args)
@@ -160,6 +167,7 @@ def main():
         # Below are cluster dependent parameters
         slurm_partition=args.partition,
         slurm_signal_delay_s=120,
+        slurm_exclude=args.exclude,
     )
 
     executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=1000)

--- a/userbenchmark/distributed/__init__.py
+++ b/userbenchmark/distributed/__init__.py
@@ -30,6 +30,7 @@ def run(args: List[str]):
         # Below are cluster dependent parameters
         slurm_partition=args.partition,
         slurm_signal_delay_s=120,
+        slurm_exclude=args.exclude,
     )
 
     executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=1000)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1309

Allow excluding bad nodes from slurm allocation - I find I need to patch this frequently due to bad nodes on the AWS cluster, might as well commit the change.

Differential Revision: [D41330289](https://our.internmc.facebook.com/intern/diff/D41330289)