### PR TITLE
fix bugs for gpu detection

### DIFF
--- a/components/model_analyzer/TorchBenchAnalyzer.py
+++ b/components/model_analyzer/TorchBenchAnalyzer.py
@@ -88,8 +88,10 @@ class ModelAnalyzer:
     def start_monitor(self):
         try:
             if self.gpu_metrics:
-                self.gpu_factory = GPUDeviceFactory()
+                self.gpu_factory = GPUDeviceFactory(self.gpu_monitor_backend)
                 self.gpus = self.gpu_factory.verify_requested_gpus(['all', ])
+                if not self.gpus:
+                    raise TorchBenchAnalyzerException('No GPU found')
                 if self.gpu_monitor_backend == 'dcgm':
                     self.gpu_monitor = DCGMMonitor(
                         self.gpus, self.config.monitoring_interval, self.gpu_metrics)


### PR DESCRIPTION
This PR fixes the following issues,
- Enabling GPU memory measurement causes an error named no metric record collected on GPUs not support DCGM. It is because the default dcgm support check will bypass all available GPUs from the device lists.
- A100 without DCGM installed has an error since the dcgm support check is forced even if you want to use nvml as the backend.