### PR TITLE
Add E2E vision_resnet50 model with CIFAR10 input data

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -10,8 +10,8 @@ RUN sudo apt-get install -y git git-lfs jq \
                             libgl1-mesa-glx libsndfile1-dev
 
 # get switch-cuda utility
-RUN wget -q https://raw.githubusercontent.com/phohenecker/switch-cuda/master/switch-cuda.sh -O /usr/bin/switch-cuda.sh
-RUN chmod +x /usr/bin/switch-cuda.sh
+RUN sudo wget -q https://raw.githubusercontent.com/phohenecker/switch-cuda/master/switch-cuda.sh -O /usr/bin/switch-cuda.sh
+RUN sudo chmod +x /usr/bin/switch-cuda.sh
 
 RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 

--- a/run_e2e.py
+++ b/run_e2e.py
@@ -23,9 +23,12 @@ def run(func) -> Dict[str, float]:
     return result
 
 def gen_result(m, run_result):
-    r = E2EBenchmarkResult(device=m.device, device_num=m.device_num, test=m.test, num_examples=m.num_examples, batch_size=m.batch_size, result=dict())
+    num_epochs = m.num_epochs if hasattr(m, 'num_epochs') else 1
+    r = E2EBenchmarkResult(device=m.device, device_num=m.device_num,
+                           test=m.test, num_examples=m.num_examples,
+                           num_epochs=num_epochs, batch_size=m.batch_size, result=dict())
     r.result["latency"] = run_result["latency_ms"] / 1000.0
-    r.result["qps"] = r.num_examples / r.result["latency"]
+    r.result["qps"] = r.num_examples / r.result["latency"] * r.num_epochs
     # add accuracy result if available
     if hasattr(m, "accuracy"):
         r.result["accuracy"] = m.accuracy

--- a/run_e2e.py
+++ b/run_e2e.py
@@ -26,6 +26,9 @@ def gen_result(m, run_result):
     r = E2EBenchmarkResult(device=m.device, device_num=m.device_num, test=m.test, num_examples=m.num_examples, batch_size=m.batch_size, result=dict())
     r.result["latency"] = run_result["latency_ms"] / 1000.0
     r.result["qps"] = r.num_examples / r.result["latency"]
+    # add accuracy result if available
+    if hasattr(m, "accuracy"):
+        r.result["accuracy"] = m.accuracy
     return r
 
 if __name__ == "__main__":

--- a/torchbenchmark/e2e.py
+++ b/torchbenchmark/e2e.py
@@ -16,6 +16,7 @@ class E2EBenchmarkResult:
     device_num: int
     test: str
     num_examples: int
+    num_epochs: int
     batch_size: int
     result: Dict[str, Any]
 

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -56,6 +56,8 @@ class Model(E2EBenchmarkModel):
             self.num_epochs = 200
             # use random init model for train
             self.model = torchvision.models.resnet50().to(self.device)
