### PR TITLE
Keep CI example generic

### DIFF
--- a/userbenchmark/ADDING_USERBENCHMARKS.md
+++ b/userbenchmark/ADDING_USERBENCHMARKS.md
@@ -65,7 +65,7 @@ https://hud.pytorch.org/userbenchmark_view?url=https:%2F%2Fossci-metrics.s3.amaz
 ### Nightly CI
 
 To enroll your userbenchmark in nightly CI, create a `ci.yaml` file in your userbenchmark home directory.
-For example, here is the [ci.yaml](https://github.com/pytorch/benchmark/blob/main/userbenchmark/nvfuser/ci.yaml) of the nvfuser userbenchmark:
+Given below is an example content of the file:
 
 ```
 platform:   "gcp_a100"


### PR DESCRIPTION
The current link is broken because the nightly CI was disabled for the nvfuser benchmark and the `ci.yaml` file was removed. This can happen in the future for any specific benchmark, so let's keep the example generic.