### PR TITLE
Bump up the transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest-benchmark
 requests
 tabulate
 git+https://github.com/rwightman/pytorch-image-models.git@45af496
-transformers==4.26.1
+transformers==4.27.4
 MonkeyType
 psutil
 pyyaml


### PR DESCRIPTION
Summary: To pick up a torchdynamo graph break fix in transformers, see https://github.com/huggingface/transformers/pull/21648