### PR TITLE
ddp_experiments script: add nccl-socket-ifname arg, fix timeout

### DIFF
--- a/userbenchmark/ddp_experiments/README.md
+++ b/userbenchmark/ddp_experiments/README.md
@@ -64,3 +64,4 @@ Supported options (not-exhaustive):
 * `--ngpus [n]` for the number of gpus per node (8 by default, but 2 is useful for simple tests that use less resources)
 * `--precision amp|fp32|fp16` for specifying precision type (fp32 default)
 * `--cluster local` to run locally instead of launching a new slurm job
+* `--nccl-socket-ifname ens` to specify the `NCCL_SOCKET_IFNAME` environment variable (ens by default). Note that most of these environment variables are explicitly set in the script, to reduce variation due to differences in user environment.

--- a/userbenchmark/ddp_experiments/__init__.py
+++ b/userbenchmark/ddp_experiments/__init__.py
@@ -142,6 +142,12 @@ def parse_args(args: List[str]=None):
         default=None,
         help="Precision (e.g. amp, fp32, fp16)",
     )
+    parser.add_argument(
+        "--nccl-socket-ifname",
+        type=str,
+        default="ens",
+        help="Value to use for NCCL_SOCKET_IFNAME environment variable",
+    )
 
 
     try:
@@ -371,7 +377,7 @@ class TrainerWrapper(object):
         # os.environ["NCCL_IB_DISABLE"] = str(1)
         os.environ["NCCL_DEBUG"] = 'INFO'
         os.environ["NCCL_DEBUG_SUBSYS"] = 'INIT,ENV,NET'
-        os.environ['NCCL_SOCKET_IFNAME'] = 'ens'
+        os.environ['NCCL_SOCKET_IFNAME'] = args.nccl_socket_ifname
         # os.environ["NCCL_ALGO"] = 'ring'
         os.environ["FI_PROVIDER"] = 'efa'
         os.environ["FI_EFA_USE_DEVICE_RDMA"]= str(1)
@@ -679,7 +685,7 @@ def main():
         slurm_exclude=args.exclude,
     )
 
-    executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=1000)
+    executor.update_parameters(name="distbench", slurm_array_parallelism=1, timeout_min=args.timeout)
 
     if "ddp" in args.distributed:
         benchmark_ddp(args, executor)


### PR DESCRIPTION
Fixes: #1486.

The timeout flag was being set incorrectly. This fixes that.

The NCCL_SOCKET_IFNAME was not configurable on the command line. This adds a --nccl-socket-ifname arg.

Testing: manually tested with:
```
python userbenchmark/ddp_experiments/__init__.py --ngpus 8 --distributed ddp --nodes 1 --filter_models resnet50 --timeout 15 --nccl-socket-ifname asdf
```

* verified that the slurm job gets killed after ~15 minutes
* in the logs, I observe `NCCL INFO NCCL_SOCKET_IFNAME set to asdf` followed by `NCCL WARN Bootstrap : no socket interface found`