### PR TITLE
Set cudnn.benchmark in timm and vision models to True by default

### DIFF
--- a/torchbenchmark/models/alexnet/metadata.yaml
+++ b/torchbenchmark/models/alexnet/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 1024
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/densenet121/metadata.yaml
+++ b/torchbenchmark/models/densenet121/metadata.yaml
@@ -1,11 +1,11 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 64
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cuda
 - device: cpu
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/mnasnet1_0/metadata.yaml
+++ b/torchbenchmark/models/mnasnet1_0/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/mobilenet_v2/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v2/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
+++ b/torchbenchmark/models/mobilenet_v3_large/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/resnet152/metadata.yaml
+++ b/torchbenchmark/models/resnet152/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 64
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/resnet18/metadata.yaml
+++ b/torchbenchmark/models/resnet18/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 256
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/resnet50/metadata.yaml
+++ b/torchbenchmark/models/resnet50/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 64
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/resnext50_32x4d/metadata.yaml
+++ b/torchbenchmark/models/resnext50_32x4d/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 64
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
+++ b/torchbenchmark/models/shufflenet_v2_x1_0/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/squeezenet1_1/metadata.yaml
+++ b/torchbenchmark/models/squeezenet1_1/metadata.yaml
@@ -1,10 +1,10 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 256
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - test: train
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_efficientdet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientdet/metadata.yaml
@@ -7,5 +7,5 @@ eval_nograd: true
 not_implemented:
 - device: cuda
 - device: cpu
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_efficientnet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientnet/metadata.yaml
@@ -4,5 +4,5 @@ devices:
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_efficientnet/metadata.yaml
+++ b/torchbenchmark/models/timm_efficientnet/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -7,5 +7,5 @@ eval_nograd: true
 not_implemented:
 - evice: cuda
   test: train
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 not_implemented:

--- a/torchbenchmark/models/timm_regnet/metadata.yaml
+++ b/torchbenchmark/models/timm_regnet/metadata.yaml
@@ -4,5 +4,5 @@ devices:
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_regnet/metadata.yaml
+++ b/torchbenchmark/models/timm_regnet/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 32
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/timm_resnest/metadata.yaml
+++ b/torchbenchmark/models/timm_resnest/metadata.yaml
@@ -4,5 +4,5 @@ devices:
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_resnest/metadata.yaml
+++ b/torchbenchmark/models/timm_resnest/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 256
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/timm_vision_transformer/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer/metadata.yaml
@@ -4,5 +4,5 @@ devices:
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_vision_transformer/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/timm_vision_transformer_large/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer_large/metadata.yaml
@@ -1,7 +1,7 @@
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false
 not_implemented:
 - device: cuda

--- a/torchbenchmark/models/timm_vision_transformer_large/metadata.yaml
+++ b/torchbenchmark/models/timm_vision_transformer_large/metadata.yaml
@@ -1,4 +1,4 @@
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/timm_vovnet/metadata.yaml
+++ b/torchbenchmark/models/timm_vovnet/metadata.yaml
@@ -4,5 +4,5 @@ devices:
 eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/models/timm_vovnet/metadata.yaml
+++ b/torchbenchmark/models/timm_vovnet/metadata.yaml
@@ -1,7 +1,7 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 128
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 train_benchmark: true

--- a/torchbenchmark/models/vgg16/metadata.yaml
+++ b/torchbenchmark/models/vgg16/metadata.yaml
@@ -1,8 +1,8 @@
 devices:
   NVIDIA A100-SXM4-40GB:
     eval_batch_size: 8
-eval_benchmark: false
+eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
-train_benchmark: false
+train_benchmark: true
 train_deterministic: false

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -18,7 +18,7 @@ class TimmModel(BenchmarkModel):
     def __init__(self, model_name, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         torch.backends.cudnn.deterministic = False
-        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.benchmark = True
 
         self.model = timm.create_model(model_name, pretrained=False, scriptable=True)
         self.cfg = TimmConfig(model = self.model, device = device)

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -19,7 +19,7 @@ class TorchVisionModel(BenchmarkModel):
     def __init__(self, model_name, test, device, jit=False, batch_size=None, weights=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         torch.backends.cudnn.deterministic = False
-        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.benchmark = True
 
         if weights is None:
             self.model = getattr(models, model_name)(pretrained=True).to(self.device)


### PR DESCRIPTION
The upstream of [timm framework](https://github.com/rwightman/pytorch-image-models/blob/e7da205345dcf770ee4bedd62d06fad7a1458904/train.py#L372) has set `torch.backends.cudnn.benchmark` to True by default. It's better to keep it the same as the upstream.

The vision framework doesn't have an upstream repo, and it is supposed to use fixed input sizes each time in TorchBench. So it's better to enable cudnn.benchmark too.