### PR TITLE
Enable fx int8 for most models on cpu device

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -7,6 +7,8 @@ from torchbenchmark.util.backends.flops import enable_fvcore_flops
 from torchbenchmark.util.env_check import is_torchvision_model, is_staged_train_test
 
 TEST_STAGE = enum.Enum('TEST_STAGE', ['FORWARD', 'BACKWARD', 'OPTIMIZER', 'ALL'])
+AVAILABLE_PRECISIONS = ["fp32", "tf32", "fp16", "amp", "fx_int8"]
+QUANT_ENGINES = ["x86", "fbgemm", "qnnpack", "onednn"]
 
 def check_correctness_p(
     model: 'torchbenchmark.util.model.BenchmarkModel',
@@ -46,7 +48,7 @@ def check_precision(model: 'torchbenchmark.util.model.BenchmarkModel', precision
             return hasattr(model, 'enable_amp') or is_staged_train_test(model)
     if precision == "fx_int8":
         return model.device == 'cpu' and hasattr(model, "enable_fx_int8")
-    assert precision == "fp32", f"Expected precision to be one of fp32, tf32, fp16, fx_int8, or amp, but get {precision}"
+    assert precision == "fp32", f"Expected precision to be one of {AVAILABLE_PRECISIONS}, but get {precision}"
     return True
 
 def check_memory_layout(model: 'torchbenchmark.util.model.BenchmakModel', channels_last: bool) -> bool:
@@ -80,10 +82,10 @@ def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', ext
         default=None,
         help="Path to function that will apply distributed wrapping fn(model, dargs.distributed)",
     )
-    parser.add_argument("--precision", choices=["fp32", "tf32", "fp16", "amp", "fx_int8"], default=get_precision_default(model), help="choose precisions from: fp32, tf32, fp16, or amp")
+    parser.add_argument("--precision", choices=AVAILABLE_PRECISIONS, default=get_precision_default(model), help=f"choose precisions from {AVAILABLE_PRECISIONS}")
     parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
     parser.add_argument("--skip_correctness", action='store_true', help="Skip correctness checks")
-    parser.add_argument("--quant-engine", choices=["x86", "fbgemm", "qnnpack", "onednn"], default='x86', help="choose quantization engine for fx_int8 precision from: x86, fbgemm, qnnpack, onednn")
+    parser.add_argument("--quant-engine", choices=QUANT_ENGINES, default='x86', help=f"choose quantization engine for fx_int8 precision from {QUANT_ENGINES}")
     dargs, opt_args = parser.parse_known_args(extra_args)
     if not check_precision(model, dargs.precision):
         raise NotImplementedError(f"precision value: {dargs.precision}, "

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -44,7 +44,9 @@ def check_precision(model: 'torchbenchmark.util.model.BenchmarkModel', precision
             return True
         if model.test == 'train' and model.device == 'cuda':
             return hasattr(model, 'enable_amp') or is_staged_train_test(model)
-    assert precision == "fp32", f"Expected precision to be one of fp32, tf32, fp16, or amp, but get {precision}"
+    if precision == "fx_int8":
+        return model.device == 'cpu' and hasattr(model, "enable_fx_int8")
+    assert precision == "fp32", f"Expected precision to be one of fp32, tf32, fp16, fx_int8, or amp, but get {precision}"
     return True
 
 def check_memory_layout(model: 'torchbenchmark.util.model.BenchmakModel', channels_last: bool) -> bool:
@@ -78,9 +80,10 @@ def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', ext
         default=None,
         help="Path to function that will apply distributed wrapping fn(model, dargs.distributed)",
     )
-    parser.add_argument("--precision", choices=["fp32", "tf32", "fp16", "amp"], default=get_precision_default(model), help="choose precisions from: fp32, tf32, fp16, or amp")
+    parser.add_argument("--precision", choices=["fp32", "tf32", "fp16", "amp", "fx_int8"], default=get_precision_default(model), help="choose precisions from: fp32, tf32, fp16, or amp")
     parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
     parser.add_argument("--skip_correctness", action='store_true', help="Skip correctness checks")
+    parser.add_argument("--quant-engine", choices=["x86", "fbgemm", "qnnpack", "onednn"], default='x86', help="choose quantization engine for fx_int8 precision from: x86, fbgemm, qnnpack, onednn")
     dargs, opt_args = parser.parse_known_args(extra_args)
     if not check_precision(model, dargs.precision):
         raise NotImplementedError(f"precision value: {dargs.precision}, "
@@ -116,6 +119,9 @@ def apply_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', dar
             assert is_staged_train_test(model), f"Expected model implements staged train test (forward, backward, optimizer)."
             import torch
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16), stage=TEST_STAGE.FORWARD)
+    elif dargs.precision == "fx_int8":
+        assert model.device == "cpu" and model.test == "eval", f"fx_int8 only work for eval mode on cpu device."
+        model.enable_fx_int8(dargs.quant_engine)
     elif not dargs.precision == "fp32":
         assert False, f"Get an invalid precision option: {dargs.precision}. Please report a bug."
 

--- a/torchbenchmark/util/fx_int8.py
+++ b/torchbenchmark/util/fx_int8.py
@@ -1,0 +1,88 @@
+import re
+import torch
+from torch.ao.quantization import QuantWrapper, get_default_qconfig_mapping, get_default_qconfig_propagation_list
+from torch.ao.quantization.quantize_fx import _fuse_fx, prepare_fx, convert_fx
+from torchbenchmark.util.env_check import is_hf_model
+
+def _append_attr(fx_module, module, fx_white_list=[]):
+    fx_attr = dir(fx_module)
+    org_attr = dir(module)
+    ignore_match_patterns = [r"_", r"quant", r"dequant", r"weight",
+                            r"bias", r'activation_post_process']
+    ignore_search_patterns = [r"_scale_", r"_zero_point_",
+                            r'_activation_post_process_']
+    add_special_patterns = [r"_forward_hooks", r"_forward_pre_hooks", r"_backward_hooks"]
+    attr_names = []
+    for i in org_attr:
+        if type(module) in fx_white_list and type(module) != torch.nn.Sequential \
+        and any([re.search(p, i) for p in add_special_patterns]):
+            continue
+        if any([re.search(p, i) for p in add_special_patterns]) \
+        or (i not in fx_attr \
+            and not any([re.match(p, i) for p in ignore_match_patterns]) \
+            and not any([re.search(p, i) for p in ignore_search_patterns])) :
+            attr_names.append(i)
+    for name in attr_names:
+        attr = getattr(module, name, None)
+        if isinstance(attr, torch.nn.Module) or \
+        isinstance(attr, torch.quantization.qconfig.QConfig):
+            continue
+        setattr(fx_module, name, attr)
+    return fx_module
+
+def get_sub_module(model, module_dict, prefix):
+    fx_white_list = get_default_qconfig_propagation_list()
+    ignore_list = []
+    if is_hf_model:
+        import transformers
+        ignore_list.extend([transformers.models.gpt2.modeling_gpt2.GPT2Attention, transformers.models.t5.modeling_t5.T5DenseActDense])
+    def _get_sub_module(model, module_dict, prefix, sub_module_list):
+        for name, module in model.named_children():
+            quant_wrap_flag = False
+            if type(module) in ignore_list:
+                continue
+            op_name = prefix + "." + name if prefix != "" else name
+            if op_name not in module_dict:
+                continue
+            if type(module) in fx_white_list and type(module) != torch.nn.Sequential:
+                module = QuantWrapper(module)
+                quant_wrap_flag = True
+            try:
+                graph_module = torch.fx.symbolic_trace(module)
+                if not quant_wrap_flag and str(module.get_submodule).count("\n") != str(graph_module.get_submodule).count("\n"):
+                    continue
+                _fuse_fx(graph_module, False)
+                setattr(model, name, module)
+                sub_module_list.append(op_name)
+            except:
+                module = _get_sub_module(module, module_dict, op_name, sub_module_list)
+                setattr(model, name, module)
+        return model
+    sub_module_list = []
+    model = _get_sub_module(model, module_dict, prefix, sub_module_list)
+    return model, sub_module_list
+
+def prepare_sub_module(sub_module_list, model, prefix, quant_engine:str='x86'):
+    qconfig_mapping = get_default_qconfig_mapping(quant_engine)
+    for name, module in model.named_children():
+        op_name = prefix + '.' + name if prefix != '' else name
+        if op_name in sub_module_list:
+            prepared_module = prepare_fx(module, qconfig_mapping, None)
+            _append_attr(prepared_module, module)
+            setattr(model, name, prepared_module)
+        else:
+            prepared_module = prepare_sub_module(sub_module_list, module, op_name, quant_engine)
+            _append_attr(prepared_module, module)
+            setattr(model, name, prepared_module)
+    return model
+
+def convert_sub_module(sub_module_list, model, prefix):
+    for name, module in model.named_children():
+        op_name = prefix + '.' + name if prefix != '' else name
+        if op_name in sub_module_list:
+            convert_module = convert_fx(module)
+            setattr(model, name, convert_module)
+        else:
+            convert_module = convert_sub_module(sub_module_list, module, op_name)
+            setattr(model, name, convert_module)
+    return model

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -168,6 +168,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 or (self.dynamo and self.opt_args.torchdynamo == "fx2trt")
                 or (not self.dynamo and (self.device == "cuda" and self.opt_args.backend == "fx2trt"))
                 or (not self.dynamo and self.opt_args.use_cosine_similarity)
+                or self.dargs.precision == "fx_int8"
             ):
                 self.correctness = correctness_check(self, cos_sim=True, deepcopy=self.DEEPCOPY)
             else:
