### PR TITLE
Add time.sleep after subprocess git calls like git checkout 

### DIFF
--- a/torchbenchmark/util/gitutils.py
+++ b/torchbenchmark/util/gitutils.py
@@ -5,6 +5,7 @@ Utils for getting git-related information.
 
 import os
 import subprocess
+import time
 from datetime import datetime
 from typing import Optional, List
 
@@ -106,10 +107,13 @@ def checkout_git_commit(repo: str, commit: str) -> bool:
         assert len(commit) != 0
         command = f"git checkout {commit}"
         subprocess.check_call(command, cwd=repo, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(3)
         command = "git submodule sync"
         subprocess.check_call(command, cwd=repo, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(3)
         command = "git submodule update --init --recursive"
         subprocess.check_call(command, cwd=repo, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(3)
         return True
     except subprocess.CalledProcessError:
         print(f"Failed to checkout commit {commit} in repo {repo}")


### PR DESCRIPTION
and git submodule operations. 

The cause of the failure for https://github.com/pytorch/benchmark/actions/runs/4195864401/jobs/7276018136 is that the git checkout 61ecaf1dd40 was tainted with an incompatible XNNPACK, e.g. 

<img width="849" alt="image" src="https://user-images.githubusercontent.com/109318740/224471419-d90b3de6-138e-416f-bd9e-260ae10eabd9.png">

Running "git submodule update --init --recursive" manually would clean up the changes. 

The reason might be because the "git submodule update --init --recursive" was executed too soon. So adding some delay to give time for the subprocess to fully finish execution. 
