### PR TITLE
Upload benchmark metrics to S3 bucket

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -78,7 +78,7 @@ jobs:
             python run_benchmark.py "${{ github.event.inputs.userbenchmark_name }}" ${{ github.event.inputs.userbenchmark_options }}
             cp -r ./.userbenchmark/"${{ github.event.inputs.userbenchmark_name }}" ../benchmark-output
           fi
-      - name: Upload result jsons to Scribe
+      - name: Upload result jsons to Scribe and S3
         run: |
           . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
           pushd benchmark
@@ -86,6 +86,7 @@ jobs:
           echo "Uploading result jsons: ${RESULTS}"
           for r in ${RESULTS[@]}; do
             python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
+            python ./scripts/userbenchmark/upload_s3.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -12,6 +12,8 @@ env:
   CONDA_ENV_NAME: "userbenchmarks-ci"
   PLATFORM_NAME: "gcp_a100"
   TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   SETUP_SCRIPT: "/workspace/setup_instance.sh"
 jobs:
   run-userbenchmark:

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -12,6 +12,8 @@ env:
   CONDA_ENV_NAME: "userbenchmarks-ci"
   PLATFORM_NAME: "aws_t4_metal"
   TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   SETUP_SCRIPT: "/data/nvme/bin/setup_instance.sh"
 jobs:
   run-userbenchmark:

--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -81,6 +81,7 @@ jobs:
           echo "Uploading result jsons: ${RESULTS}"
           for r in ${RESULTS[@]}; do
             python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
+            python ./scripts/userbenchmark/upload_s3.py --userbenchmark_json "${r}" --userbenchmark_platform "${PLATFORM_NAME}"
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/scripts/install_basics_amzn_linux_2.sh
+++ b/scripts/install_basics_amzn_linux_2.sh
@@ -7,7 +7,7 @@ chmod +x "$filename"
 sudo yum makecache --refresh
 sudo yum install -y git jq \
                 vim wget curl ninja-build cmake \
-                gcc11 gcc11-c++ \
+                gcc \
                 libglvnd-glx libsndfile
 
 . ${HOME}/miniconda3/etc/profile.d/conda.sh

--- a/scripts/install_basics_amzn_linux_2.sh
+++ b/scripts/install_basics_amzn_linux_2.sh
@@ -7,6 +7,7 @@ chmod +x "$filename"
 sudo yum makecache --refresh
 sudo yum install -y git jq \
                 vim wget curl ninja-build cmake \
+                gcc11 gcc11-c++ \
                 libglvnd-glx libsndfile
 
 . ${HOME}/miniconda3/etc/profile.d/conda.sh

--- a/scripts/userbenchmark/upload_s3.py
+++ b/scripts/userbenchmark/upload_s3.py
@@ -1,9 +1,25 @@
 import argparse
 import json
+import sys
 from pathlib import Path
 from datetime import datetime
 
-from utils.s3_utils import S3Client
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+class add_path():
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        sys.path.insert(0, self.path)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            sys.path.remove(self.path)
+        except ValueError:
+            pass
+
+with add_path(str(REPO_ROOT)):
+    from utils.s3_utils import S3Client
 
 USERBENCHMARK_S3_BUCKET = "ossci-metrics"
 USERBENCHMARK_S3_OBJECT = "torchbench-userbenchmark"

--- a/scripts/userbenchmark/upload_s3.py
+++ b/scripts/userbenchmark/upload_s3.py
@@ -1,0 +1,31 @@
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+def get_date_from_metrics(metrics_file: str):
+    datetime_obj = datetime.strptime(metrics_file, "metrics-%Y%m%d%H%M%S")
+    return datetime.strftime(datetime_obj, "%Y-%m-%d")
+
+def get_ub_name(metrics_file_path: str):
+    with open(metrics_file_path, "r") as mf:
+        metrics = json.load(mf)
+    return metrics["name"]
+
+def upload_s3(ub_name: str, platform_name: str, date_str: str, file_path: Path):
+    """S3 path:
+        s3://ossci-metrics/torchbench_userbenchmark/<userbenchmark-name>/<platform-name>/<date>/metrics-<time>.json"""
+    pass
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--userbenchmark_platform", required=True,
+                        help='Name of the userbenchmark platform')
+    parser.add_argument("--userbenchmark_json", required=True,
+                        help='Upload userbenchmark json data')
+    args = parser.parse_args()
+    json_path = Path(args.userbenchmark_json)
+    assert json_path.exists(), f"Specified result json path {args.userbenchmark_json} does not exist."
+    date_str = get_date_from_metrics(json_path.stem)
+    ub_name = get_ub_name(args.userbenchmark_json)
+    upload_s3(ub_name, args.userbenchmark_platform, date_str, json_path)

