### PR TITLE
[distributed+PT2] Add "cluster" option for slurm cluster settings

### DIFF
--- a/userbenchmark/ddp_experiments/README.md
+++ b/userbenchmark/ddp_experiments/README.md
@@ -63,3 +63,4 @@ Supported options (not-exhaustive):
 * `--nodes 8 4 2 1` to set the list of nodes to benchmark on.
 * `--ngpus [n]` for the number of gpus per node (8 by default, but 2 is useful for simple tests that use less resources)
 * `--precision amp|fp32|fp16` for specifying precision type (fp32 default)
+* `--cluster local` to run locally instead of launching a new slurm job

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -87,6 +87,13 @@ def parse_args(args: List[str]=None):
     )
 
     parser.add_argument(
+        "--cluster",
+        default=None,
+        type=str,
+        help="Which slurm cluster to target. Use 'local' to run jobs locally, 'debug' to run jobs in process",
+    )
+
+    parser.add_argument(
         "--distributed",
         default="ddp_no_static_graph",
         type=str,
@@ -658,7 +665,7 @@ def main():
     args = parse_args()
 
     # Note that the folder will depend on the job_id, to easily track experiments
-    executor = submitit.AutoExecutor(folder=args.job_dir, slurm_max_num_timeout=3000)
+    executor = submitit.AutoExecutor(folder=args.job_dir, cluster=args.cluster, slurm_max_num_timeout=3000)
 
     executor.update_parameters(
         gpus_per_node=args.ngpus,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1362
* #1361

This allows you to run with `--cluster local`, to utilize the GPUs on the current allocation (so you don't have to launch a new slurm job or have a pytorch env that's accessible across multiple machines)

Differential Revision: [D42437977](https://our.internmc.facebook.com/intern/diff/D42437977)