### PR TITLE
Fix cudagraph backend

### DIFF
--- a/torchbenchmark/util/backends/__init__.py
+++ b/torchbenchmark/util/backends/__init__.py
@@ -34,10 +34,7 @@ def list_backends():
 # register the backends
 from .jit import torchscript
 from .ait import fx2ait
-<<<<<<< HEAD
 from .trt import fx2trt, torch_trt
-=======
 from .cudagraph import cudagraph
->>>>>>> 12151c41 (Add cuda graph)
 
 __all__ = [list_backends, create_backend ]

--- a/torchbenchmark/util/backends/__init__.py
+++ b/torchbenchmark/util/backends/__init__.py
@@ -34,6 +34,10 @@ def list_backends():
 # register the backends
 from .jit import torchscript
 from .ait import fx2ait
+<<<<<<< HEAD
 from .trt import fx2trt, torch_trt
+=======
+from .cudagraph import cudagraph
+>>>>>>> 12151c41 (Add cuda graph)
 
 __all__ = [list_backends, create_backend ]

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -8,20 +8,28 @@ WARMUP_ITER = 3
 def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: List[str]):
     cudagraph_func_name = f"cudagraph_{model.test}"
     assert hasattr(model, cudagraph_func_name), f"CUDA Graph only works on models implement {cudagraph_func_name}()"
+    if model.test == "train":
+        assert hasattr(model, "SKIP_ZERO_GRAD"), f"The model must support skipping zero grad in its train test."
     def _cudagraph():
         # CUDAGraph can't be copied/pickled, disable copying in correctness checking
         model.DEEPCOPY = False
+        model.SKIP_ZERO_GRAD = True
         # warmup
         s = torch.cuda.Stream()
         s.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(s):
             for _ in range(WARMUP_ITER):
+                model.opt.zero_grad(set_to_none=True)
                 model.invoke()
         torch.cuda.current_stream().wait_stream(s)
         # capture
         cuda_graph = torch.cuda.CUDAGraph()
+        model.opt.zero_grad(set_to_none=True)
         with torch.cuda.graph(cuda_graph):
             model.invoke()
         model.g = cuda_graph
-        model.invoke = getattr(model, cudagraph_func_name)
+        if model.test == "train":
+            model.train = getattr(model, cudagraph_func_name)
+        else:
+            model.eval = getattr(model, cudagraph_func_name)
     return _cudagraph, backend_args

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -8,9 +8,9 @@ WARMUP_ITER = 3
 def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: List[str]):
     cudagraph_func_name = f"cudagraph_{model.test}"
     assert hasattr(model, cudagraph_func_name), f"CUDA Graph only works on models implement {cudagraph_func_name}()"
-    # CUDAGraph can't be copied/pickled, disable copying in correctness checking
-    model.DEEPCOPY = False
     def _cudagraph():
+        # CUDAGraph can't be copied/pickled, disable copying in correctness checking
+        model.DEEPCOPY = False
         # warmup
         s = torch.cuda.Stream()
         s.wait_stream(torch.cuda.current_stream())

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -8,6 +8,8 @@ WARMUP_ITER = 3
 def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: List[str]):
     cudagraph_func_name = f"cudagraph_{model.test}"
     assert hasattr(model, cudagraph_func_name), f"CUDA Graph only works on models implement {cudagraph_func_name}()"
+    # CUDAGraph can't be copied/pickled, disable copying in correctness checking
+    model.DEEPCOPY = False
     def _cudagraph():
         # warmup
         s = torch.cuda.Stream()

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -1,26 +1,24 @@
 import torch
-from typing import Tuple
+from torchbenchmark.util.backends import create_backend
+from typing import List
 
-def enable_cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', example_inputs: Tuple[torch.tensor]):
-    optimizer = model.optimizer
-    loss_fn = model.loss_fn
-    # warmup
-    s = torch.cuda.Stream()
-    s.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(s):
-        for _ in range(3):
-            optimizer.zero_grad(set_to_none=True)
-            y_pred = model.model(*example_inputs)
-            loss = loss_fn(y_pred, model.example_outputs)
-            loss.backward()
-            optimizer.step()
-    torch.cuda.current_stream().wait_stream(s)
-    # capture
-    g = torch.cuda.CUDAGraph()
-    optimizer.zero_grad(set_to_none=True)
-    with torch.cuda.graph(g):
-        static_y_pred = model.model(*example_inputs)
-        static_loss = loss_fn(static_y_pred, model.example_outputs)
-        static_loss.backward()
-        optimizer.step()
-    model.g = g
+WARMUP_ITER = 3
+
+@create_backend
+def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: List[str]):
+    def _cudagraph():
+        # warmup
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(WARMUP_ITER):
+                model.invoke()
+        torch.cuda.current_stream().wait_stream(s)
+        # capture
+        cuda_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(cuda_graph):
+            model.invoke()
+        def _run_cudagraph(g=cuda_graph):
+            g.replay()
+        model.invoke = _run_cudagraph
+    return _cudagraph, backend_args

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -19,12 +19,14 @@ def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: L
         s.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(s):
             for _ in range(WARMUP_ITER):
