### PR TITLE
Add model torchrec dlrm

### DIFF
--- a/test.py
+++ b/test.py
@@ -68,7 +68,7 @@ def _load_test(path, device):
 
     def example_fn(self):
         task = ModelTask(path, timeout=TIMEOUT)
-        with task.watch_cuda_memory(skip=(device != "cuda"), assert_equal=self.assertEqual):
+        with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
                 _create_example_model_instance(task, device)
                 task.check_example()

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -140,8 +140,6 @@ class Model(BenchmarkModel):
         return self.model, self.example_inputs
 
     def forward(self):
-        if self.opt:
-            self.opt.zero_grad()
         losses, output = self.model(self.example_inputs)
         return losses
 
@@ -149,8 +147,7 @@ class Model(BenchmarkModel):
         torch.sum(losses, dim=0).backward()
 
     def optimizer(self):
-        if self.opt:
-            self.opt.step()
+        self.opt.step()
 
     def eval(self):
         with torch.no_grad():

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -68,7 +68,7 @@ class Model(BenchmarkModel):
         if args.interaction_type == InteractionType.ORIGINAL:
             dlrm_model = DLRM(
                 embedding_bag_collection=EmbeddingBagCollection(
-                    tables=eb_configs, device=torch.device("meta")
+                    tables=eb_configs, device=self.device
                 ),
                 dense_in_features=len(DEFAULT_INT_NAMES),
                 dense_arch_layer_sizes=args.dense_arch_layer_sizes,
@@ -78,7 +78,7 @@ class Model(BenchmarkModel):
         elif args.interaction_type == InteractionType.DCN:
             dlrm_model = DLRM_DCN(
                 embedding_bag_collection=EmbeddingBagCollection(
-                    tables=eb_configs, device=torch.device("meta")
+                    tables=eb_configs, device=self.device
                 ),
                 dense_in_features=len(DEFAULT_INT_NAMES),
                 dense_arch_layer_sizes=args.dense_arch_layer_sizes,
@@ -90,7 +90,7 @@ class Model(BenchmarkModel):
         elif args.interaction_type == InteractionType.PROJECTION:
             dlrm_model = DLRM_Projection(
                 embedding_bag_collection=EmbeddingBagCollection(
-                    tables=eb_configs, device=torch.device("meta")
+                    tables=eb_configs, device=self.device
                 ),
                 dense_in_features=len(DEFAULT_INT_NAMES),
                 dense_arch_layer_sizes=args.dense_arch_layer_sizes,
@@ -125,7 +125,9 @@ class Model(BenchmarkModel):
             dict(in_backward_optimizer_filter(self.model.named_parameters())),
             optimizer_with_params(),
         )
-        opt = CombinedOptimizer([self.model.fused_optimizer, dense_optimizer])
+        # opt = CombinedOptimizer([self.model.fused_optimizer, dense_optimizer])
+        # Only run dense optimizer
+        opt = CombinedOptimizer([dense_optimizer])
         if args.multi_hot_sizes is not None:
             raise RuntimeError("Multi-hot is not supported in TorchBench.")
         if self.test == "train":

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -1,6 +1,5 @@
 import torch
 
-
 # OSS import
 try:
     # pyre-ignore[21]
@@ -11,9 +10,6 @@ try:
     # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm:lr_scheduler
     from lr_scheduler import LRPolicyScheduler
 
-    # pyre-ignore[21]
-    # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm:multi_hot
-    from multi_hot import Multihot, RestartableMap
 except ImportError:
     pass
 
@@ -129,7 +125,7 @@ class Model(BenchmarkModel):
             optimizer_with_params(),
         )
         optimizer = CombinedOptimizer([model.fused_optimizer, dense_optimizer])
-        lr_scheduler = LRPolicyScheduler(
+        self.lr_scheduler = LRPolicyScheduler(
             optimizer, args.lr_warmup_steps, args.lr_decay_start, args.lr_decay_steps
         )
         if args.multi_hot_sizes is not None:

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -1,0 +1,143 @@
+import torch
+
+
+# OSS import
+try:
+    # pyre-ignore[21]
+    # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm/data:dlrm_dataloader
+    from data.dlrm_dataloader import get_dataloader
+
+    # pyre-ignore[21]
+    # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm:lr_scheduler
+    from lr_scheduler import LRPolicyScheduler
+
+    # pyre-ignore[21]
+    # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm:multi_hot
+    from multi_hot import Multihot, RestartableMap
+except ImportError:
+    pass
+
+from pyre_extensions import none_throws
+from torchrec.datasets.criteo import DEFAULT_CAT_NAMES, DEFAULT_INT_NAMES
+from torchrec import EmbeddingBagCollection
+from torchrec.models.dlrm import DLRM, DLRM_DCN, DLRM_Projection, DLRMTrain
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
+from torchrec.optim.optimizers import in_backward_optimizer_filter
+
+from ...util.model import BenchmarkModel
+from torchbenchmark.tasks import RECOMMENDATION
+
+from .args import parse_args, InteractionType
+
+
+class Model(BenchmarkModel):
+    task = RECOMMENDATION.RECOMMENDATION
+    # upstream default batch size: 32
+    # https://github.com/facebookresearch/dlrm/blob/main/torchrec_dlrm/dlrm_main.py#L86
+    DEFAULT_TRAIN_BSIZE = 32
+    DEFAULT_EVAL_BSIZE = 32
+
+    def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
+        super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+        args = parse_args(self.extra_args)
+
+        train_dataloader = None
+        eb_configs = [
+            EmbeddingBagConfig(
+                name=f"t_{feature_name}",
+                embedding_dim=args.embedding_dim,
+                num_embeddings=none_throws(args.num_embeddings_per_feature)[feature_idx]
+                if args.num_embeddings is None
+                else args.num_embeddings,
+                feature_names=[feature_name],
+            )
+            for feature_idx, feature_name in enumerate(DEFAULT_CAT_NAMES)
+        ]
+        if args.interaction_type == InteractionType.ORIGINAL:
+            dlrm_model = DLRM(
+                embedding_bag_collection=EmbeddingBagCollection(
+                    tables=eb_configs, device=torch.device("meta")
+                ),
+                dense_in_features=len(DEFAULT_INT_NAMES),
+                dense_arch_layer_sizes=args.dense_arch_layer_sizes,
+                over_arch_layer_sizes=args.over_arch_layer_sizes,
+                dense_device=device,
+            )
+        elif args.interaction_type == InteractionType.DCN:
+            dlrm_model = DLRM_DCN(
+                embedding_bag_collection=EmbeddingBagCollection(
+                    tables=eb_configs, device=torch.device("meta")
+                ),
+                dense_in_features=len(DEFAULT_INT_NAMES),
+                dense_arch_layer_sizes=args.dense_arch_layer_sizes,
+                over_arch_layer_sizes=args.over_arch_layer_sizes,
+                dcn_num_layers=args.dcn_num_layers,
+                dcn_low_rank_dim=args.dcn_low_rank_dim,
+                dense_device=device,
+            )
+        elif args.interaction_type == InteractionType.PROJECTION:
+            dlrm_model = DLRM_Projection(
+                embedding_bag_collection=EmbeddingBagCollection(
+                    tables=eb_configs, device=torch.device("meta")
+                ),
+                dense_in_features=len(DEFAULT_INT_NAMES),
+                dense_arch_layer_sizes=args.dense_arch_layer_sizes,
+                over_arch_layer_sizes=args.over_arch_layer_sizes,
+                interaction_branch1_layer_sizes=args.interaction_branch1_layer_sizes,
+                interaction_branch2_layer_sizes=args.interaction_branch2_layer_sizes,
+                dense_device=device,
+            )
+        else:
+            raise ValueError(
+                "Unknown interaction option set. Should be original, dcn, or projection."
+            )
+        train_model = DLRMTrain(dlrm_model)
+        embedding_optimizer = torch.optim.Adagrad if args.adagrad else torch.optim.SGD
+        # This will apply the Adagrad optimizer in the backward pass for the embeddings (sparse_arch). This means that
+        # the optimizer update will be applied in the backward pass, in this case through a fused op.
+        # TorchRec will use the FBGEMM implementation of EXACT_ADAGRAD. For GPU devices, a fused CUDA kernel is invoked. For CPU, FBGEMM_GPU invokes CPU kernels
+        # https://github.com/pytorch/FBGEMM/blob/2cb8b0dff3e67f9a009c4299defbd6b99cc12b8f/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops.py#L676-L678
+        apply_optimizer_in_backward(
+            embedding_optimizer,
+            train_model.model.sparse_arch.parameters(),
+            {"lr": args.learning_rate},
+        )
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                local_world_size=get_local_size(),
+                world_size=dist.get_world_size(),
+                compute_device=device.type,
+            ),
+            batch_size=args.batch_size,
+            # If experience OOM, increase the percentage. see
+            # https://pytorch.org/torchrec/torchrec.distributed.planner.html#torchrec.distributed.planner.storage_reservations.HeuristicalStorageReservation
+            storage_reservation=HeuristicalStorageReservation(percentage=0.05),
+        )
+        plan = planner.collective_plan(
+            train_model, get_default_sharders(), dist.GroupMember.WORLD
+        )
+        def optimizer_with_params():
+            if args.adagrad:
+                return lambda params: torch.optim.Adagrad(params, lr=args.learning_rate)
+            else:
+                return lambda params: torch.optim.SGD(params, lr=args.learning_rate)
+
+        dense_optimizer = KeyedOptimizerWrapper(
+            dict(in_backward_optimizer_filter(model.named_parameters())),
+            optimizer_with_params(),
+        )
+        optimizer = CombinedOptimizer([model.fused_optimizer, dense_optimizer])
+        lr_scheduler = LRPolicyScheduler(
+            optimizer, args.lr_warmup_steps, args.lr_decay_start, args.lr_decay_steps
+        )
+        if args.multi_hot_sizes is not None:
+            raise RuntimeError("Multi-hot is not supported in TorchBench.")
+
+
+    def train(self):
+        pass
+
+    def eval(self):
+        pass

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -140,7 +140,8 @@ class Model(BenchmarkModel):
         return self.model, self.example_inputs
 
     def forward(self):
