### PR TITLE
Add channels_last for all torchbench models and enable it with run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -292,6 +292,7 @@ if __name__ == "__main__":
                         help="Specify metrics [cpu_peak_mem,gpu_peak_mem,flops]to be collected. The metrics are separated by comma such as cpu_peak_mem,gpu_peak_mem.")
     parser.add_argument("--metrics-gpu-backend", choices=["dcgm", "default"], default="default", help="""Specify the backend [dcgm, default] to collect metrics. \nIn default mode, the latency(execution time) is collected by time.time_ns() and it is always enabled. Optionally,
     \n  - you can specify cpu peak memory usage by --metrics cpu_peak_mem, and it is collected by psutil.Process().  \n  - you can specify gpu peak memory usage by --metrics gpu_peak_mem, and it is collected by nvml library.\n  - you can specify flops by --metrics flops, and it is collected by fvcore.\nIn dcgm mode, the latency(execution time) is collected by time.time_ns() and it is always enabled. Optionally,\n  - you can specify cpu peak memory usage by --metrics cpu_peak_mem, and it is collected by psutil.Process().\n  - you can specify cpu and gpu peak memory usage by --metrics cpu_peak_mem,gpu_peak_mem, and they are collected by dcgm library.""")
+    parser.add_argument("--channels-last", action="store_true", help="enable torch.channels_last()")
     args, extra_args = parser.parse_known_args()
     if args.cudastreams and not args.device == "cuda":
         print("cuda device required to use --cudastreams option!")
@@ -305,6 +306,8 @@ if __name__ == "__main__":
 
     m = Model(device=args.device, test=args.test, jit=(args.mode == "jit"), batch_size=args.bs, extra_args=extra_args)
     print(f"Running {args.test} method from {Model.name} on {args.device} in {args.mode} mode with input batch size {m.batch_size}.")
+    if args.channels_last:
+        m.enable_channels_last()
 
     test = m.invoke
     if args.amp:


### PR DESCRIPTION
In order to standardize the performance evluation and increase coverage, added the `channels_last` for all torchbench models, and enable it with `run.py` entry for debug using. This PR as a first step to standardize and increase coverage for TorchBench, which works for the roadmap #1293.  

Took `alexnet` as an example, which run on CLX 8280L (28cc)
```shell
python run.py alexnet -d cpu -m eager -t eval
Running eval method from alexnet on cpu in eager mode with input batch size 128.
CPU Total Wall Time: 108.189 milliseconds
```

```shell
python run.py alexnet -d cpu -m eager -t eval --channels-last
Running eval method from alexnet on cpu in eager mode with input batch size 128.
CPU Total Wall Time:  72.930 milliseconds
```