+            from .resnet import ResNet50
+            self.model = ResNet50().to(self.device)
             self.model.train()
             self.criterion = torch.nn.CrossEntropyLoss()
             self.optimizer = torch.optim.SGD(self.model.parameters(), lr=self.lr,

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -5,7 +5,7 @@ import torchvision.transforms as transforms
 from torchbenchmark.util.e2emodel import E2EBenchmarkModel
 from torchbenchmark.tasks import COMPUTER_VISION
 import os
-import tqdm
+from tqdm import tqdm
 
 from pathlib import Path
 

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -20,6 +20,7 @@ class Model(E2EBenchmarkModel):
     def __init__(self, test, batch_size=None, extra_args=[]):
         super().__init__(test=test, batch_size=batch_size, extra_args=extra_args)
         self.device = "cuda"
+        self.device_num = 1
         data_root = CURRENT_DIR.joinpath(".data")
         assert torch.cuda.is_available(), f"This model requires CUDA device available."
         transform_train = transforms.Compose([

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -38,6 +38,7 @@ class Model(E2EBenchmarkModel):
             root=str(data_root), train=True, download=True, transform=transform_train)
         self.trainloader = torch.utils.data.DataLoader(
             trainset, batch_size=self.batch_size, shuffle=True, num_workers=2)
+        self.num_examples = len(self.trainloader)
 
         testset = torchvision.datasets.CIFAR10(
             root=str(data_root), train=False, download=True, transform=transform_test)

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -38,7 +38,7 @@ class Model(E2EBenchmarkModel):
             root=str(data_root), train=True, download=True, transform=transform_train)
         self.trainloader = torch.utils.data.DataLoader(
             trainset, batch_size=self.batch_size, shuffle=True, num_workers=2)
-        self.num_examples = len(self.trainloader)
+        self.num_examples = len(trainset)
 
         testset = torchvision.datasets.CIFAR10(
             root=str(data_root), train=False, download=True, transform=transform_test)

--- a/torchbenchmark/e2e_models/vision_resnet50/__init__.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/__init__.py
@@ -1,0 +1,76 @@
+# upstream repo: https://github.com/kuangliu/pytorch-cifar
+import torch
+import torchvision
+import torchvision.transforms as transforms
+from torchbenchmark.util.e2emodel import E2EBenchmarkModel
+from torchbenchmark.tasks import COMPUTER_VISION
+import os
+
+from pathlib import Path
+
+# setup environment variable
+CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
+
+class Model(E2EBenchmarkModel):
+    task = COMPUTER_VISION.CLASSIFICATION
+    DEFAULT_TRAIN_BSIZE: int = 128
+    DEFAULT_EVAL_BSIZE: int = 1
+
+    def __init__(self, test, batch_size=None, extra_args=[]):
+        super().__init__(test=test, batch_size=batch_size, extra_args=extra_args)
+        self.device = "cuda"
+        data_root = CURRENT_DIR.joinpath(".data")
+        assert torch.cuda.is_available(), f"This model requires CUDA device available."
+        transform_train = transforms.Compose([
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        ])
+
+        transform_test = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+        ])
+        trainset = torchvision.datasets.CIFAR10(
+            root=str(data_root), train=True, download=True, transform=transform_train)
+        trainloader = torch.utils.data.DataLoader(
+            trainset, batch_size=self.batch_size, shuffle=True, num_workers=2)
+
+        testset = torchvision.datasets.CIFAR10(
+            root=str(data_root), train=False, download=True, transform=transform_test)
+        testloader = torch.utils.data.DataLoader(
+            testset, batch_size=self.batch_size, shuffle=False, num_workers=2)
+        
+        self.classes = ('plane', 'car', 'bird', 'cat', 'deer',
+                        'dog', 'frog', 'horse', 'ship', 'truck')
+        self.lr = 0.1
+        # initial accuracy
+        self.acc = 0
+
+        if self.test == "train":
+            # by default, run 200 epochs
+            self.num_epochs = 200
+            # use random init model for train
+            self.model = torchvision.models.resnet50().to(self.device)
+            self.model.train()
+            self.criterion = torch.nn.CrossEntropyLoss()
+            self.optimizer = torch.optim.SGD(self.model.parameters(), lr=self.lr,
+                             momentum=0.9, weight_decay=5e-4)
+            self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(self.optimizer, T_max=200)
+        else:
+            # use pretrained model for eval
+            self.model = torchvision.models.resnet50(pretrained=True).to(self.device)
+            self.model.eval()
+
+    def test(self):
+        self.model.eval()
+        with torch.no_grad():
+            pass
+
+    def train(self):
+        self.model.train()
+        pass
+
+    def eval(self):
+        pass

--- a/torchbenchmark/e2e_models/vision_resnet50/resnet.py
+++ b/torchbenchmark/e2e_models/vision_resnet50/resnet.py
@@ -1,0 +1,115 @@
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Conv2d(
+            in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3,
+                               stride=1, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion*planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion*planes,
+                          kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion*planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(Bottleneck, self).__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3,
+                               stride=stride, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.conv3 = nn.Conv2d(planes, self.expansion *
+                               planes, kernel_size=1, bias=False)
+        self.bn3 = nn.BatchNorm2d(self.expansion*planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion*planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion*planes,
+                          kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion*planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = F.relu(self.bn2(self.conv2(out)))
+        out = self.bn3(self.conv3(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class ResNet(nn.Module):
+    def __init__(self, block, num_blocks, num_classes=10):
+        super(ResNet, self).__init__()
+        self.in_planes = 64
+
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3,
+                               stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(64)
+        self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, num_blocks[3], stride=2)
+        self.linear = nn.Linear(512*block.expansion, num_classes)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = self.layer4(out)
+        out = F.avg_pool2d(out, 4)
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+def ResNet18():
+    return ResNet(BasicBlock, [2, 2, 2, 2])
+
+
+def ResNet34():
+    return ResNet(BasicBlock, [3, 4, 6, 3])
+
+
+def ResNet50():
+    return ResNet(Bottleneck, [3, 4, 6, 3])
+
+
+def ResNet101():
+    return ResNet(Bottleneck, [3, 4, 23, 3])
+
+
+def ResNet152():
+    return ResNet(Bottleneck, [3, 8, 36, 3])


### PR DESCRIPTION
This PR adds resnet50 model training using the CIFAR10 input dataset.
The CIFAR10 input dataset is about 164MB. The train set has 50000 images and test set has 10000 images. Each image is 32x32 and belongs to one in 10 classes, with 6000 images per class.

It uses the default upstream parameter, which has batch size 128 and 200 epochs.
On my local reproduction, I get 83.66% accuracy after 200 epochs of training.

Upstream training code: https://github.com/kuangliu/pytorch-cifar


Test Plan:
```
$ python run_e2e.py vision_resnet50 -t train
Training epoch: 100%|██████████████| 200/200 [57:24<00:00, 17.22s/it]
{"device": "cuda", "device_num": 1, "test": "train", "num_examples": 50000, "num_epochs": 200, "batch_size": 128, "result": {"latency": 4183.559438905, "qps": 2390.309052861787, "accuracy": 83.66}}

```