### PR TITLE
Add explicit APIs in BenchmarkModel

### DIFF
--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -50,7 +50,13 @@ def is_fambench_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool
     return hasattr(model, 'FAMBENCH_MODEL') and model.FAMBENCH_MODEL
 
 def is_staged_train_test(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
-    return hasattr(model, 'forward') and hasattr(model, 'backward') and hasattr(model, 'optimizer')
+    try:
+        losses = model.forward()
+        model.backward(losses)
+        model.optimizer()
+    except NotImplementedError:
+        return False
+    return True
 
 def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim=True, deepcopy=True, rounds=STABLENESS_CHECK_ROUNDS) -> Tuple['torch.Tensor']:
     """Get the eager output. Run eager mode a couple of times to guarantee stableness.

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -286,6 +286,32 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 out = self.eval()
         return out
 
+    def get_module(self):
+        raise NotImplementedError("To enroll into more granular benchmarking, every BenchmarkModel is exhorted "
+                                  "to implement a way to retrieve a torch module from it. It is okay if this "
+                                  "remains unimplemented for models that have vastly different architectures.")
+
+    # Should return loss
+    def forward(self):
+        raise NotImplementedError("To enroll into more granular benchmarking, every BenchmarkModel is exhorted "
+                                  "to implement a modular forward step.")
+
+    def backward(self, loss) -> None:
+        raise NotImplementedError("To enroll into more granular benchmarking, every BenchmarkModel is exhorted "
+                                  "to implement a modular backward step.")
+
+    def optimizer_step(self) -> None:
+        raise NotImplementedError("To enroll into more granular benchmarking, every BenchmarkModel is exhorted "
+                                  "to implement a modular optimizer step.")
+
+    def train(self):
+        raise NotImplementedError("Every BenchmarkModel should implement a train() representing a training loop. "
+                                  "Note that train() should be equivalent to chaining forward(), backward(loss) "
+                                  "and optimizer_step() and can be implemented as such.")
+
+    def eval(self):
+        raise NotImplementedError("Every BenchmarkModel should implement a eval() representing an inference loop.")
+
     def eval_in_nograd(self):
         return True
 


### PR DESCRIPTION
This is part 1 of adding ways to more granularly benchmark.

Also explicitly document what methods we expect BenchmarkModels to have.