### PR TITLE
Fix stray `pretrained=True` warnings from torchvision

### DIFF
--- a/torchbenchmark/models/Super_SloMo/model_wrapper.py
+++ b/torchbenchmark/models/Super_SloMo/model_wrapper.py
@@ -16,7 +16,7 @@ class Model(torch.nn.Module):
         self.ArbTimeFlowIntrp = model.UNet(20, 5).to(device)
         self.trainFlowBackWarp = model.backWarp(352, 352, device)
 
-        vgg16 = torchvision.models.vgg16(pretrained=True)
+        vgg16 = torchvision.models.vgg16(weights=torchvision.models.VGG16_Weights.IMAGENET1K_V1)
         vgg16_conv_4_3 = nn.Sequential(*list(vgg16.children())[0][:22])
         vgg16_conv_4_3.to(device)
         for param in vgg16_conv_4_3.parameters():

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -56,7 +56,9 @@ class Model(BenchmarkModel):
             self.DEFAULT_EVAL_BSIZE = 1
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
-        self.model = torchvision.models.detection.maskrcnn_resnet50_fpn(pretrained=True).to(self.device)
+        self.model = torchvision.models.detection.maskrcnn_resnet50_fpn(
+            weights=torchvision.models.detection.MaskRCNN_ResNet50_FPN_Weights.COCO_V1
+        ).to(self.device)
         # setup optimizer
         # optimizer parameters copied from
         # https://github.com/pytorch/vision/blob/30f4d108319b0cd28ae5662947e300aad98c32e9/references/detection/train.py#L77


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1346

Follow up to #1280, this fixes vision_maskrcnn and Super_SloMo which use torchvision, but do not subclass TorchVisionModel. This fixes the warning about `pretrained=True` being a deprecated option.

Differential Revision: [D42053509](https://our.internmc.facebook.com/intern/diff/D42053509)