### PR TITLE
enable peak memory measurement by default

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -115,8 +115,10 @@ class ModelAnalyzer:
         try:
             self.start_monitor_timestamp = time_ns()
             if self.gpu_metrics:
-                self.gpu_factory = GPUDeviceFactory()
+                self.gpu_factory = GPUDeviceFactory(self.gpu_monitor_backend)
                 self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
+                if not self.gpus:
+                    raise TorchBenchAnalyzerException('No GPU found')
                 if self.gpu_monitor_backend == 'dcgm':
                     self.gpu_monitor = DCGMMonitor(
                         self.gpus, self.config.monitoring_interval, self.gpu_metrics)

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -279,11 +279,11 @@ class ModelAnalyzer:
             else:
                 raise TorchBenchAnalyzerException("No available GPU with uuid ", gpu_uuid, " found!")
         else:
-            if len(self.gpu_metric_value) > 1:
-                logger.warning("There are multiple available GPUs and will only return the first one's flops.")
+            # Will only return the first one's peak memory bandwidth. So please use CUDA_VISIBLE_DEVICES to specify the GPU.
             gpu_uuid = next(iter(self.gpu_metric_value))
             gpu = self.gpu_factory.get_device_by_uuid(gpu_uuid)
-            return gpu._sm_count * gpu._fma_count * 2 * gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9
+            device_id = self.gpu_factory.get_device_by_uuid(gpu_uuid).device_id()
+            return device_id, gpu._sm_count * gpu._fma_count * 2 * gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9
 
     def calculate_gpu_peak_mem(self, gpu_uuid=None) -> float:
         """
@@ -295,12 +295,12 @@ class ModelAnalyzer:
                 return self.gpu_metric_value[gpu_uuid][GPUPeakMemory].value() / 1024
             else:
                 raise TorchBenchAnalyzerException("No available GPU with uuid ", gpu_uuid, " found!")
-        if len(self.gpu_metric_value) > 1:
-            logger.warning("There are multiple available GPUs and will only return the first one's peak memory bandwidth.")
         if len(self.gpu_metric_value) == 0:
             raise TorchBenchAnalyzerException("No metrics collected!")
+        # Will only return the first one's peak memory bandwidth. So please use CUDA_VISIBLE_DEVICES to specify the GPU.
         gpu_uuid = next(iter(self.gpu_metric_value))
-        return self.gpu_metric_value[gpu_uuid][GPUPeakMemory].value() / 1024
+        device_id = self.gpu_factory.get_device_by_uuid(gpu_uuid).device_id()
+        return device_id, self.gpu_metric_value[gpu_uuid][GPUPeakMemory].value() / 1024
 
     def calculate_cpu_peak_mem(self, cpu_uuid=None) -> float:
         """

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -334,6 +334,6 @@ def check_nvml():
         pynvml.nvmlInit()
         pynvml.nvmlShutdown()
     except Exception as e:
-        logger.error("ERROR: NVML init failed. Please check the installation of nvidia-ml-py.", e)
+        logger.error("ERROR: NVML init failed. Please check the installation of pynvml.", e)
         exit(-1)
     return True

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -99,7 +99,7 @@ class ModelAnalyzer:
         self.gpu_monitor_backend = 'nvml'
 
     def set_export_csv_name(self, export_csv_name=''):
-        if export_csv_name == '':
+        if not export_csv_name:
             return
         self.export_csv_name = export_csv_name
         # test for correct permission
@@ -108,7 +108,7 @@ class ModelAnalyzer:
 
     def update_export_name(self, insert_str=''):
         index = self.export_csv_name.find('.csv')
-        if index != -1:
+        if not index == -1:
             self.export_csv_name = self.export_csv_name[:index] + insert_str + self.export_csv_name[index:]
 
     def start_monitor(self):

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -1,5 +1,5 @@
 
-from typing import OrderedDict
+from typing import Optional, OrderedDict, Tuple
 
 from .dcgm.cpu_monitor import CPUMonitor
 from .dcgm.dcgm_monitor import DCGMMonitor
@@ -30,7 +30,7 @@ from time import time_ns
 
 
 class ModelAnalyzer:
-    def __init__(self, export_metrics_file='', metrics_needed=[], metrics_gpu_backend='dcgm'):
+    def __init__(self, export_metrics_file=None, metrics_needed=[], metrics_gpu_backend='dcgm'):
         # For debug
         # set_logger(logging.DEBUG)
         set_logger()
