### PR TITLE
fix bug for record collections

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -28,6 +28,7 @@ import logging
 logger = logging.getLogger(LOGGER_NAME)
 import json
 
+
 class ModelAnalyzer:
     def __init__(self):
         # For debug
@@ -42,8 +43,8 @@ class ModelAnalyzer:
         self.gpu_metrics = []
         # the final metric results. Its format is {GPU_UUID: {GPUUtilization: }}
         # Example:
-        # {'GPU-4177e846-1274-84e3-dcde': 
-        #   {<class '.tb_dcgm_types.gpu_fp32active.GPUFP32Active'>: 
+        # {'GPU-4177e846-1274-84e3-dcde':
+        #   {<class '.tb_dcgm_types.gpu_fp32active.GPUFP32Active'>:
         #      <.tb_dcgm_types.gpu_fp32active.GPUFP32Active object at 0x7f14bbae2280>
         #   }
         #  }
@@ -67,12 +68,16 @@ class ModelAnalyzer:
 
     def add_metric_gpu_peak_mem(self):
         self.gpu_metrics.append(GPUPeakMemory)
+
     def add_metric_gpu_flops(self):
         self.gpu_metrics.append(GPUFP32Active)
+
     def add_metric_cpu_peak_mem(self):
         self.cpu_metrics.append(CPUPeakMemory)
+
     def set_gpu_monitor_backend_nvml(self):
         self.gpu_monitor_backend = 'nvml'
+
     def set_export_csv_name(self, export_csv_name=''):
         self.export_csv_name = export_csv_name
         # test for correct permission
@@ -111,7 +116,7 @@ class ModelAnalyzer:
             self.cpu_monitor.destroy()
             self.cpu_monitor = None
             self.cpu_monitor_started = False
-    
+
     def stop_monitor(self):
         if self.gpu_monitor:
             self.gpu_records = self.gpu_monitor.stop_recording_metrics()
@@ -119,27 +124,33 @@ class ModelAnalyzer:
             self.cpu_records = self.cpu_monitor.stop_recording_metrics()
         # This must be called after stop_recording_metrics
         self._destory_monitor()
-        if self.gpu_records:
-            # insert all gpu_records into record_aggregator
-            self.gpu_record_aggregator.insert_all(self.gpu_records)
-        if self.cpu_records:
-            self.cpu_record_aggregator.insert_all(self.cpu_records)
 
-    
-    def aggregate(self):
+    def aggregate(self, end_measure_time=None):
         """
-        aggregate must be called after stop_monitor.
+        Aaggregate must be called after stop_monitor.
+        Args:
+            end_measure_time: the end time in ms of the measurement. Needs to be converted to ns.
         """
+        if end_measure_time:
+            end_measure_time = (end_measure_time + 1) * 1e6
         if self.gpu_records:
+            if end_measure_time:
+                end_measure_time = self.gpu_records[0]._timestamp + end_measure_time
+                self.gpu_records = [record for record in self.gpu_records if record._timestamp <= end_measure_time]
+            self.gpu_record_aggregator.insert_all(self.gpu_records)
             records_groupby_gpu = self.gpu_record_aggregator.groupby(
                 self.gpu_metrics, lambda record: record.device_uuid())
-            
+
             for gpu in self.gpus:
                 self.gpu_metric_value[gpu.device_uuid()] = {}
             for metric_type, metric in records_groupby_gpu.items():
                 for gpu_uuid, metric_value in metric.items():
                     self.gpu_metric_value[gpu_uuid][metric_type] = metric_value
         if self.cpu_records:
+            if end_measure_time:
+                end_measure_time = self.cpu_records[0]._timestamp + end_measure_time
+                self.cpu_records = [record for record in self.cpu_records if record._timestamp <= end_measure_time]
+            self.cpu_record_aggregator.insert_all(self.cpu_records)
             records_groupby_cpu = self.cpu_record_aggregator.groupby(
                 self.cpu_metrics, lambda record: record.device_uuid())
             # detault cpu id is 0x1
