### PR TITLE
Disable CPU device on torchrec_dlrm

### DIFF
--- a/scripts/install_basics_amzn_linux_2.sh
+++ b/scripts/install_basics_amzn_linux_2.sh
@@ -7,7 +7,7 @@ chmod +x "$filename"
 sudo yum makecache --refresh
 sudo yum install -y git jq \
                 vim wget curl ninja-build cmake \
-                gcc \
+                gcc kernel-headers kernel-devel kernel-source \
                 libglvnd-glx libsndfile
 
 . ${HOME}/miniconda3/etc/profile.d/conda.sh

--- a/scripts/setup_nvda_11.7.sh
+++ b/scripts/setup_nvda_11.7.sh
@@ -2,10 +2,12 @@
 set -ex -o pipefail
 
 # Setup NVIDIA Driver
-DRIVER_FN="NVIDIA-Linux-x86_64-515.76.run"
-wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
-sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
-nvidia-smi
+if ! lsmod | grep -q nvidia; then
+  DRIVER_FN="NVIDIA-Linux-x86_64-515.76.run"
+  wget "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
+  sudo /bin/bash "$DRIVER_FN" -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
+  nvidia-smi
+fi
 
 # Setup CUDA 11.7 and cuDNN 8.5.0.96
 wget -q https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux.run -O cuda_11.7.0_515.43.04_linux.run

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -37,6 +37,8 @@ class Model(BenchmarkModel):
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         args = parse_args(self.extra_args)
+        if self.device == "cpu":
+            raise NotImplementedError("CPU is not supported by this model. See issue https://github.com/pytorch/pytorch/issues/97308.")
         backend = "nccl" if self.device == "cuda" else "gloo"
         device = torch.device(self.device)
         os.environ["RANK"] = "0"


### PR DESCRIPTION
The CI is broken because of an upstream pytorch issue: https://github.com/pytorch/pytorch/issues/97308
Disable CPU device for now.