@@ -368,4 +369,105 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         if hasattr(self, 'example_inputs'):
             self.example_inputs = inputs_convert(self.example_inputs)
         else:
-            warnings.warn(UserWarning(f"{model_name} example inputs doesn't convert to `channels_last`!"))
+            warnings.warn(UserWarning(f"{model_name} example inputs doesn't convert to `channels_last`!"))     
+
+    def enable_fx_int8(self, quant_engine:str='x86'):
+        from torch.ao.quantization import QuantWrapper, get_default_qconfig_mapping, get_default_qconfig_propagation_list
+        from torch.ao.quantization.quantize_fx import _fuse_fx, prepare_fx, convert_fx
+        torch.backends.quantized.engine = quant_engine
+        qconfig_mapping = get_default_qconfig_mapping(quant_engine)
+
+        def _append_attr(fx_module, module, fx_white_list=[]):
+            import re
+            fx_attr = dir(fx_module)
+            org_attr = dir(module)
+            ignore_match_patterns = [r"_", r"quant", r"dequant", r"weight",
+                                    r"bias", r'activation_post_process']
+            ignore_search_patterns = [r"_scale_", r"_zero_point_",
+                                    r'_activation_post_process_']
+            add_special_patterns = [r"_forward_hooks", r"_forward_pre_hooks", r"_backward_hooks"]
+            attr_names = []
+            for i in org_attr:
+                if type(module) in fx_white_list and type(module) != torch.nn.Sequential \
+                and any([re.search(p, i) for p in add_special_patterns]):
+                    continue
+                if any([re.search(p, i) for p in add_special_patterns]) \
+                or (i not in fx_attr \
+                    and not any([re.match(p, i) for p in ignore_match_patterns]) \
+                    and not any([re.search(p, i) for p in ignore_search_patterns])) :
+                    attr_names.append(i)
+            for name in attr_names:
+                attr = getattr(module, name, None)
+                if isinstance(attr, torch.nn.Module) or \
+                isinstance(attr, torch.quantization.qconfig.QConfig):
+                    continue
+                setattr(fx_module, name, attr)
+            return fx_module
+
+        def _get_sub_module(model, module_dict, prefix):
+            import transformers
+            fx_white_list = get_default_qconfig_propagation_list()
+            ignore_list = []
+            if is_hf_model:
+                import transformers
+                ignore_list.extend([transformers.models.gpt2.modeling_gpt2.GPT2Attention, transformers.models.t5.modeling_t5.T5DenseActDense])
+            for name, module in model.named_children():
+                quant_wrap_flag = False
+                if type(module) in ignore_list:
+                    continue
+                op_name = prefix + "." + name if prefix != "" else name
+                if op_name not in module_dict:
+                    continue
+                if type(module) in fx_white_list and type(module) != torch.nn.Sequential:
+                    module = QuantWrapper(module)
+                    quant_wrap_flag = True
+                try:
+                    graph_module = torch.fx.symbolic_trace(module)
+                    if not quant_wrap_flag and str(module.get_submodule).count("\n") != str(graph_module.get_submodule).count("\n"):
+                        continue
+                    _fuse_fx(graph_module, False)
+                    setattr(model, name, module)
+                    sub_module_list.append(op_name)
+                except:
+                    _get_sub_module(module, module_dict, op_name)
+            return model
+
+        def _prepare_sub_module(sub_module_list, model, prefix):
+            for name, module in model.named_children():
+                op_name = prefix + '.' + name if prefix != '' else name
+                if op_name in sub_module_list:
+                    prepared_module = prepare_fx(module, qconfig_mapping, None)
+                    _append_attr(prepared_module, module)
+                    setattr(model, name, prepared_module)
+                else:
+                    _prepare_sub_module(sub_module_list, module, op_name)
+            return model
+
+        def _convert_sub_module(sub_module_list, model, prefix):
+            for name, module in model.named_children():
+                op_name = prefix + '.' + name if prefix != '' else name
+                if op_name in sub_module_list:
+                    convert_module = convert_fx(module)
+                    setattr(model, name, convert_module)
+                else:
+                    _convert_sub_module(sub_module_list, module, op_name)
+            return model
+
+        try:
+            model, _ = self.get_module()
+            sub_module_list = []
+            # Get sub modules
+            model = _get_sub_module(model, dict(model.named_modules()), '')
+            if not len(sub_module_list):
+                warnings.warn(UserWarning(f"{self.name} doesn't have submodule can ben quantized!"))
+            model = _prepare_sub_module(sub_module_list, model, '')
+            self.set_module(model)
+            # Calibration
+            self.eval()
+            model, _ = self.get_module()
+            model = _convert_sub_module(sub_module_list, model, '')
+            self.set_module(model)
+        except Exception as e:
+            print(e)
+            warnings.warn(UserWarning(f"{self.name} doesn't support `fx_int8` yet!"))
+            raise RuntimeError

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -14,6 +14,7 @@ from torchbenchmark.util.extra_args import check_correctness_p, parse_opt_args, 
                                            parse_decoration_args, apply_decoration_args, is_staged_train_test, \
                                            TEST_STAGE
 from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check, is_hf_model
