### PR TITLE
Fix torchrec_dlrm model and enable fbcode test

### DIFF
--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -51,8 +51,7 @@ class Model(BenchmarkModel):
         if self.test == "eval":
             args.test_batch_size = self.batch_size
             loader = get_dataloader(args, backend, "test")
-        limit_batches = 1
-        self.iterator = itertools.islice(iter(loader), limit_batches)
+        self.iterator = itertools.cycle(iter(loader))
         self.example_inputs = next(self.iterator).to(device)
         # parse the args
         args.dense_arch_layer_sizes = [int(x) for x in args.dense_arch_layer_sizes.split(',') if x.strip().isdigit()]

--- a/torchbenchmark/models/torchrec_dlrm/metadata.yaml
+++ b/torchbenchmark/models/torchrec_dlrm/metadata.yaml
@@ -4,5 +4,3 @@ eval_nograd: true
 train_benchmark: false
 train_deterministic: false
 skip_cuda_memory_leak: true
-not_implemented:
-  - test: train


### PR DESCRIPTION
Summary:
Fix a bug in the train test, the train pipeline requires multiple batches of inputs, but the iterator has only 1 batch.

Fix the iterator to use `cycle()` which returns infinite batches of data.
Also, enable the torchrec_dlrm model running in fbcode.

Inductor still doesn't work for this model, stack backtrace is attached.

Differential Revision: D43397292