@@ -55,7 +55,7 @@ class ModelAnalyzer:
         self.gpu_records = None
         self.config = AnalayzerConfig()
         self.gpu_record_aggregator = RecordAggregator()
-        self.export_csv_name = ''
+        self.export_csv_name = None
         self.set_export_csv_name(export_metrics_file)
         # the cpu metrics to be collected. available metrics are [CPUPeakMemory, ]
         self.cpu_metrics = []
@@ -65,7 +65,7 @@ class ModelAnalyzer:
         self.cpu_record_aggregator = RecordAggregator()
         self.cpu_metric_value = {}
         # GPU Monitor Backend
-        self.gpu_monitor_backend = 'dcgm'
+        self.gpu_monitor_backend = metrics_gpu_backend
         self.start_monitor_timestamp = None
         self.stop_monitor_timestamp = None
         self.metrics_backend_mapping = {}
@@ -98,7 +98,7 @@ class ModelAnalyzer:
     def set_gpu_monitor_backend_nvml(self):
         self.gpu_monitor_backend = 'nvml'
 
-    def set_export_csv_name(self, export_csv_name=''):
+    def set_export_csv_name(self, export_csv_name=None):
         if not export_csv_name:
             return
         self.export_csv_name = export_csv_name
@@ -285,7 +285,7 @@ class ModelAnalyzer:
             device_id = self.gpu_factory.get_device_by_uuid(gpu_uuid).device_id()
             return device_id, gpu._sm_count * gpu._fma_count * 2 * gpu._frequency * self.gpu_metric_value[gpu_uuid][GPUFP32Active].value() / 1e+9
 
-    def calculate_gpu_peak_mem(self, gpu_uuid=None) -> float:
+    def calculate_gpu_peak_mem(self, gpu_uuid=None) -> Tuple[Optional[str], float]:
         """
         The function to calculate GPU peak memory usage for the first available GPU.
         @return : a floating number representing GB.

--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -308,7 +308,7 @@ class ModelAnalyzer:
         @return : a floating number representing GB.
         """
         if len(self.cpu_metric_value) > 1:
-            logger.warning("There are multiple available CPUs and will only return the first one's peak memory bandwidth.")
+            logger.debug("There are multiple available CPUs and will only return the first one's peak memory bandwidth.")
         cpu_uuid = next(iter(self.cpu_metric_value))
         return self.cpu_metric_value[cpu_uuid][CPUPeakMemory].value() / 1024
     

--- a/components/model_analyzer/dcgm/nvml_monitor.py
+++ b/components/model_analyzer/dcgm/nvml_monitor.py
@@ -73,7 +73,8 @@ class NVMLMonitor(Monitor):
             handle = self._nvml.nvmlDeviceGetHandleByUUID(gpu.device_uuid())
             for metric in self._metrics:
                 nvml_field = self.model_analyzer_to_nvml_field[metric]
-                atimestamp = time.time_ns()
+                # convert to microseconds to keep consistency with the dcgm monitor
+                atimestamp = time.time_ns() // 1000
                 if metric == GPUPeakMemory:
                     info = self._nvml.nvmlDeviceGetMemoryInfo(handle)
                     # @Yueming TODO: need to update with the nvml API version 2. Because the nvml API version 1 returns the used memory including the memory allocated by the GPU driver.

--- a/components/model_analyzer/dcgm/nvml_monitor.py
+++ b/components/model_analyzer/dcgm/nvml_monitor.py
@@ -18,7 +18,7 @@ from . import dcgm_field_helpers
 from . import dcgm_structs as structs
 
 from packaging import version
-
+import pynvml
 
 
 class NVMLMonitor(Monitor):
