### PR TITLE
Make jit a kwarg with default value False in 4 models

### DIFF
--- a/torchbenchmark/models/alexnet/__init__.py
+++ b/torchbenchmark/models/alexnet/__init__.py
@@ -9,7 +9,7 @@ class Model(TorchVisionModel):
     DEFAULT_TRAIN_BSIZE = 128
     DEFAULT_EVAL_BSIZE = 128
 
-    def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(model_name="alexnet", test=test, device=device, jit=jit,
                          batch_size=batch_size, weights=models.AlexNet_Weights.IMAGENET1K_V1,
                          extra_args=extra_args)

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -22,7 +22,7 @@ class Model(BenchmarkModel):
     # Which will return non-deterministic results
     SKIP_CORRECTNESS_CHECK = True
 
-    def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
         # load from disk or synthesize data

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -49,7 +49,7 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 32
     ALLOW_CUSTOMIZE_BSIZE = False
 
-    def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
 
         n_way = 5

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -34,7 +34,7 @@ class Model(BenchmarkModel):
     DEFAULT_TRAIN_BSIZE = 1024
     DEFAULT_EVAL_BSIZE = 1024
 
-    def __init__(self, test, device, jit, batch_size=None, extra_args=[]):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         args = parse_args(self.extra_args)
         backend = "nccl" if self.device == "cuda" else "gloo"


### PR DESCRIPTION
The superclass already has a default of False for the `jit` argument. Keep it optional.