### PR TITLE
Fix wrong if check

### DIFF
--- a/run.py
+++ b/run.py
@@ -155,7 +155,7 @@ def run_one_step(func, nwarmup=WARMUP_ROUNDS, num_iter=10, model=None, export_me
     cpu_peak_mem = None
     gpu_peak_mem = None
     mem_device_id = None
-    if 'cpu_peak_mem' or 'gpu_peak_mem' in metrics_needed:
+    if 'cpu_peak_mem' in metrics_needed or 'gpu_peak_mem' in metrics_needed:
         cpu_peak_mem, mem_device_id, gpu_peak_mem = get_peak_memory(func, model.device, export_metrics_file=export_metrics_file, metrics_needed=metrics_needed, metrics_gpu_backend=metrics_gpu_backend)
 
     printResultSummaryTime(result_summary, metrics_needed, model, flops_model_analyzer, cpu_peak_mem, mem_device_id, gpu_peak_mem)


### PR DESCRIPTION
Missing `in metrics_needed` for `cpu_peak_mem` when check if the `metrics_needed` includes `cpu_peak_mem` or `gpu_peak_mem`.