@@ -48,7 +48,6 @@ class NVMLMonitor(Monitor):
         """
 
         super().__init__(frequency, metrics)
-        import pynvml
         self._nvml = pynvml
         self._nvml.nvmlInit()
         self._metrics = metrics
@@ -57,6 +56,7 @@ class NVMLMonitor(Monitor):
         self._gpus = gpus
         # gpu handles: {gpu: handle}
         self._gpu_handles = {}
+        self._nvmlDeviceGetHandleByUUID = None
         self.check_nvml_compatibility()
         for gpu in self._gpus:
             self._gpu_handles[gpu] = self._nvmlDeviceGetHandleByUUID(gpu.device_uuid())
@@ -66,7 +66,6 @@ class NVMLMonitor(Monitor):
 
     def check_nvml_compatibility(self):
         # check pynvml version, if it is less than 11.5.0, convert uuid to bytes
-        import pynvml
         current_version = version.parse(pynvml.__version__)
         if current_version < version.parse("11.5.0"):
             self._nvmlDeviceGetHandleByUUID=self._nvmlDeviceGetHandleByUUID_for_older_pynvml

--- a/components/model_analyzer/requirements.txt
+++ b/components/model_analyzer/requirements.txt
@@ -1,2 +1,2 @@
 numba
-nvidia-ml-py
+pynvml

--- a/components/model_analyzer/tb_dcgm_types/da_exceptions.py
+++ b/components/model_analyzer/tb_dcgm_types/da_exceptions.py
@@ -3,14 +3,3 @@ class TorchBenchAnalyzerException(Exception):
     A custom exception specific to the TorchBench Model Analyzer
     """
     pass
-
-
-class TorchBenchAnalyzerExceptionGPUUnavailable(Exception):
-    """
-    A warning when the GPU is not visible to the process. 
-    It is benign and can be ignored when there are multiple GPUs and only a subset of them are used.
-    """
-
-    def __init__(self, gpu_uuid='0000', *args: object) -> None:
-        self.message = f'Warning: GPU with {gpu_uuid} uuid is not present!'
-        super().__init__(self.message, *args)

--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from numba.cuda.cudadrv import enums
 # @Yueming Hao: TODO: Replace this with nvml API
+from .da_exceptions import TorchBenchAnalyzerException
 from numba import cuda
-from .da_exceptions import TorchBenchAnalyzerException, TorchBenchAnalyzerExceptionGPUUnavailable
-
-
 
 class Device:
     """
@@ -47,23 +44,16 @@ class GPUDevice(Device):
                 Device UUID
         """
 
-        assert type(device_name) is str
-        assert type(device_id) is int
-        assert type(pci_bus_id) is str
-        assert type(device_uuid) is str
-
         self._device_name = device_name
         self._device_id = device_id
         self._pci_bus_id = pci_bus_id
         self._device_uuid = device_uuid
         self._device = None
-        self._sm_count = 0
         for gpu in cuda.gpus:
             if gpu._device.uuid == device_uuid:
                 self._device = gpu
         if self._device is None:
-            raise TorchBenchAnalyzerExceptionGPUUnavailable(device_uuid)
-
+            raise TorchBenchAnalyzerException('Failed to find GPU with UUID: {}'.format(device_uuid))
         self._sm_count = self._device.MULTIPROCESSOR_COUNT
         fma_count = ConvertSMVer2Cores(self._device.COMPUTE_CAPABILITY_MAJOR, self._device.COMPUTE_CAPABILITY_MINOR)
         if fma_count == 0:

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -83,7 +83,8 @@ class GPUDeviceFactory:
                     try :
                         gpu_device = GPUDevice(device_name, device_id, pci_bus_id,device_uuid)
                     except TorchBenchAnalyzerException as e:
-                        logger.warning("Skipping device %s due to %s", device_name, e)
+                        # logger.warning("Skipping device %s due to %s", device_name, e)
+                        continue
                     self._devices.append(gpu_device)
                     self._devices_by_bus_id[pci_bus_id] = gpu_device
                     self._devices_by_uuid[device_uuid] = gpu_device
@@ -101,7 +102,7 @@ class GPUDeviceFactory:
                 try:
                     gpu_device = GPUDevice(device_name, device_id, pci_bus_id, device_uuid)
                 except TorchBenchAnalyzerException as e:
-                    logger.warning("Skipping device %s due to %s", device_name, e)
+                    # logger.warning("Skipping device %s due to %s", device_name, e)
                     continue
                 self._devices.append(gpu_device)
                 self._devices_by_bus_id[pci_bus_id] = gpu_device

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -20,6 +20,7 @@ from ..dcgm import dcgm_structs as structs
 from .da_exceptions import TorchBenchAnalyzerException
 import pynvml
 import numba.cuda
