### PR TITLE
Use cos_sim for amp precision in correctness checks

### DIFF
--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -158,7 +158,13 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             # in this case, use more relaxed cosine similarity instead of torch.allclose
             # for correctness testing
             # see: https://github.com/pytorch/torchdynamo/pull/438
-            if self.dargs.precision == "fp16" or (self.dynamo and self.opt_args.torchdynamo == "fx2trt") or (not self.dynamo and self.opt_args.fx2trt) or (not self.dynamo and self.opt_args.use_cosine_similarity):
+            if (
+                self.dargs.precision == "fp16"
+                or self.dargs.precision == "amp"
+                or (self.dynamo and self.opt_args.torchdynamo == "fx2trt")
+                or (not self.dynamo and self.opt_args.fx2trt)
+                or (not self.dynamo and self.opt_args.use_cosine_similarity)
+            ):
                 self.correctness = correctness_check(self, cos_sim=True, deepcopy=self.DEEPCOPY)
             else:
                 # get tolerance of correctness check from os.environ


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1336
* #1330

cosine similarity doesn't check dtyp, so this makes correctness checks pass. Tested on hf_T5 and resnet50 with:

```
$ python run.py [model] -t train -d cuda --precision amp --torchdynamo inductor
```

Differential Revision: [D41788114](https://our.internmc.facebook.com/intern/diff/D41788114)