### PR TITLE
check for fx2trt only for cuda device

### DIFF
--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -164,7 +164,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 self.dargs.precision == "fp16"
                 or self.dargs.precision == "amp"
                 or (self.dynamo and self.opt_args.torchdynamo == "fx2trt")
-                or (not self.dynamo and self.opt_args.fx2trt)
+                or (not self.dynamo and (self.device == "cuda" and self.opt_args.backend == "fx2trt"))
                 or (not self.dynamo and self.opt_args.use_cosine_similarity)
             ):
                 self.correctness = correctness_check(self, cos_sim=True, deepcopy=self.DEEPCOPY)


### PR DESCRIPTION
this change is required to make the cpu device (-d cpu) work on the latest commit.