+numba.cuda.config.CUDA_LOG_LEVEL = "ERROR"
 import logging
 
 logger = logging.getLogger(LOGGER_NAME)

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -70,7 +70,7 @@ class GPUDeviceFactory:
                         gpu_device = GPUDevice(device_name, device_id, pci_bus_id,
                                             device_uuid)
                     except TorchBenchAnalyzerExceptionGPUUnavailable as e:
-                        logger.warning(e)
+                        logger.info(e)
                         continue
                     self._devices.append(gpu_device)
                     self._devices_by_bus_id[pci_bus_id] = gpu_device
@@ -93,7 +93,7 @@ class GPUDeviceFactory:
                 try:
                     gpu_device = GPUDevice(device_name, device_id, pci_bus_id, device_uuid)
                 except TorchBenchAnalyzerExceptionGPUUnavailable as e:
-                    logger.warning(e)
+                    logger.info(e)
                     continue
                 self._devices.append(gpu_device)
                 self._devices_by_bus_id[pci_bus_id] = gpu_device

--- a/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device_factory.py
@@ -64,7 +64,7 @@ class GPUDeviceFactory:
 
         if self._model_analyzer_backend == 'dcgm':
             if numba.cuda.is_available():
-                logger.info("Initiliazing GPUDevice handles using DCGM")
+                logger.debug("Initiliazing GPUDevice handles using DCGM")
                 structs._dcgmInit(dcgmPath)
                 dcgm_agent.dcgmInit()
 
@@ -83,7 +83,7 @@ class GPUDeviceFactory:
                     try :
                         gpu_device = GPUDevice(device_name, device_id, pci_bus_id,device_uuid)
                     except TorchBenchAnalyzerException as e:
-                        # logger.warning("Skipping device %s due to %s", device_name, e)
+                        logger.debug("Skipping device %s due to %s", device_name, e)
                         continue
                     self._devices.append(gpu_device)
                     self._devices_by_bus_id[pci_bus_id] = gpu_device
@@ -91,7 +91,7 @@ class GPUDeviceFactory:
 
             dcgm_agent.dcgmShutdown()
         else:
-            logger.info("Initializing GPUDevice handles using NVML")
+            logger.debug("Initializing GPUDevice handles using NVML")
             # Create a GPU device for every supported NVML device
             nvml_device_count = self._nvml.nvmlDeviceGetCount()
             for device_id in range(nvml_device_count):
@@ -102,7 +102,7 @@ class GPUDeviceFactory:
                 try:
                     gpu_device = GPUDevice(device_name, device_id, pci_bus_id, device_uuid)
                 except TorchBenchAnalyzerException as e:
-                    # logger.warning("Skipping device %s due to %s", device_name, e)
+                    logger.debug("Skipping device %s due to %s", device_name, e)
                     continue
                 self._devices.append(gpu_device)
                 self._devices_by_bus_id[pci_bus_id] = gpu_device
@@ -225,7 +225,7 @@ class GPUDeviceFactory:
                 self._log_gpus_used(cuda_visible_gpus)
                 return cuda_visible_gpus
             elif requested_gpus[0] == '[]':
-                logger.info("No GPUs requested")
+                logger.debug("No GPUs requested")
                 return []
 
         try:
@@ -271,7 +271,7 @@ class GPUDeviceFactory:
                         self.get_device_by_cuda_index(cuda_device.id))
                 except TorchBenchAnalyzerException:
                     # Device not supported by DCGM, log warning
