### PR TITLE
GeForce clock query fix Issue #1440

### DIFF
--- a/torchbenchmark/util/machine_config.py
+++ b/torchbenchmark/util/machine_config.py
@@ -115,6 +115,8 @@ def has_nvidia_smi():
 
 def get_nvidia_gpu_clocks(device_ids: typing.List[int] = None):
     clocks = nvidia_smi_query("clocks.applications.graphics", device_ids)
+    for clock in range(len(clocks)):
+        clocks[clock] = 0 if clocks[clock] == '[N/A]' else clocks[clock]
     return [int(clock) for clock in clocks]
 
 def get_nvidia_gpu_temps(device_ids: typing.List[int] = None):


### PR DESCRIPTION
My apologies, not sure how to link this PR to [issue-1440](https://github.com/pytorch/benchmark/issues/1440). This mainly affects individuals who are using GeForce video cards for general benchmarking.

this will check the clocks list received from nvidia_smi_query function and change any clock from [N/A] to 0, allowing the integer return back to the calling function.