+from torchbenchmark.util.fx_int8 import get_sub_module, prepare_sub_module, convert_sub_module
 
 class PostInitProcessor(type):
     def __call__(cls, *args, **kwargs):
@@ -369,105 +370,23 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         if hasattr(self, 'example_inputs'):
             self.example_inputs = inputs_convert(self.example_inputs)
         else:
-            warnings.warn(UserWarning(f"{model_name} example inputs doesn't convert to `channels_last`!"))     
+            warnings.warn(UserWarning(f"{model_name} example inputs doesn't convert to `channels_last`!"))
 
     def enable_fx_int8(self, quant_engine:str='x86'):
-        from torch.ao.quantization import QuantWrapper, get_default_qconfig_mapping, get_default_qconfig_propagation_list
-        from torch.ao.quantization.quantize_fx import _fuse_fx, prepare_fx, convert_fx
         torch.backends.quantized.engine = quant_engine
-        qconfig_mapping = get_default_qconfig_mapping(quant_engine)
-
-        def _append_attr(fx_module, module, fx_white_list=[]):
-            import re
-            fx_attr = dir(fx_module)
-            org_attr = dir(module)
-            ignore_match_patterns = [r"_", r"quant", r"dequant", r"weight",
-                                    r"bias", r'activation_post_process']
-            ignore_search_patterns = [r"_scale_", r"_zero_point_",
-                                    r'_activation_post_process_']
-            add_special_patterns = [r"_forward_hooks", r"_forward_pre_hooks", r"_backward_hooks"]
-            attr_names = []
-            for i in org_attr:
-                if type(module) in fx_white_list and type(module) != torch.nn.Sequential \
-                and any([re.search(p, i) for p in add_special_patterns]):
-                    continue
-                if any([re.search(p, i) for p in add_special_patterns]) \
-                or (i not in fx_attr \
-                    and not any([re.match(p, i) for p in ignore_match_patterns]) \
-                    and not any([re.search(p, i) for p in ignore_search_patterns])) :
-                    attr_names.append(i)
-            for name in attr_names:
-                attr = getattr(module, name, None)
-                if isinstance(attr, torch.nn.Module) or \
-                isinstance(attr, torch.quantization.qconfig.QConfig):
-                    continue
-                setattr(fx_module, name, attr)
-            return fx_module
-
-        def _get_sub_module(model, module_dict, prefix):
-            import transformers
-            fx_white_list = get_default_qconfig_propagation_list()
-            ignore_list = []
-            if is_hf_model:
-                import transformers
-                ignore_list.extend([transformers.models.gpt2.modeling_gpt2.GPT2Attention, transformers.models.t5.modeling_t5.T5DenseActDense])
-            for name, module in model.named_children():
-                quant_wrap_flag = False
-                if type(module) in ignore_list:
-                    continue
-                op_name = prefix + "." + name if prefix != "" else name
-                if op_name not in module_dict:
-                    continue
-                if type(module) in fx_white_list and type(module) != torch.nn.Sequential:
-                    module = QuantWrapper(module)
-                    quant_wrap_flag = True
-                try:
-                    graph_module = torch.fx.symbolic_trace(module)
-                    if not quant_wrap_flag and str(module.get_submodule).count("\n") != str(graph_module.get_submodule).count("\n"):
-                        continue
-                    _fuse_fx(graph_module, False)
-                    setattr(model, name, module)
-                    sub_module_list.append(op_name)
-                except:
-                    _get_sub_module(module, module_dict, op_name)
-            return model
-
-        def _prepare_sub_module(sub_module_list, model, prefix):
-            for name, module in model.named_children():
-                op_name = prefix + '.' + name if prefix != '' else name
-                if op_name in sub_module_list:
-                    prepared_module = prepare_fx(module, qconfig_mapping, None)
-                    _append_attr(prepared_module, module)
-                    setattr(model, name, prepared_module)
-                else:
-                    _prepare_sub_module(sub_module_list, module, op_name)
-            return model
-
-        def _convert_sub_module(sub_module_list, model, prefix):
-            for name, module in model.named_children():
-                op_name = prefix + '.' + name if prefix != '' else name
-                if op_name in sub_module_list:
-                    convert_module = convert_fx(module)
-                    setattr(model, name, convert_module)
-                else:
-                    _convert_sub_module(sub_module_list, module, op_name)
-            return model
-
         try:
             model, _ = self.get_module()
