### PR TITLE
Copy the nvidia libraries to the default library path

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Tune Nvidia GPU
         run: |
           . "${SETUP_SCRIPT}"
-          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -pm 1
-          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -ac 1215,1410
+          # Copy the NVIDIA libraries to the default libraries path
+          sudo cp -r /usr/local/nvidia/lib64/* /lib/x86_64-linux-gnu/
+          sudo nvidia-smi -pm 1
+          sudo nvidia-smi -ac 1215,1410
           nvidia-smi
       - name: Install PyTorch nightly
         run: |


### PR DESCRIPTION
ld cannot find the Nvidia so files even if we set $LD_LIBRARY_PATH and $LIBRARY_PATH, so we need to manually copy those files to `/lib/x86_64-linux-gnu/`


Test plan:
https://github.com/pytorch/benchmark/actions/runs/4559295944
