### PR TITLE
Upgrade to gcc-11 in the A100 Docker to fix CI error

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -9,6 +9,10 @@ RUN sudo apt-get install -y git git-lfs jq \
                             vim wget curl ninja-build cmake \
                             libgl1-mesa-glx libsndfile1-dev
 
+# Install gcc-11, needed by the latest fbgemm
+RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    sudo apt install -y g++-11
+
 # get switch-cuda utility
 RUN sudo wget -q https://raw.githubusercontent.com/phohenecker/switch-cuda/master/switch-cuda.sh -O /usr/bin/switch-cuda.sh
 RUN sudo chmod +x /usr/bin/switch-cuda.sh

--- a/torchbenchmark/models/torchrec_dlrm/metadata.yaml
+++ b/torchbenchmark/models/torchrec_dlrm/metadata.yaml
@@ -4,3 +4,5 @@ eval_nograd: true
 train_benchmark: false
 train_deterministic: false
 skip_cuda_memory_leak: true
+not_implemented:
+  - test: train


### PR DESCRIPTION
The error (https://github.com/pytorch/benchmark/actions/runs/4245223753/jobs/7380449492) is because fbgemm requires at least gcc-11, or GLIBCXX_3.4.29, and fbgemm is required by torchrec_dlrm.

gcc-9 uses GLIBCXX_3.4.28, which is incompatible.