@@ -147,13 +158,13 @@ class ModelAnalyzer:
             for metric_type, metric in records_groupby_cpu.items():
                 for cpu_uuid, metric_value in metric.items():
                     self.cpu_metric_value[cpu_uuid][metric_type] = metric_value
-    
+
     def set_monitoring_interval(self, attempted_interval):
         """
         The default monitoring internval is DEFAULT_MONITORING_INTERVAL * 1000 ms.
         """
-        if attempted_interval < 0.1:
-            logger.warning("The attempted interval is too short, would cause untrusted profiling results.")
+        # if attempted_interval < 0.1:
+        #     logger.warning("The attempted interval is too short, would cause untrusted profiling results.")
         self.config.monitoring_interval = attempted_interval
 
     def print_flops(self):
@@ -163,10 +174,10 @@ class ModelAnalyzer:
             print(self.gpu_metric_value[gpu_uuid][GPUFP32Active].value())
             # TFLOPs/second = Device_SM_Count x Device_FMAs_Per_Cycle_Per_SM x 2 x Running_Frequency_KHz x DCGM_Activity / 1e+9
             print("GPU : TFLOPs/Second %.4f" % (gpu._sm_count * gpu._fma_count * 2 *
-                gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9))
+                                                gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9))
         # @Yueming Hao: print all collected gpu records, for debug only
-        logger.debug(json.dumps([_.to_dict() for _ in self.gpu_records], indent = 4))
-    
+        logger.debug(json.dumps([_.to_dict() for _ in self.gpu_records], indent=4))
+
     def export_all_records_to_csv(self):
         records_groupby_gpu = self.gpu_record_aggregator.groupby_wo_aggregate(
             self.gpu_metrics, lambda record: record.device_uuid())
@@ -183,7 +194,7 @@ class ModelAnalyzer:
                     csv_records[gpu_uuid][record_type][record.timestamp()] = record.value()
         with open(self.export_csv_name, 'w') as fout:
             for gpu_uuid in csv_records:
-                # timestamp record in DCGM is microsecond 
+                # timestamp record in DCGM is microsecond
                 timestamps = set()
                 fout.write("timestamp(ms), ")
                 for record_type in csv_records[gpu_uuid]:
@@ -213,18 +224,17 @@ class ModelAnalyzer:
                     line = "%.2f, " % ((a_timestamp - timestamp_start) / 1000)
                     for record_type in csv_records[gpu_uuid]:
                         value = csv_records[gpu_uuid][record_type].get(a_timestamp, -1)
-                        line += "%.2f, "% value
+                        line += "%.2f, " % value
                     line += "%.2f, " % duration
                     if duration != 0 :
                         if GPUPCIERX in self.gpu_metrics:
                             pcierx_record = csv_records[gpu_uuid][GPUPCIERX].get(a_timestamp, -1)
                             if pcierx_record != -1:
-                                line += "%.2f, " % (pcierx_record / duration *1000/1024/1024/1024 )
+                                line += "%.2f, " % (pcierx_record / duration * 1000 / 1024 / 1024 / 1024)
                         if GPUPCIETX in self.gpu_metrics:
                             pcietx_record = csv_records[gpu_uuid][GPUPCIETX].get(a_timestamp, -1)
-                            line += "%.2f, " % (pcietx_record / duration *1000/1024/1024/1024 )
+                            line += "%.2f, " % (pcietx_record / duration * 1000 / 1024 / 1024 / 1024)
                     fout.write(line + "\n")
