### PR TITLE
Use the correct batch size for timm ViT to improve stableness

### DIFF
--- a/torchbenchmark/models/timm_vision_transformer/__init__.py
+++ b/torchbenchmark/models/timm_vision_transformer/__init__.py
@@ -4,8 +4,8 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(TimmModel):
     task = COMPUTER_VISION.GENERATION
 
-    DEFAULT_TRAIN_BSIZE = 8
-    DEFAULT_EVAL_BSIZE = 8
+    DEFAULT_TRAIN_BSIZE = 32
+    DEFAULT_EVAL_BSIZE = 32
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, model_name='vit_small_patch16_224', device=device,

--- a/torchbenchmark/models/timm_vision_transformer_large/__init__.py
+++ b/torchbenchmark/models/timm_vision_transformer_large/__init__.py
@@ -4,8 +4,8 @@ from torchbenchmark.tasks import COMPUTER_VISION
 class Model(TimmModel):
     task = COMPUTER_VISION.GENERATION
 
-    DEFAULT_TRAIN_BSIZE = 8
-    DEFAULT_EVAL_BSIZE = 8
+    DEFAULT_TRAIN_BSIZE = 32
+    DEFAULT_EVAL_BSIZE = 32
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, model_name='vit_giant_patch14_224', device=device,

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -31,9 +31,6 @@ class TimmModel(BenchmarkModel):
             self.model.train()
         elif test == "eval":
             self.model.eval()
-
-        if device == 'cuda':
-            torch.cuda.empty_cache()
         self.amp_context = suppress
 
     def gen_inputs(self, num_batches:int=1) -> Tuple[Generator, Optional[int]]:


### PR DESCRIPTION
Use the correct batch size for ViT models train.

Upstream batch size: 32 (https://github.com/rwightman/pytorch-image-models/blob/main/train.py#L131)

BS=8, variation 17%: https://github.com/pytorch/benchmark/actions/runs/4147202172

BS=32, variation 0.9%: https://github.com/pytorch/benchmark/actions/runs/4205506091