### PR TITLE
Replace the numpy.meshgrid() with more efficient torch.meshgrid()

### DIFF
--- a/torchbenchmark/models/Super_SloMo/slomo_model.py
+++ b/torchbenchmark/models/Super_SloMo/slomo_model.py
@@ -244,11 +244,10 @@ class backWarp(nn.Module):
 
         super(backWarp, self).__init__()
         # create a grid
-        gridX, gridY = np.meshgrid(np.arange(W), np.arange(H))
         self.W = W
         self.H = H
-        self.gridX = torch.tensor(gridX, requires_grad=False, device=device)
-        self.gridY = torch.tensor(gridY, requires_grad=False, device=device)
+        self.gridX, self.gridY = torch.meshgrid(torch.arange(W, requires_grad=False, device=device), 
+                                                torch.arange(H, requires_grad=False, device=device), indexing='xy')
         
     def forward(self, img, flow):
         """

--- a/torchbenchmark/models/Super_SloMo/slomo_model.py
+++ b/torchbenchmark/models/Super_SloMo/slomo_model.py
@@ -246,6 +246,9 @@ class backWarp(nn.Module):
         # create a grid
         self.W = W
         self.H = H
+        
+        # Use torch.meshgrid instead of np.meshgrid to imrpove performance
+        # https://github.com/avinashpaliwal/Super-SloMo/pull/111
         self.gridX, self.gridY = torch.meshgrid(torch.arange(W, requires_grad=False, device=device), 
                                                 torch.arange(H, requires_grad=False, device=device), indexing='xy')
         


### PR DESCRIPTION
This PR fixes a performance issue for the model [Super-SloMo](https://github.com/pytorch/benchmark/tree/main/torchbenchmark/models/Super_SloMo).  The [`backwarp` class](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/Super_SloMo/slomo_model.py#L213) calls `np.meshgrid()` and `torch.tensor()` to create a grid in [the class constructor](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/Super_SloMo/slomo_model.py#L232). The `torch` modules provides similar API [`torch.meshgrid()`](https://pytorch.org/docs/stable/generated/torch.meshgrid.html) with far better performance. According to my [example profiling script](https://gist.github.com/CuiJinku/d85436d31aade0f49d13cc7e5f4f844b), the `torch.meshgrid()` has **25X** speedup on a single NVIDIA 3090 GPU.