### PR TITLE
change fastNLP_Bert's task name

### DIFF
--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -36,7 +36,7 @@ logger.setLevel(logging.WARNING)
 
 
 class Model(BenchmarkModel):
-    task = NLP.OTHER_NLP
+    task = NLP.LANGUAGE_MODELING
     # Use the train batch size from the original CMRC2018 Q&A task
     # Source: https://fastnlp.readthedocs.io/zh/latest/tutorials/extend_1_bert_embedding.html
     DEFAULT_TRAIN_BSIZE = 6


### PR DESCRIPTION
fastNLP_Bert is the only one classified as `NLP.OTHER_NLP`. Since BERT_pytorch and hf_Bert are classified to `NLP.LANGUAGE_MODELING`, is it better to use `NLP.LANGUAGE_MODELING` here?