### PR TITLE
README: Add `torchaudio` to pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Or use pip:
 pip install --pre torch torchvision torchtext torchaudio -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
 ```
 
+Install other necessary libraries:
+```
+pip install pyyaml
+```
+
 Install the benchmark suite, which will recursively install dependencies for all the models.  Currently, the repo is intended to be installed from the source tree.
 ```
 git clone <benchmark>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ conda install -y pytorch torchtext torchvision torchaudio cudatoolkit=11.6 -c py
 Or use pip:
 (but don't mix and match pip and conda for the torch family of libs! - [see notes below](#notes))
 ```
-pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
+pip install --pre torch torchvision torchtext torchaudio -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
 ```
 
 Install the benchmark suite, which will recursively install dependencies for all the models.  Currently, the repo is intended to be installed from the source tree.


### PR DESCRIPTION
Found that it was necessary to add `torchaudio` to the pip command to run `python install.py`.

Also I needed to run `pip install pyyaml`. Not sure if it is worth adding to the README.