### PR TITLE
Ignore pkls and zips and pts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 .data
 ._*
 */**/__pycache__
+*/**/*.pkl
+*/**/*.pt
 */**/*.pyc
+*/**/*.tar.gz
 *.out*
 *.swp
 *.swo


### PR DESCRIPTION
running install.py could add zips --> don't have those show up with `git status`