### PR TITLE
fix bug for short model executions

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -132,7 +132,11 @@ class ModelAnalyzer:
         Aaggregate must be called after stop_monitor.
         """
         if self.gpu_records:
-            self.gpu_records = [record for record in self.gpu_records if record.timestamp() <= self.stop_monitor_timestamp]
+            new_gpu_records = [record for record in self.gpu_records if record.timestamp() <= self.stop_monitor_timestamp]
+            if len(new_gpu_records) == 0:
+                self.gpu_records = self.gpu_records[:1]
+            else:
+                self.gpu_records = new_gpu_records
             self.gpu_record_aggregator.insert_all(self.gpu_records)
             records_groupby_gpu = self.gpu_record_aggregator.groupby(
                 self.gpu_metrics, lambda record: record.device_uuid())

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -143,7 +143,11 @@ class ModelAnalyzer:
                 for gpu_uuid, metric_value in metric.items():
                     self.gpu_metric_value[gpu_uuid][metric_type] = metric_value
         if self.cpu_records:
-            self.cpu_records = [record for record in self.cpu_records if record.timestamp() <= self.stop_monitor_timestamp]
+            new_cpu_records = [record for record in self.cpu_records if record.timestamp() <= self.stop_monitor_timestamp]
+            if len(new_cpu_records) == 0:
+                self.cpu_records = self.cpu_records[:1]
+            else:
+                self.cpu_records = new_cpu_records
             self.cpu_record_aggregator.insert_all(self.cpu_records)
             records_groupby_cpu = self.cpu_record_aggregator.groupby(
                 self.cpu_metrics, lambda record: record.device_uuid())


### PR DESCRIPTION
If the models' execution times are too short, e.g. 1ms, the CPU peak memory measurements will be discarded. It is because there is some overhead to create and start the monitoring for peak memory measurements, and it causes the timestamps to be a little bigger than the stop_timestamp. It happens only for several tiny models such as `phlippe_resnet` with torchinductor and torchscript, `pyhpc_equation_of_state` with torchscript.  I didn't observe the same thing happening on GPU memory records, but I also updated the GPU part.

This PR fixes this issue by reserving at least one record of CPU and GPU memory usage.