-        self.opt.zero_grad()
+        if self.opt:
+            self.opt.zero_grad()
         losses, output = self.model(self.example_inputs)
         return losses
 
@@ -148,7 +149,8 @@ class Model(BenchmarkModel):
         torch.sum(losses, dim=0).backward()
 
     def optimizer(self):
-        self.opt.step()
+        if self.opt:
+            self.opt.step()
 
     def eval(self):
         with torch.no_grad():

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -137,7 +137,7 @@ class Model(BenchmarkModel):
             self.model.eval()
 
     def get_module(self):
-        return self.model, self.example_inputs
+        return self.model, (self.example_inputs, )
 
     def forward(self):
         losses, output = self.model(self.example_inputs)

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -45,6 +45,11 @@ class Model(BenchmarkModel):
         limit_batches = 1
         iterator = itertools.islice(iter(loader), limit_batches)
         self.example_inputs = next(iterator).to(self.device)
+        # parse the args
+        args.dense_arch_layer_sizes = [int(x) for x in args.dense_arch_layer_sizes.split(',') if x.strip().isdigit()]
+        args.over_arch_layer_sizes = [int(x) for x in args.over_arch_layer_sizes.split(',') if x.strip().isdigit()]
+        args.interaction_branch1_layer_sizes = [int(x) for x in args.interaction_branch1_layer_sizes.split(',') if x.strip().isdigit()]
+        args.interaction_branch2_layer_sizes = [int(x) for x in args.interaction_branch2_layer_sizes.split(',') if x.strip().isdigit()]
 
         assert args.in_memory_binary_criteo_path == None and args.synthetic_multi_hot_criteo_path == None, \
             f"Torchbench only supports random data inputs."

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     pass
 
