### PR TITLE
Clarify instllation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ pip install pyyaml
 
 Install the benchmark suite, which will recursively install dependencies for all the models.  Currently, the repo is intended to be installed from the source tree.
 ```
-git clone <benchmark>
-cd <benchmark>
+git clone https://github.com/pytorch/benchmark
+cd benchmark
 python install.py
 ```
 
@@ -58,8 +58,8 @@ See detailed instructions to install torchtext [here](https://github.com/pytorch
 Make sure to enable CUDA (by `FORCE_CUDA=1`) if using CUDA.
 Then,
 ```
-git clone <benchmark>
-cd <benchmark>
+git clone https://github.com/pytorch/benchmark
+cd benchmark
 python install.py
 ```
 


### PR DESCRIPTION
The value of `<benchmark>` used in `git clone` and `cd` steps are not the same. For `git clone`, https://github.com/pytorch/benchmark is required to use and then it's required to `cd` to `benchmark` directory. 
Also, providing a repo link for git clone is a standard practice, and it can be easy to understand for someone new to PyTorch and benchmark. 
This PR provides a small improvement towards clarifying it. 