-            sub_module_list = []
             # Get sub modules
-            model = _get_sub_module(model, dict(model.named_modules()), '')
+            model, sub_module_list = get_sub_module(model, dict(model.named_modules()), '')
             if not len(sub_module_list):
                 warnings.warn(UserWarning(f"{self.name} doesn't have submodule can ben quantized!"))
-            model = _prepare_sub_module(sub_module_list, model, '')
+            model = prepare_sub_module(sub_module_list, model, '', quant_engine)
             self.set_module(model)
             # Calibration
             self.eval()
             model, _ = self.get_module()
-            model = _convert_sub_module(sub_module_list, model, '')
+            model = convert_sub_module(sub_module_list, model, '')
             self.set_module(model)
         except Exception as e:
             print(e)
-            warnings.warn(UserWarning(f"{self.name} doesn't support `fx_int8` yet!"))
-            raise RuntimeError
+            raise RuntimeError(f"{self.name} doesn't support `fx_int8` yet!")


### PR DESCRIPTION
Enable fx int8 for most models on cpu device

Works for Roadmap #1293 for fx int8 support, below is an example on CLX machine

```
$ python run.py alexnet -d cpu -t eval --precision fp32 -m eager
Running eval method from alexnet on cpu in eager mode with input batch size 128.
CPU Total Wall Time:  93.586 milliseconds
CPU Peak Memory:                6.3857 GB

$ python run.py alexnet -d cpu -t eval --precision fx_int8 -m eager
Running eval method from alexnet on cpu in eager mode with input batch size 128.
CPU Total Wall Time:  21.892 milliseconds
CPU Peak Memory:                1.4150 GB

$ python run.py alexnet -d cpu -t eval --precision fp32 -m jit
Running eval method from alexnet on cpu in jit mode with input batch size 128.
CPU Total Wall Time:  70.556 milliseconds
CPU Peak Memory:                1.5918 GB
Correctness:                         True

$ python run.py alexnet -d cpu -t eval --precision fx_int8 -m jit
Running eval method from alexnet on cpu in jit mode with input batch size 128.
CPU Total Wall Time:  21.176 milliseconds
CPU Peak Memory:                1.6758 GB
Correctness:                         True

$ python run.py alexnet -d cpu -t eval --precision fx_int8 -m jit --quant-engine fbgemm
Running eval method from alexnet on cpu in jit mode with input batch size 128.
CPU Total Wall Time:  29.487 milliseconds
CPU Peak Memory:                1.6777 GB
Correctness:                         True
```