+import itertools
 from pyre_extensions import none_throws
 from torchrec.datasets.criteo import DEFAULT_CAT_NAMES, DEFAULT_INT_NAMES
 from torchrec import EmbeddingBagCollection
@@ -41,9 +42,9 @@ class Model(BenchmarkModel):
         if self.test == "eval":
             args.test_batch_size = self.batch_size
             loader = get_dataloader(args, backend, "test")
-        # prefetch data to device
-        for data in loader:
-            self.example_inputs = data.to(self.device)
+        limit_batches = 1
+        iterator = itertools.islice(iter(loader), limit_batches)
+        self.example_inputs = next(iterator).to(self.device)
 
         assert args.in_memory_binary_criteo_path == None and args.synthetic_multi_hot_criteo_path == None, \
             f"Torchbench only supports random data inputs."

--- a/torchbenchmark/models/torchrec_dlrm/args.py
+++ b/torchbenchmark/models/torchrec_dlrm/args.py
@@ -1,0 +1,243 @@
+import argparse
+
+from enum import Enum
+from typing import List
+
+class InteractionType(Enum):
+    ORIGINAL = "original"
+    DCN = "dcn"
+    PROJECTION = "projection"
+
+    def __str__(self):
+        return self.value
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="torchrec dlrm example trainer")
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=1,
+        help="number of epochs to train",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="batch size to use for training",
+    )
+    parser.add_argument(
+        "--drop_last_training_batch",
+        dest="drop_last_training_batch",
+        action="store_true",
+        help="Drop the last non-full training batch",
+    )
+    parser.add_argument(
+        "--test_batch_size",
+        type=int,
+        default=None,
+        help="batch size to use for validation and testing",
+    )
+    parser.add_argument(
+        "--limit_train_batches",
+        type=int,
+        default=None,
+        help="number of train batches",
+    )
+    parser.add_argument(
+        "--limit_val_batches",
+        type=int,
+        default=None,
+        help="number of validation batches",
+    )
+    parser.add_argument(
+        "--limit_test_batches",
+        type=int,
+        default=None,
+        help="number of test batches",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="criteo_1t",
+        help="dataset for experiment, current support criteo_1tb, criteo_kaggle",
+    )
+    parser.add_argument(
+        "--num_embeddings",
+        type=int,
+        default=100_000,
+        help="max_ind_size. The number of embeddings in each embedding table. Defaults"
+        " to 100_000 if num_embeddings_per_feature is not supplied.",
+    )
+    parser.add_argument(
+        "--num_embeddings_per_feature",
+        type=str,
+        default=None,
+        help="Comma separated max_ind_size per sparse feature. The number of embeddings"
+        " in each embedding table. 26 values are expected for the Criteo dataset.",
+    )
+    parser.add_argument(
+        "--dense_arch_layer_sizes",
+        type=str,
+        default="512,256,64",
+        help="Comma separated layer sizes for dense arch.",
+    )
+    parser.add_argument(
+        "--over_arch_layer_sizes",
+        type=str,
+        default="512,512,256,1",
+        help="Comma separated layer sizes for over arch.",
+    )
+    parser.add_argument(
+        "--embedding_dim",
+        type=int,
+        default=64,
+        help="Size of each embedding.",
+    )
+    parser.add_argument(
+        "--interaction_branch1_layer_sizes",
+        type=str,
+        default="2048,2048",
+        help="Comma separated layer sizes for interaction branch1 (only on dlrm with projection).",
+    )
+    parser.add_argument(
+        "--interaction_branch2_layer_sizes",
+        type=str,
+        default="2048,2048",
+        help="Comma separated layer sizes for interaction branch2 (only on dlrm with projection).",
+    )
+    parser.add_argument(
+        "--dcn_num_layers",
+        type=int,
+        default=3,
+        help="Number of DCN layers in interaction layer (only on dlrm with DCN).",
+    )
+    parser.add_argument(
+        "--dcn_low_rank_dim",
+        type=int,
+        default=512,
+        help="Low rank dimension for DCN in interaction layer (only on dlrm with DCN).",
+    )
+    parser.add_argument(
+        "--undersampling_rate",
+        type=float,
+        help="Desired proportion of zero-labeled samples to retain (i.e. undersampling zero-labeled rows)."
+        " Ex. 0.3 indicates only 30pct of the rows with label 0 will be kept."
+        " All rows with label 1 will be kept. Value should be between 0 and 1."
+        " When not supplied, no undersampling occurs.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Random seed for reproducibility.",
+    )
+    parser.add_argument(
+        "--pin_memory",
+        dest="pin_memory",
+        action="store_true",
+        help="Use pinned memory when loading data.",
+    )
+    parser.add_argument(
+        "--mmap_mode",
+        dest="mmap_mode",
+        action="store_true",
+        help="--mmap_mode mmaps the dataset."
+        " That is, the dataset is kept on disk but is accessed as if it were in memory."
+        " --mmap_mode is intended mostly for faster debugging. Use --mmap_mode to bypass"
+        " preloading the dataset when preloading takes too long or when there is "
+        " insufficient memory available to load the full dataset.",
+    )
+    parser.add_argument(
+        "--in_memory_binary_criteo_path",
+        type=str,
+        default=None,
+        help="Directory path containing the Criteo dataset npy files.",
+    )
+    parser.add_argument(
+        "--synthetic_multi_hot_criteo_path",
+        type=str,
+        default=None,
+        help="Directory path containing the MLPerf v2 synthetic multi-hot dataset npz files.",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=15.0,
+        help="Learning rate.",
+    )
+    parser.add_argument(
+        "--shuffle_batches",
+        dest="shuffle_batches",
+        action="store_true",
+        help="Shuffle each batch during training.",
+    )
+    parser.add_argument(
+        "--shuffle_training_set",
+        dest="shuffle_training_set",
+        action="store_true",
+        help="Shuffle the training set in memory. This will override mmap_mode",
+    )
+    parser.add_argument(
+        "--validation_freq_within_epoch",
+        type=int,
+        default=None,
+        help="Frequency at which validation will be run within an epoch.",
+    )
+    parser.set_defaults(
+        pin_memory=None,
+        mmap_mode=None,
+        drop_last=None,
+        shuffle_batches=None,
+        shuffle_training_set=None,
+    )
+    parser.add_argument(
+        "--adagrad",
+        dest="adagrad",
+        action="store_true",
+        help="Flag to determine if adagrad optimizer should be used.",
+    )
+    parser.add_argument(
+        "--interaction_type",
+        type=InteractionType,
+        choices=list(InteractionType),
+        default=InteractionType.ORIGINAL,
+        help="Determine the interaction type to be used (original, dcn, or projection)"
+        " default is original DLRM with pairwise dot product",
+    )
+    parser.add_argument(
+        "--collect_multi_hot_freqs_stats",
+        dest="collect_multi_hot_freqs_stats",
+        action="store_true",
+        help="Flag to determine whether to collect stats on freq of embedding access.",
+    )
+    parser.add_argument(
+        "--multi_hot_sizes",
+        type=str,
+        default=None,
+        help="Comma separated multihot size per sparse feature. 26 values are expected for the Criteo dataset.",
+    )
+    parser.add_argument(
+        "--multi_hot_distribution_type",
+        type=str,
+        choices=["uniform", "pareto"],
+        default=None,
+        help="Multi-hot distribution options.",
+    )
+    parser.add_argument("--lr_warmup_steps", type=int, default=0)
+    parser.add_argument("--lr_decay_start", type=int, default=0)
+    parser.add_argument("--lr_decay_steps", type=int, default=0)
+    parser.add_argument(
+        "--print_lr",
+        action="store_true",
+        help="Print learning rate every iteration.",
+    )
+    parser.add_argument(
+        "--allow_tf32",
+        action="store_true",
+        help="Enable TensorFloat-32 mode for matrix multiplications on A100 (or newer) GPUs.",
+    )
+    parser.add_argument(
+        "--print_sharding_plan",
+        action="store_true",
+        help="Print the sharding plan used for each embedding table.",
+    )
+    return parser.parse_args(argv)

