### PR TITLE
Update model task type

### DIFF
--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -8,11 +8,11 @@ from opacus.validators.module_validator import ModuleValidator
 from typing import Tuple
 
 from ...util.model import BenchmarkModel
-from torchbenchmark.tasks import OTHER
+from torchbenchmark.tasks import COMPUTER_VISION
 
 
 class Model(BenchmarkModel):
-    task = OTHER.OTHER_TASKS
+    task = COMPUTER_VISION.CLASSIFICATION
     DEFAULT_TRAIN_BSIZE = 64
     DEFAULT_EVAL_BSIZE = 64
 


### PR DESCRIPTION
Model opacus_cifar10 is based on resnet18, so the task type should be COMPUTER_VISION.CLASSIFICATION.