-
 
     def calculate_flops(self, gpu_uuid=None) -> float:
         """
@@ -272,8 +282,9 @@ class ModelAnalyzer:
         cpu_uuid = next(iter(self.cpu_metric_value))
         return self.cpu_metric_value[cpu_uuid][CPUPeakMemory].value() / 1024
 
+
 def check_dcgm():
-    try: 
+    try:
         temp_model_analyzer = ModelAnalyzer()
         temp_model_analyzer.add_metric_gpu_flops()
         temp_model_analyzer.start_monitor()
@@ -282,6 +293,7 @@ def check_dcgm():
         logger.error("ERROR: DCGM init failed. ", e)
         exit(-1)
     return True
+
 
 def check_nvml():
     try:

--- a/components/model_analyzer/dcgm/dcgm_monitor.py
+++ b/components/model_analyzer/dcgm/dcgm_monitor.py
@@ -123,7 +123,7 @@ class DCGMMonitor(Monitor):
                                 metric_type(value=float(measurement.value),
                                             device_uuid=gpu.device_uuid(),
                                             timestamp=measurement.ts))
-
+        records.sort(key=lambda x: x._timestamp)
         return records
 
     def destroy(self):

--- a/components/model_analyzer/dcgm/monitor.py
+++ b/components/model_analyzer/dcgm/monitor.py
@@ -62,6 +62,7 @@ class Monitor(ABC):
             duration = time.time() - begin
             if duration < frequency:
                 time.sleep(frequency - duration)
+        self._monitoring_iteration()
 
     @abstractmethod
     def _monitoring_iteration(self):
@@ -114,6 +115,7 @@ class Monitor(ABC):
                 "called before stop_recording_metrics")
 
         self._thread_active = False
+        self._thread.wait()
         self._thread = None
 
         return self._collect_records()

--- a/components/model_analyzer/tb_dcgm_types/config.py
+++ b/components/model_analyzer/tb_dcgm_types/config.py
@@ -1,7 +1,7 @@
 
 
 # default is 100 ms.
-DEFAULT_MONITORING_INTERVAL = 0.1
+DEFAULT_MONITORING_INTERVAL = 0.01
 
 
 class AnalayzerConfig:

--- a/components/model_analyzer/tb_dcgm_types/config.py
+++ b/components/model_analyzer/tb_dcgm_types/config.py
@@ -1,6 +1,6 @@
 
 
-# default is 100 ms.
+# default is 0.01 second
 DEFAULT_MONITORING_INTERVAL = 0.01
 
 

--- a/run.py
+++ b/run.py
@@ -73,7 +73,7 @@ def printResultSummaryTime(result_summary, metrics_needed=[], metrics_backend_ma
         cpu_walltime = np.median(list(map(lambda x: x[0], result_summary)))
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % cpu_walltime, sep=''))
     if model_analyzer:
-        model_analyzer.aggregate(cpu_walltime * len(result_summary))
+        model_analyzer.aggregate()
     # if model_flops is not None, output the TFLOPs per sec
     if 'flops' in metrics_needed:
         if metrics_backend_mapping['flops'] == 'dcgm':

--- a/run.py
+++ b/run.py
@@ -72,7 +72,8 @@ def printResultSummaryTime(result_summary, metrics_needed=[], metrics_backend_ma
     else:
         cpu_walltime = np.median(list(map(lambda x: x[0], result_summary)))
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % cpu_walltime, sep=''))
-
+    if model_analyzer:
+        model_analyzer.aggregate(cpu_walltime * len(result_summary))
     # if model_flops is not None, output the TFLOPs per sec
     if 'flops' in metrics_needed:
         if metrics_backend_mapping['flops'] == 'dcgm':
@@ -174,7 +175,6 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_me
 
     if model_analyzer is not None:
         model_analyzer.stop_monitor()
-        model_analyzer.aggregate()
 
     printResultSummaryTime(result_summary, metrics_needed, metrics_backend_mapping, model, model_analyzer)
 


### PR DESCRIPTION
When using model analyzer to collect GPU and CPU metrics, the monitor threads are not safely exiting, and the last bunch of records is discarded. It has a small impact on the final metric values because we aggregate all values and use the average number. But when we enable the `--export-metrics` option to export all detailed metric information, the discarded records have a big influence on the result correctness.

This PR fixes the bug via the following method.
- use `self._thread.wait()` for the monitor threads to finish. 
- add an extra `self._monitoring_iteration()` to collect the last bunch of records after setting `self._thread_active` to false.