### PR TITLE
Using FP32 for DRQ network.

### DIFF
--- a/torchbenchmark/models/drq/drq.py
+++ b/torchbenchmark/models/drq/drq.py
@@ -167,7 +167,8 @@ class DRQAgent(object):
         # tie conv layers between actor and critic
         self.actor.encoder.copy_conv_weights_from(self.critic.encoder)
 
-        self.log_alpha = torch.tensor(np.log(cfg.init_temperature)).to(device)
+        self.log_alpha = torch.tensor(np.log(cfg.init_temperature,
+                                             dtype=np.float32)).to(device)
         self.log_alpha.requires_grad = True
         # set target entropy to -|A|
         self.target_entropy = -action_shape[0]


### PR DESCRIPTION
Moving the temperature numpy log to FP32.