### PR TITLE
Add accuracy metrics to e2e models

### DIFF
--- a/torchbenchmark/e2e_models/hf_bert/__init__.py
+++ b/torchbenchmark/e2e_models/hf_bert/__init__.py
@@ -66,6 +66,7 @@ class Model(E2EBenchmarkModel):
                   "--max_train_steps", max_train_steps,
                   "--output_dir", output_dir]
         hf_args = parse_args(in_arg)
+        self.num_epochs = hf_args.num_train_epochs
 
         # ideally we don't modify the model code directly, but attaching deepspeed
         # must be done before self.prep initializes accelerator.
@@ -255,6 +256,9 @@ class Model(E2EBenchmarkModel):
                     )
 
                 eval_metric = self.metric.compute()
+        # store accuracy results
+        if self.hf_args.task_name == "cola" and self.tb_args.validate_in_train:
+            self.accuracy = eval_metric["matthews_correlation"]
         return eval_metric
 
     def eval(self) -> Optional[dict]:

--- a/torchbenchmark/e2e_models/hf_bert/requirements.txt
+++ b/torchbenchmark/e2e_models/hf_bert/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 protobuf
 torch
 evaluate
+sacrebleu

--- a/torchbenchmark/e2e_models/hf_t5/__init__.py
+++ b/torchbenchmark/e2e_models/hf_t5/__init__.py
@@ -88,6 +88,7 @@ class Model(E2EBenchmarkModel):
                   "--output_dir", output_dir]
         in_arg.extend(task_args)
         hf_args = parse_args(in_arg)
+        self.num_epochs = hf_args.num_train_epochs
 
         # ideally we don't modify the model code directly, but attaching deepspeed
         # must be done before self.prep initialiazes accelerator.

--- a/torchbenchmark/e2e_models/hf_t5/__init__.py
+++ b/torchbenchmark/e2e_models/hf_t5/__init__.py
@@ -345,7 +345,10 @@ class Model(E2EBenchmarkModel):
                 if completed_steps >= self.hf_args.max_train_steps:
                     break
             if self.tb_args.validate_in_train:
-                eval_metric = self.eval() # run evaluation 
+                eval_metric = self.eval() # run evaluation
+        # store accuracy results
+        if self.tb_args.validate_in_train:
+            self.accuracy = eval_metric["score"]
         return eval_metric
     
     def eval(self):

--- a/torchbenchmark/util/framework/transformers/text_classification/args.py
+++ b/torchbenchmark/util/framework/transformers/text_classification/args.py
@@ -20,8 +20,8 @@ task_to_keys = {
 def parse_torchbench_args(extra_args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--task_name", default="cola", choices=task_to_keys.keys(), help="Name of task to run")
-    # do not validate in train by default
-    parser.add_argument("--validate_in_train", action="store_true", help="Validate result in train")
+    # validate in train by default
+    parser.add_argument("--validate_in_train", action="store_false", help="Validate result in train")
     # use fp16 mixed precision by default
     parser.add_argument("--fp16", default="amp", choices=["amp", "no"], help="Enable mixed precision")
     parser.add_argument(

--- a/torchbenchmark/util/framework/transformers/translation/args.py
+++ b/torchbenchmark/util/framework/transformers/translation/args.py
@@ -25,8 +25,8 @@ task_to_keys = {
 def parse_torchbench_args(extra_args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--task_name", default="wmt-en-ro", choices=task_to_keys.keys(), help="Name of task to run") 
-    # do not validate in train by default
-    parser.add_argument("--validate_in_train", action="store_true", help="Validate result in train")
+    # validate in train by default
+    parser.add_argument("--validate_in_train", action="store_false", help="Validate result in train")
     # use fp16 mixed precision by default
     parser.add_argument("--fp16", default="amp", choices=["amp", "no"], help="Enable mixed precision")
     parser.add_argument(


### PR DESCRIPTION
This PR makes two changes to E2E models:
1. Turn on accuracy validation in train by default
2. Store the accuracy metrics in the result json file

For example:

```
$ python run_e2e.py hf_bert -t train
{"device": "cuda", "device_num": 1, "test": "train", "num_examples": 8576, "num_epochs": 3, "batch_size": 32, "result": {"latency": 8.417137417, "qps": 3056.6211201491665, "accuracy": 0.4213272367274183}}
```

```
$ python run_e2e.py hf_t5 -t train
{"device": "cuda", "device_num": 1, "test": "train", "num_examples": 610336, "num_epochs": 3, "batch_size": 32, "result": {"latency": 141.87018556799998, "qps": 12906.221223784734, "accuracy": 27.662052905235683}}
```