### PR TITLE
Pin pygame version to fix soft_actor_critic

### DIFF
--- a/torchbenchmark/models/soft_actor_critic/requirements.txt
+++ b/torchbenchmark/models/soft_actor_critic/requirements.txt
@@ -1,2 +1,3 @@
 gym==0.25.2
-pygame
+# pygame 2.1.3 requires sdl2-config, which doesn't exist in our benchmark environment
+pygame==2.1.2


### PR DESCRIPTION
The latest pygame requires sdl2-config, which is not available in our environment.