### PR TITLE
fix bug for multigpus when only a subset is visible

### DIFF
--- a/components/model_analyzer/tb_dcgm_types/da_exceptions.py
+++ b/components/model_analyzer/tb_dcgm_types/da_exceptions.py
@@ -1,6 +1,16 @@
 class TorchBenchAnalyzerException(Exception):
     """
-    A custom exception specific to the Triton Model
-    Analyzer
+    A custom exception specific to the TorchBench Model Analyzer
     """
     pass
+
+
+class TorchBenchAnalyzerException_GPU_Inavailable(Exception):
+    """
+    A warning when the GPU is not visible to the process. 
+    It is benign and can be ignored when there are multiple GPUs and only a subset of them are used.
+    """
+
+    def __init__(self, gpu_uuid='0000', *args: object) -> None:
+        self.message = f'Warning: GPU with {gpu_uuid} uuid is not present!'
+        super().__init__(self.message, *args)

--- a/components/model_analyzer/tb_dcgm_types/da_exceptions.py
+++ b/components/model_analyzer/tb_dcgm_types/da_exceptions.py
@@ -5,7 +5,7 @@ class TorchBenchAnalyzerException(Exception):
     pass
 
 
-class TorchBenchAnalyzerException_GPU_Inavailable(Exception):
+class TorchBenchAnalyzerExceptionGPUUnavailable(Exception):
     """
     A warning when the GPU is not visible to the process. 
     It is benign and can be ignored when there are multiple GPUs and only a subset of them are used.

--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -15,7 +15,7 @@ import logging
 from numba.cuda.cudadrv import enums
 # @Yueming Hao: TODO: Replace this with nvml API
 from numba import cuda
-from .da_exceptions import TorchBenchAnalyzerException
+from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerException_GPU_Inavailable
 
 
 
@@ -62,9 +62,8 @@ class GPUDevice(Device):
             if gpu._device.uuid == device_uuid:
                 self._device = gpu
         if self._device is None:
-            raise TorchBenchAnalyzerException(
-                f'GPU with {device_uuid} uuid is not present!'
-            )
+            raise TorchBenchAnalyzerException_GPU_Inavailable(device_uuid)
+
         self._sm_count = self._device.MULTIPROCESSOR_COUNT
         fma_count = ConvertSMVer2Cores(self._device.COMPUTE_CAPABILITY_MAJOR, self._device.COMPUTE_CAPABILITY_MINOR)
         if fma_count == 0:

--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -15,7 +15,7 @@ import logging
 from numba.cuda.cudadrv import enums
 # @Yueming Hao: TODO: Replace this with nvml API
 from numba import cuda
-from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerException_GPU_Inavailable
+from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerExceptionGPUUnavailable
 
 
 
@@ -62,7 +62,7 @@ class GPUDevice(Device):
             if gpu._device.uuid == device_uuid:
                 self._device = gpu
         if self._device is None:
-            raise TorchBenchAnalyzerException_GPU_Inavailable(device_uuid)
+            raise TorchBenchAnalyzerExceptionGPUUnavailable(device_uuid)
 
         self._sm_count = self._device.MULTIPROCESSOR_COUNT
         fma_count = ConvertSMVer2Cores(self._device.COMPUTE_CAPABILITY_MAJOR, self._device.COMPUTE_CAPABILITY_MINOR)

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -17,7 +17,7 @@ LOGGER_NAME = "model_analyzer_logger"
 from .gpu_device import GPUDevice
 from  ..dcgm import dcgm_agent as dcgm_agent
 from ..dcgm import dcgm_structs as structs
-from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerException_GPU_Inavailable
+from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerExceptionGPUUnavailable
 
 import numba.cuda
 import logging
@@ -67,7 +67,7 @@ class GPUDeviceFactory:
                 try:
                     gpu_device = GPUDevice(device_name, device_id, pci_bus_id,
                                            device_uuid)
-                except TorchBenchAnalyzerException_GPU_Inavailable as e:
+                except TorchBenchAnalyzerExceptionGPUUnavailable as e:
                     logger.warning(e)
                     continue
                 self._devices.append(gpu_device)


### PR DESCRIPTION
When there are multiple GPUs and only a subset is visible, e.g. specified the visible GPUs by `CUDA_VISIBLE_DEVICES`, to the process, errors occur as described in https://github.com/pytorch/benchmark/issues/1331

fixes  https://github.com/pytorch/benchmark/issues/1331