### PR TITLE
drq: change view to reshape to support channels last

### DIFF
--- a/torchbenchmark/models/drq/drq.py
+++ b/torchbenchmark/models/drq/drq.py
@@ -43,6 +43,8 @@ class Encoder(nn.Module):
             conv = torch.relu(self.convs[i](conv))
             self.outputs['conv%s' % (i + 1)] = conv
 
+        # Changed view to reshape here to support channels last input
+        # TODO: upstream this change to https://github.com/denisyarats/drq/blob/master/drq.py#L48
         h = conv.reshape(conv.size(0), -1)
         return h
 

--- a/torchbenchmark/models/drq/drq.py
+++ b/torchbenchmark/models/drq/drq.py
@@ -43,7 +43,7 @@ class Encoder(nn.Module):
             conv = torch.relu(self.convs[i](conv))
             self.outputs['conv%s' % (i + 1)] = conv
 
-        h = conv.view(conv.size(0), -1)
+        h = conv.reshape(conv.size(0), -1)
         return h
 
     def forward(self, obs, detach=False):


### PR DESCRIPTION
The current implementation of `drq` does not support **channels last** input since `view` has constraints on the input size and stride (https://pytorch.org/docs/stable/generated/torch.Tensor.view.html):
```
Cannot view a tensor with shape torch.Size([1, 32, 35, 35]) and strides (39200, 1, 1120, 32) as a tensor with shape (1, 39200)!
```

Change `view` to `reshape` which returns a view if the shapes are compatible, and copies (equivalent to calling `contiguous()`) otherwise.
