### PR TITLE
Implement `enable_amp` for vision & huggingface models

### DIFF
--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -2,6 +2,7 @@ import math
 import random
 import os
 import torch
+from contextlib import nullcontext
 from torch import optim
 from torchbenchmark.util.model import BenchmarkModel
 import transformers
@@ -88,6 +89,8 @@ class HuggingFaceModel(BenchmarkModel):
                 self.example_inputs['decoder_input_ids'] = eval_context
             self.model.eval()
 
+        self.amp_context = nullcontext
+
     def get_module(self, wrap_model=True):
         if class_models[self.name][3] == 'AutoModelForSeq2SeqLM':
             k = 'labels' if self.test == 'train' else 'decoder_input_ids'
@@ -121,14 +124,16 @@ class HuggingFaceModel(BenchmarkModel):
         self.model = self.model.half()
 
     def train(self):
-        outputs = self.model(**self.example_inputs)
+        with self.amp_context():
+            outputs = self.model(**self.example_inputs)
         loss = outputs.loss
         loss.backward()
         self.optimizer.step()
 
     def eval(self) -> Tuple[torch.Tensor]:
         with torch.no_grad():
-            out = self.model(**self.example_inputs)
+            with self.amp_context():
+                out = self.model(**self.example_inputs)
         # logits: prediction scores of language modeling head
         # https://github.com/huggingface/transformers/blob/v4.16.2/src/transformers/modeling_outputs.py#L455
         # transformations such as fx2trt will cast the original output type to dict
@@ -138,3 +143,6 @@ class HuggingFaceModel(BenchmarkModel):
             return (out.logits, )
         else:
             return (out["logits"], )
+
+    def enable_amp(self):
+        self.amp_context = lambda: torch.cuda.amp.autocast(dtype=torch.float16)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1336
* __->__ #1330

Tested with:
```
python run.py [hf_T5_large|resnet50] -t train -d cuda --precision [fp32|amp] --torchdynamo inductor --skip_correctness
```

* resnet50 w/ fp32: 37ms
* resnet50 w/ amp: 25ms
* hf_T5_large w/ fp32: 418ms
* hf_T5_large w/ amp: 127ms

I run with `--skip_correctness` to avoid a correctness check that's failing due to dtype mismatch. The failure also occurs for timm, where `enable_amp` is already implemented.

Also verified that these 2 models do not error out for `-t eval`.

Differential Revision: [D41620520](https://our.internmc.facebook.com/intern/diff/D41620520)