-                    logger.warning(
+                    logger.debug(
                         f"Device '{str(cuda_device.name, encoding='ascii')}' with "
                         f"cuda device id {cuda_device.id} is not supported by DCGM."
                     )
@@ -283,6 +283,6 @@ class GPUDeviceFactory:
         """
 
         for gpu in gpus:
-            logger.info(
+            logger.debug(
                 f"Using GPU {gpu.device_id()} {gpu.device_name()} with UUID {gpu.device_uuid()}"
             )

--- a/components/model_analyzer/tb_dcgm_types/tb_logger.py
+++ b/components/model_analyzer/tb_dcgm_types/tb_logger.py
@@ -5,7 +5,7 @@ import logging
 LOGGER_NAME = 'TorchBenchLogger'
 
 
-def set_logger(logger_level=logging.warning):
+def set_logger(logger_level=logging.WARNING):
     formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/components/model_analyzer/tb_dcgm_types/tb_logger.py
+++ b/components/model_analyzer/tb_dcgm_types/tb_logger.py
@@ -5,7 +5,7 @@ import logging
 LOGGER_NAME = 'TorchBenchLogger'
 
 
-def set_logger(logger_level=logging.INFO):
+def set_logger(logger_level=logging.warning):
     formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ numpy==1.21.2
 git+https://github.com/kornia/kornia.git@b7050c3
 scipy # for lazy_bench.py
 submitit
+nvidia-ml-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ numpy==1.21.2
 git+https://github.com/kornia/kornia.git@b7050c3
 scipy # for lazy_bench.py
 submitit
-nvidia-ml-py
+pynvml

--- a/run.py
+++ b/run.py
@@ -117,10 +117,6 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_me
             model_analyzer.add_metric_cpu_peak_mem()
         if metrics_gpu_backend == "default":
             model_analyzer.set_gpu_monitor_backend_nvml()
-        for metric in metrics_backend_mapping:
-            print(f"Metric {metric} is collected by {metrics_backend_mapping[metric]} backend")
-        if 'cpu_peak_mem' in metrics_needed:
-            print("Metric cpu_peak_mem is collected by psutil.Process.")
         model_analyzer.start_monitor()
 
     if stress:

--- a/run.py
+++ b/run.py
@@ -80,14 +80,14 @@ def printResultSummaryTime(result_summary, metrics_needed=[], model=None, flops_
         else:
             flops, batch_size = model.get_flops()
             tflops = flops * batch_size / (cpu_walltime / 1.0e3) / 1.0e12
-        print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
+        print('{:<20} {:>20}'.format("GPU %d FLOPS:" % tflops_device_id, "%.4f TFLOPs per second" % tflops, sep=''))
     if gpu_peak_mem is not None:
         print('{:<20} {:>20}'.format("GPU %d Peak Memory:" % device_id, "%.4f GB" % gpu_peak_mem, sep=''))
     if cpu_peak_mem is not None:
         print('{:<20} {:>20}'.format("CPU Peak Memory:", "%.4f GB" % cpu_peak_mem, sep=''))
 
 
-def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_metrics_file='', stress=0, metrics_needed=[], metrics_gpu_backend=None):
+def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_metrics_file=None, stress=0, metrics_needed=[], metrics_gpu_backend=None):
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
         func()

--- a/run.py
+++ b/run.py
@@ -58,7 +58,7 @@ def run_one_step_with_cudastreams(func, streamcount):
         print('{:<20} {:>20}'.format("GPU Time:", "%.3f milliseconds" % start_event.elapsed_time(end_event)), sep='')
 
 
-def printResultSummaryTime(result_summary, metrics_needed=[], model=None, flops_model_analyzer=None, cpu_peak_mem=None, device_id=None, gpu_peak_mem=None):
+def printResultSummaryTime(result_summary, metrics_needed=[], model=None, flops_model_analyzer=None, cpu_peak_mem=None, mem_device_id=None, gpu_peak_mem=None):
     if args.device == "cuda":
         gpu_time = np.median(list(map(lambda x: x[0], result_summary)))
         cpu_walltime = np.median(list(map(lambda x: x[1], result_summary)))
@@ -82,7 +82,7 @@ def printResultSummaryTime(result_summary, metrics_needed=[], model=None, flops_
             tflops = flops * batch_size / (cpu_walltime / 1.0e3) / 1.0e12
         print('{:<20} {:>20}'.format("GPU %d FLOPS:" % tflops_device_id, "%.4f TFLOPs per second" % tflops, sep=''))
     if gpu_peak_mem is not None:
-        print('{:<20} {:>20}'.format("GPU %d Peak Memory:" % device_id, "%.4f GB" % gpu_peak_mem, sep=''))
+        print('{:<20} {:>20}'.format("GPU %d Peak Memory:" % mem_device_id, "%.4f GB" % gpu_peak_mem, sep=''))
     if cpu_peak_mem is not None:
         print('{:<20} {:>20}'.format("CPU Peak Memory:", "%.4f GB" % cpu_peak_mem, sep=''))
 
@@ -154,10 +154,11 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_me
         flops_model_analyzer.aggregate()
     cpu_peak_mem = None
     gpu_peak_mem = None
+    mem_device_id = None
     if 'cpu_peak_mem' or 'gpu_peak_mem' in metrics_needed:
-        cpu_peak_mem, device_id, gpu_peak_mem = get_peak_memory(func, model.device, export_metrics_file=export_metrics_file, metrics_needed=metrics_needed, metrics_gpu_backend=metrics_gpu_backend)
+        cpu_peak_mem, mem_device_id, gpu_peak_mem = get_peak_memory(func, model.device, export_metrics_file=export_metrics_file, metrics_needed=metrics_needed, metrics_gpu_backend=metrics_gpu_backend)
 
-    printResultSummaryTime(result_summary, metrics_needed, model, flops_model_analyzer, cpu_peak_mem, device_id, gpu_peak_mem)
+    printResultSummaryTime(result_summary, metrics_needed, model, flops_model_analyzer, cpu_peak_mem, mem_device_id, gpu_peak_mem)
 
 
 

--- a/run.py
+++ b/run.py
@@ -301,7 +301,9 @@ if __name__ == "__main__":
         test = torch.autocast("cuda")(test)
     metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
     # enable cpu_peak_mem and gpu_peak_mem by default
-    metrics_needed.extend(['cpu_peak_mem', 'gpu_peak_mem'])
+    metrics_needed.append('cpu_peak_mem')
+    if args.device == 'cuda':
+        metrics_needed.append('gpu_peak_mem')
     metrics_needed = list(set(metrics_needed))
     metrics_gpu_backend = args.metrics_gpu_backend
     if metrics_needed:
@@ -322,7 +324,7 @@ if __name__ == "__main__":
             exit(-1)
         export_metrics_file = "%s_all_metrics.csv" % args.model
     else:
-        export_metrics_file = ''
+        export_metrics_file = None
     if args.profile:
         profile_one_step(test)
     elif args.cudastreams:

--- a/run.py
+++ b/run.py
@@ -14,6 +14,7 @@ import numpy as np
 import torch.profiler as profiler
 
 from torchbenchmark import load_model_by_name
+from torchbenchmark.util.experiment.metrics import get_peak_memory
 import torch
 
 WARMUP_ROUNDS = 3
@@ -57,7 +58,7 @@ def run_one_step_with_cudastreams(func, streamcount):
         print('{:<20} {:>20}'.format("GPU Time:", "%.3f milliseconds" % start_event.elapsed_time(end_event)), sep='')
 
 
-def printResultSummaryTime(result_summary, metrics_needed=[], metrics_backend_mapping={}, model=None, model_analyzer=None):
+def printResultSummaryTime(result_summary, metrics_needed=[], model=None, flops_model_analyzer=None, cpu_peak_mem=None, gpu_peak_mem=None):
     if args.device == "cuda":
         gpu_time = np.median(list(map(lambda x: x[0], result_summary)))
         cpu_walltime = np.median(list(map(lambda x: x[1], result_summary)))
@@ -72,52 +73,31 @@ def printResultSummaryTime(result_summary, metrics_needed=[], metrics_backend_ma
     else:
         cpu_walltime = np.median(list(map(lambda x: x[0], result_summary)))
         print('{:<20} {:>20}'.format("CPU Total Wall Time:", "%.3f milliseconds" % cpu_walltime, sep=''))
-    if model_analyzer:
-        model_analyzer.aggregate()
     # if model_flops is not None, output the TFLOPs per sec
     if 'flops' in metrics_needed:
-        if metrics_backend_mapping['flops'] == 'dcgm':
-            tflops = model_analyzer.calculate_flops()
+        if flops_model_analyzer.metrics_backend_mapping['flops'] == 'dcgm':
+            tflops = flops_model_analyzer.calculate_flops()
         else:
             flops, batch_size = model.get_flops()
             tflops = flops * batch_size / (cpu_walltime / 1.0e3) / 1.0e12
         print('{:<20} {:>20}'.format("FLOPS:", "%.4f TFLOPs per second" % tflops, sep=''))
-
-    if 'gpu_peak_mem' in metrics_needed:
-        gpu_peak_mem = model_analyzer.calculate_gpu_peak_mem()
+    if gpu_peak_mem is not None:
         print('{:<20} {:>20}'.format("GPU Peak Memory:", "%.4f GB" % gpu_peak_mem, sep=''))
-    if 'cpu_peak_mem' in metrics_needed:
-        cpu_peak_mem = model_analyzer.calculate_cpu_peak_mem()
+    if cpu_peak_mem is not None:
         print('{:<20} {:>20}'.format("CPU Peak Memory:", "%.4f GB" % cpu_peak_mem, sep=''))
 
 
-def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_metrics_file=False, stress=0, metrics_needed=[], metrics_gpu_backend=None):
+def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_metrics_file='', stress=0, metrics_needed=[], metrics_gpu_backend=None):
     # Warm-up `nwarmup` rounds
     for _i in range(nwarmup):
         func()
 
     result_summary = []
-    metrics_backend_mapping = {}
-    model_analyzer = None
-    if metrics_needed:
+    flops_model_analyzer = None
+    if 'flops' in metrics_needed:
         from components.model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
-        model_analyzer = ModelAnalyzer()
-        if export_metrics_file:
-            model_analyzer.set_export_csv_name(export_metrics_file)
-        if 'gpu_peak_mem' in metrics_needed:
-            model_analyzer.add_metric_gpu_peak_mem()
-            metrics_backend_mapping['gpu_peak_mem'] = 'dcgm' if metrics_gpu_backend == 'dcgm' else 'nvml'
-        if 'flops' in metrics_needed:
-            if metrics_gpu_backend == 'dcgm':
-                model_analyzer.add_metric_gpu_flops()
-                metrics_backend_mapping['flops'] = 'dcgm'
-            else:
-                metrics_backend_mapping['flops'] = 'fvcore'
-        if 'cpu_peak_mem' in metrics_needed:
-            model_analyzer.add_metric_cpu_peak_mem()
-        if metrics_gpu_backend == "default":
-            model_analyzer.set_gpu_monitor_backend_nvml()
-        model_analyzer.start_monitor()
+        flops_model_analyzer = ModelAnalyzer(export_metrics_file, ['flops'], metrics_gpu_backend)
+        flops_model_analyzer.start_monitor()
 
     if stress:
         cur_time = time.time_ns()
@@ -169,13 +149,16 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_me
                 last_it = _i
         _i += 1
 
-    if model_analyzer is not None:
-        model_analyzer.stop_monitor()
+    if flops_model_analyzer is not None:
+        flops_model_analyzer.stop_monitor()
+        flops_model_analyzer.aggregate()
+    cpu_peak_mem = None
+    gpu_peak_mem = None
+    if 'cpu_peak_mem' or 'gpu_peak_mem' in metrics_needed:
+        cpu_peak_mem, gpu_peak_mem = get_peak_memory(func, model.device, export_metrics_file=export_metrics_file, metrics_needed=metrics_needed, metrics_gpu_backend=metrics_gpu_backend)
 
-    printResultSummaryTime(result_summary, metrics_needed, metrics_backend_mapping, model, model_analyzer)
+    printResultSummaryTime(result_summary, metrics_needed, model, flops_model_analyzer, cpu_peak_mem, gpu_peak_mem)
 
-    if export_metrics_file:
-        model_analyzer.export_all_records_to_csv()
 
 
 def profile_one_step(func, nwarmup=WARMUP_ROUNDS):
@@ -339,7 +322,7 @@ if __name__ == "__main__":
             exit(-1)
         export_metrics_file = "%s_all_metrics.csv" % args.model
     else:
-        export_metrics_file = False
+        export_metrics_file = ''
     if args.profile:
         profile_one_step(test)
     elif args.cudastreams:

--- a/run.py
+++ b/run.py
@@ -321,6 +321,9 @@ if __name__ == "__main__":
     if args.amp:
         test = torch.autocast("cuda")(test)
     metrics_needed = [_ for _ in args.metrics.split(',') if _.strip()] if args.metrics else []
+    # enable cpu_peak_mem and gpu_peak_mem by default
+    metrics_needed.extend(['cpu_peak_mem', 'gpu_peak_mem'])
+    metrics_needed = list(set(metrics_needed))
     metrics_gpu_backend = args.metrics_gpu_backend
     if metrics_needed:
         if metrics_gpu_backend == 'dcgm':

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -6,7 +6,7 @@ import time
 import dataclasses
 from torchbenchmark.util.model import BenchmarkModel
 from torchbenchmark import ModelTask
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Optional
 
 WARMUP_ROUNDS = 10
 BENCHMARK_ITERS = 15
@@ -15,7 +15,7 @@ NANOSECONDS_PER_MILLISECONDS = 1_000_000.0
 @dataclasses.dataclass
 class TorchBenchModelMetrics:
     latencies: List[float]
-    cpu_peak_mem: float
+    cpu_peak_mem: Optional[float]
     gpu_peak_mem: float
 
 def get_latencies(func, device: str, nwarmup=WARMUP_ROUNDS, num_iter=BENCHMARK_ITERS) -> List[float]:

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -41,7 +41,8 @@ def get_latencies(func, device: str, nwarmup=WARMUP_ROUNDS, num_iter=BENCHMARK_I
         result_summary.append((t1 - t0) / NANOSECONDS_PER_MILLISECONDS)
     return result_summary
 
-def get_peak_memory(func, device: str, num_iter=MEMPROF_ITER, export_metrics_file='', metrics_needed=[], metrics_gpu_backend='dcgm') -> Tuple[float, float]:
+
+def get_peak_memory(func, device: str, num_iter=MEMPROF_ITER, export_metrics_file='', metrics_needed=[], metrics_gpu_backend='dcgm') -> Tuple[Optional[float], Optional[str], Optional[float]]:
     "Run one step of the model, and return the peak memory in MB."
     from components.model_analyzer.TorchBenchAnalyzer import ModelAnalyzer
     new_metrics_needed = [_ for _ in metrics_needed if _ in ['cpu_peak_mem', 'gpu_peak_mem']]
@@ -59,14 +60,12 @@ def get_peak_memory(func, device: str, num_iter=MEMPROF_ITER, export_metrics_fil
     mem_model_analyzer.stop_monitor()
     mem_model_analyzer.aggregate()
     device_id = None
+    gpu_peak_mem = None
+    cpu_peak_mem = None
     if 'gpu_peak_mem' in metrics_needed:
         device_id, gpu_peak_mem = mem_model_analyzer.calculate_gpu_peak_mem()
-    else:
-        gpu_peak_mem = None
     if 'cpu_peak_mem' in metrics_needed:
         cpu_peak_mem = mem_model_analyzer.calculate_cpu_peak_mem()
-    else:
-        cpu_peak_mem = None
     if export_metrics_file:
         mem_model_analyzer.update_export_name("_peak_memory")
         mem_model_analyzer.export_all_records_to_csv()

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -58,7 +58,7 @@ def get_peak_memory(func, device: str, num_iter=BENCHMARK_ITERS, export_metrics_
     mem_model_analyzer.stop_monitor()
     mem_model_analyzer.aggregate()
     if 'gpu_peak_mem' in metrics_needed:
-        gpu_peak_mem = mem_model_analyzer.calculate_gpu_peak_mem()
+        device_id, gpu_peak_mem = mem_model_analyzer.calculate_gpu_peak_mem()
     else:
         gpu_peak_mem = None
     if 'cpu_peak_mem' in metrics_needed:
@@ -68,7 +68,7 @@ def get_peak_memory(func, device: str, num_iter=BENCHMARK_ITERS, export_metrics_
     if export_metrics_file:
         mem_model_analyzer.update_export_name("_peak_memory")
         mem_model_analyzer.export_all_records_to_csv()
-    return cpu_peak_mem, gpu_peak_mem
+    return cpu_peak_mem, device_id, gpu_peak_mem
 
 
 def _get_model_test_metrics(model: BenchmarkModel) -> TorchBenchModelMetrics:

--- a/userbenchmark/model-stableness/__init__.py
+++ b/userbenchmark/model-stableness/__init__.py
@@ -96,7 +96,7 @@ def run(args: List[str]):
                 # load the model instance within the same process
                 model = load_model(cfg)
                 # get the model test metrics
-                metrics: TorchBenchModelMetrics = get_model_test_metrics(model)
+                metrics: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=["latencies"])
                 single_round_result.append({
                     'cfg': cfg.__dict__,
                     'raw_metrics': metrics.__dict__,


### PR DESCRIPTION
The CPU and GPU peak memory measurements will be enabled by default.
The output is like the following:
```
$ python3 run.py -d cuda -t train   BERT_pytorch 
Running train method from BERT_pytorch on cuda in eager mode with input batch size 16.
GPU Time:            107.128 milliseconds
CPU Total Wall Time: 107.156 milliseconds
GPU 0 Peak Memory:                6.2205 GB
CPU Peak Memory:                2.8018 GB
```
The dependent package could be installed by the following command.
```
pip install pynvml
```