--- a/scripts/userbenchmark/upload_s3.py
+++ b/scripts/userbenchmark/upload_s3.py
@@ -3,6 +3,11 @@ import json
 from pathlib import Path
 from datetime import datetime
 
+from utils.s3_utils import S3Client
+
+USERBENCHMARK_S3_BUCKET = "ossci-metrics"
+USERBENCHMARK_S3_OBJECT = "torchbench-userbenchmark"
+
 def get_date_from_metrics(metrics_file: str):
     datetime_obj = datetime.strptime(metrics_file, "metrics-%Y%m%d%H%M%S")
     return datetime.strftime(datetime_obj, "%Y-%m-%d")
@@ -15,7 +20,9 @@ def get_ub_name(metrics_file_path: str):
 def upload_s3(ub_name: str, platform_name: str, date_str: str, file_path: Path):
     """S3 path:
         s3://ossci-metrics/torchbench_userbenchmark/<userbenchmark-name>/<platform-name>/<date>/metrics-<time>.json"""
-    pass
+    s3client = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
+    prefix = f"{ub_name}/{platform_name}/{date_str}"
+    s3client.upload_file(prefix=prefix, file_path=file_path)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -1,0 +1,42 @@
+import boto3
+import os
+from pathlib import Path
+
+class S3Client:
+    def __init__(self, bucket, object):
+        self.s3 = boto3.client('s3')
+        self.bucket = bucket
+        self.object = object
+
+    def download_file(self, key: str, dest_dir: str):
+        filename = S3Client.get_filename_from_key(key)
+        assert filename, f"Expected non-empty filename from key {key}."
+        with open(os.path.join(dest_dir, filename), 'wb') as f:
+            self.s3.download_fileobj(self.bucket, key, f)
+
+    def upload_file(self, prefix: str, file_path: Path):
+        file_name = file_path.name
+        s3_key = f"{self.object}/{prefix}/{file_name}" if prefix else f"{self.object}/{file_name}"
+        response = self.s3.upload_file(str(file_path), self.bucket, s3_key)
+        print(f"S3 client response: {response}")
+
+    def exists(self, prefix: str, file_name: str):
+        """Test if the key object/prefix/file_name exists in the S3 bucket.
+           If True, return the S3 object key. Return None otherwise. """
+        s3_key = f"{self.object}/{prefix}/{file_name}" if prefix else f"{self.object}/{file_name}"
+        result = self.s3.list_objects_v2(Bucket=self.bucket, Prefix=s3_key)
+        if 'Contents' in result:
+            return s3_key
+        return None
+
+    def list_directory(self, directory=None):
+        """List the directory files in the S3 bucket path.
+           If the directory doesn't exist, report an error. """
+        prefix = f"{self.object}/{directory}/" if directory else f"{self.object}/"
+        pages = self.s3.get_paginator("list_objects").paginate(Bucket=self.bucket, Prefix=prefix)
+        keys = filter(lambda x: not x == prefix, [e['Key'] for p in pages for e in p['Contents']])
+        return list(keys)
+    
+    def get_filename_from_key(object_key: str):
+        filename = object_key.split('/')[-1]
+        return filename


### PR DESCRIPTION
Enable metrics file upload to S3 bucket ossci-metrics by default.


Test workflow:
A100: https://github.com/pytorch/benchmark/actions/runs/4417886123
T4: https://github.com/pytorch/benchmark/actions/runs/4418258576