--- a/torchbenchmark/models/torchrec_dlrm/data/dlrm_dataloader.py
+++ b/torchbenchmark/models/torchrec_dlrm/data/dlrm_dataloader.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+from typing import List
+
+from torch import distributed as dist
+from torch.utils.data import DataLoader
+from torchrec.datasets.criteo import (
+    CAT_FEATURE_COUNT,
+    DAYS,
+    DEFAULT_CAT_NAMES,
+    DEFAULT_INT_NAMES,
+    InMemoryBinaryCriteoIterDataPipe,
+)
+from torchrec.datasets.random import RandomRecDataset
+
+# OSS import
+try:
+    # pyre-ignore[21]
+    # @manual=//ai_codesign/benchmarks/dlrm/torchrec_dlrm/data:multi_hot_criteo
+    from data.multi_hot_criteo import MultiHotCriteoIterDataPipe
+
+except ImportError:
+    pass
+
+# internal import
+try:
+    from .multi_hot_criteo import MultiHotCriteoIterDataPipe  # noqa F811
+except ImportError:
+    pass
+
+STAGES = ["train", "val", "test"]
+
+
+def _get_random_dataloader(
+    args: argparse.Namespace,
+    stage: str,
+) -> DataLoader:
+    attr = f"limit_{stage}_batches"
+    num_batches = getattr(args, attr)
+    if stage in ["val", "test"] and args.test_batch_size is not None:
+        batch_size = args.test_batch_size
+    else:
+        batch_size = args.batch_size
+    return DataLoader(
+        RandomRecDataset(
+            keys=DEFAULT_CAT_NAMES,
+            batch_size=batch_size,
+            hash_size=args.num_embeddings,
+            hash_sizes=args.num_embeddings_per_feature
+            if hasattr(args, "num_embeddings_per_feature")
+            else None,
+            manual_seed=args.seed if hasattr(args, "seed") else None,
+            ids_per_feature=1,
+            num_dense=len(DEFAULT_INT_NAMES),
+            num_batches=num_batches,
+        ),
+        batch_size=None,
+        batch_sampler=None,
+        pin_memory=args.pin_memory,
+        num_workers=0,
+    )
+
+def _get_in_memory_dataloader(
+    args: argparse.Namespace,
+    stage: str,
+) -> DataLoader:
+    if args.in_memory_binary_criteo_path is not None:
+        dir_path = args.in_memory_binary_criteo_path
+        sparse_part = "sparse.npy"
+        datapipe = InMemoryBinaryCriteoIterDataPipe
+    else:
+        dir_path = args.synthetic_multi_hot_criteo_path
+        sparse_part = "sparse_multi_hot.npz"
+        datapipe = MultiHotCriteoIterDataPipe
+
+    if stage == "train":
+        stage_files: List[List[str]] = [
+            [os.path.join(dir_path, f"day_{i}_dense.npy") for i in range(DAYS - 1)],
+            [os.path.join(dir_path, f"day_{i}_{sparse_part}") for i in range(DAYS - 1)],
+            [os.path.join(dir_path, f"day_{i}_labels.npy") for i in range(DAYS - 1)],
+        ]
+    elif stage in ["val", "test"]:
+        stage_files: List[List[str]] = [
+            [os.path.join(dir_path, f"day_{DAYS-1}_dense.npy")],
+            [os.path.join(dir_path, f"day_{DAYS-1}_{sparse_part}")],
+            [os.path.join(dir_path, f"day_{DAYS-1}_labels.npy")],
+        ]
+    if stage in ["val", "test"] and args.test_batch_size is not None:
+        batch_size = args.test_batch_size
+    else:
+        batch_size = args.batch_size
+    dataloader = DataLoader(
+        datapipe(
+            stage,
+            *stage_files,  # pyre-ignore[6]
+            batch_size=batch_size,
+            rank=dist.get_rank(),
+            world_size=dist.get_world_size(),
+            drop_last=args.drop_last_training_batch if stage == "train" else False,
+            shuffle_batches=args.shuffle_batches,
+            shuffle_training_set=args.shuffle_training_set,
+            shuffle_training_set_random_seed=args.seed,
+            mmap_mode=args.mmap_mode,
+            hashes=args.num_embeddings_per_feature
+            if args.num_embeddings is None
+            else ([args.num_embeddings] * CAT_FEATURE_COUNT),
+        ),
+        batch_size=None,
+        pin_memory=args.pin_memory,
+        collate_fn=lambda x: x,
+    )
+    return dataloader
+
+
+def get_dataloader(args: argparse.Namespace, backend: str, stage: str) -> DataLoader:
+    """
+    Gets desired dataloader from dlrm_main command line options. Currently, this
+    function is able to return either a DataLoader wrapped around a RandomRecDataset or
+    a Dataloader wrapped around an InMemoryBinaryCriteoIterDataPipe.
+    Args:
+        args (argparse.Namespace): Command line options supplied to dlrm_main.py's main
+            function.
+        backend (str): "nccl" or "gloo".
+        stage (str): "train", "val", or "test".
+    Returns:
+        dataloader (DataLoader): PyTorch dataloader for the specified options.
+    """
+    stage = stage.lower()
+    if stage not in STAGES:
+        raise ValueError(f"Supplied stage was {stage}. Must be one of {STAGES}.")
+
+    args.pin_memory = (
+        (backend == "nccl") if not hasattr(args, "pin_memory") else args.pin_memory
+    )
+
+    if (
+        args.in_memory_binary_criteo_path is None
+        and args.synthetic_multi_hot_criteo_path is None
+    ):
+        return _get_random_dataloader(args, stage)
+    else:
+        return _get_in_memory_dataloader(args, stage)

