### PR TITLE
[model-stableness] Fix type in iter rounds

### DIFF
--- a/torchbenchmark/models/yolov3/yolo_train.py
+++ b/torchbenchmark/models/yolov3/yolo_train.py
@@ -412,7 +412,8 @@ def prepare_training_loop(args):
             #     plot_results()  # save as results.png
             # print('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
             # dist.destroy_process_group() if torch.cuda.device_count() > 1 else None
-            torch.cuda.empty_cache()
+            # torchbench: disable empty cache
+            # torch.cuda.empty_cache()
             return results
         return train_loop, model, dataloader
 

--- a/userbenchmark/model-stableness/__init__.py
+++ b/userbenchmark/model-stableness/__init__.py
@@ -31,7 +31,7 @@ def generate_model_config(model_name: str) -> List[TorchBenchModelConfig]:
 
 def parse_args(args: List[str]):
     parser = argparse.ArgumentParser()
-    parser.add_argument("-r", "--rounds", default=15, help="Number of rounds to run to simulate measuring max delta in workflow.")
+    parser.add_argument("-r", "--rounds", default=15, type=int, help="Number of rounds to run to simulate measuring max delta in workflow.")
     parser.add_argument("-m", "--models", default="", help="Specify the models to run, default (empty) runs all models.")
     parser.add_argument("-d", "--device", default="cpu", help="Specify the device.")
     parser.add_argument("-t", "--test", default="eval", help="Specify the test.")


### PR DESCRIPTION
torch.cuda.empty_cache() is causing stableness issues in yolov3, so we are removing it from the benchmark test.