-                model.opt.zero_grad(set_to_none=True)
+                if model.test == "train":
+                    model.opt.zero_grad(set_to_none=True)
                 model.invoke()
         torch.cuda.current_stream().wait_stream(s)
         # capture
         cuda_graph = torch.cuda.CUDAGraph()
-        model.opt.zero_grad(set_to_none=True)
+        if model.test == "train":
+            model.opt.zero_grad(set_to_none=True)
         with torch.cuda.graph(cuda_graph):
             model.invoke()
         model.g = cuda_graph

--- a/torchbenchmark/util/backends/cudagraph.py
+++ b/torchbenchmark/util/backends/cudagraph.py
@@ -32,6 +32,8 @@ def cudagraph(model: 'torchbenchmark.util.model.BenchmarkModel', backend_args: L
         model.g = cuda_graph
         if model.test == "train":
             model.train = getattr(model, cudagraph_func_name)
-        else:
+        elif model.test == "eval":
             model.eval = getattr(model, cudagraph_func_name)
+        else:
+            assert False, f"Expected model test train or eval, get {model.test}"
     return _cudagraph, backend_args

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -19,14 +19,13 @@ def check_correctness_p(
         return False
     if dargs.skip_correctness:
         return False
-    is_eval_test = model.test == "eval"
     # always check correctness with torchdynamo
     if model.dynamo:
         return True
     opt_args_dict = vars(opt_args)
     for k in opt_args_dict:
         if opt_args_dict[k]:
-            return is_eval_test
+            return True
     return False
 
 def add_bool_arg(parser: argparse.ArgumentParser, name: str, default_value: bool=True):
@@ -135,8 +134,6 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
         model._enable_backend, extra_args = backend(model, backend_args=extra_args)
     if model.device == "cpu" and args.fuser:
         raise NotImplementedError("Fuser only works with GPU.")
-    if is_torchvision_model(model):
-        args.cudagraph = False
     return args, extra_args
 
 def apply_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', args: argparse.Namespace):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -40,6 +40,9 @@ class TorchVisionModel(BenchmarkModel):
             self.real_output = [ torch.rand_like(self.example_outputs) ]
         elif test == "eval":
             self.model.eval()
+            self.example_outputs = torch.rand_like(self.model(*self.example_inputs))
+            self.real_input = [ torch.rand_like(self.example_inputs[0]) ]
+            self.real_output = [ torch.rand_like(self.example_outputs) ]
 
         self.amp_context = nullcontext
 

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -15,6 +15,8 @@ class TorchVisionModel(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = None
     # Default eval precision on CUDA device is fp16
     DEFAULT_EVAL_CUDA_PRECISION = "fp16"
+    # Whether to skip the opt zero grad
+    SKIP_ZERO_GRAD = False
 
     def __init__(self, model_name, test, device, jit=False, batch_size=None, weights=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
@@ -67,7 +69,7 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self):
-        if self.opt:
+        if self.opt and not self.SKIP_ZERO_GRAD:
             self.opt.zero_grad()
         for data, target in zip(self.real_input, self.real_output):
             with self.amp_context():

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -33,7 +33,7 @@ class TorchVisionModel(BenchmarkModel):
             # if backend is cudagraph, must set optimizer to be capturable
             capturable = bool(int(os.getenv("ADAM_CAPTURABLE", 0))) \
                 if not self.opt_args.backend == "cudagraph" else True
-            self.optimizer = optim.Adam(self.model.parameters(), capturable=capturable)
+            self.opt = optim.Adam(self.model.parameters(), capturable=capturable)
             self.loss_fn = torch.nn.CrossEntropyLoss()
             self.real_input = [ torch.rand_like(self.example_inputs[0]) ]
             self.real_output = [ torch.rand_like(self.example_outputs) ]
@@ -67,12 +67,12 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self):
-        self.optimizer.zero_grad()
+        self.opt.zero_grad()
         for data, target in zip(self.real_input, self.real_output):
             with self.amp_context():
                 pred = self.model(data)
             self.loss_fn(pred, target).backward()
-            self.optimizer.step()
+            self.opt.step()
 
     def cudagraph_train(self):
         for data, target in zip(self.real_input, self.real_output):

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -67,12 +67,14 @@ class TorchVisionModel(BenchmarkModel):
         return self.model, self.example_inputs
 
     def train(self):
-        self.opt.zero_grad()
+        if self.opt:
+            self.opt.zero_grad()
         for data, target in zip(self.real_input, self.real_output):
             with self.amp_context():
                 pred = self.model(data)
             self.loss_fn(pred, target).backward()
-            self.opt.step()
+            if self.opt:
+                self.opt.step()
 
     def cudagraph_train(self):
         for data, target in zip(self.real_input, self.real_output):


### PR DESCRIPTION
Fix the CUDA Graph code on torchvision.

Test plan:
```
$ python run.py  resnet18 -d cuda -t eval --backend cudagraph
Running eval method from resnet18 on cuda in eager mode with input batch size 256.
GPU Time:             16.525 milliseconds
CPU Total Wall Time:  16.561 milliseconds
Correctness:                         True
$ python run.py  resnet18 -d cuda -t train --backend cudagraph
Running train method from resnet18 on cuda in eager mode with input batch size 16.
GPU Time:              7.137 milliseconds
CPU Total Wall Time:   7.199 milliseconds
Correctness:                        False
```