--- a/torchbenchmark/models/torchrec_dlrm/install.py
+++ b/torchbenchmark/models/torchrec_dlrm/install.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()
+

--- a/torchbenchmark/models/torchrec_dlrm/metadata.yaml
+++ b/torchbenchmark/models/torchrec_dlrm/metadata.yaml
@@ -3,3 +3,4 @@ eval_deterministic: false
 eval_nograd: true
 train_benchmark: false
 train_deterministic: false
+skip_cuda_memory_leak: true

--- a/torchbenchmark/models/torchrec_dlrm/metadata.yaml
+++ b/torchbenchmark/models/torchrec_dlrm/metadata.yaml
@@ -1,0 +1,5 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false

--- a/torchbenchmark/models/torchrec_dlrm/origin
+++ b/torchbenchmark/models/torchrec_dlrm/origin
@@ -1,0 +1,1 @@
+https://github.com/facebookresearch/dlrm

--- a/torchbenchmark/models/torchrec_dlrm/requirements.txt
+++ b/torchbenchmark/models/torchrec_dlrm/requirements.txt
@@ -1,0 +1,2 @@
+torchrec-nightly
+fbgemm-gpu-nightly


### PR DESCRIPTION
Original model file: https://github.com/facebookresearch/dlrm/blob/main/torchrec_dlrm/dlrm_main.py
Using the default config in the model file.
Need to modify a few places to run on single GPU device, including removing DDP, change device from "meta" to concrete devices, and remove fused optimizer.

Test Plan:
Experiment on T4 16 GB
```
$ python run.py torchrec_dlrm -d cuda --bs 4096 -t eval
Running eval method from torchrec_dlrm on cuda in eager mode with input batch size 4096.
GPU Time:              5.040 milliseconds
CPU Total Wall Time:   5.066 milliseconds

$ python run.py torchrec_dlrm -d cuda --bs 4096 -t train
Running train method from torchrec_dlrm on cuda in eager mode with input batch size 4096.
GPU Time:             32.600 milliseconds
CPU Total Wall Time:  32.625 milliseconds
```

```
$ python run.py torchrec_dlrm -d cuda --bs 4096 -t eval --torchdynamo inductor
[2023-02-04 14:14:36,265] torch._inductor.compile_fx: [WARNING] skipping cudagraphs due to multiple devices
Segmentation fault (core dumped)

$ python run.py torchrec_dlrm -d cuda --bs 4096 -t train --torchdynamo inductor
[2023-02-04 14:14:36,265] torch._inductor.compile_fx: [WARNING] skipping cudagraphs due to multiple devices
Segmentation fault (core dumped)
```