### PR TITLE
Avoid making conda a hard dependency

### DIFF
--- a/torchbenchmark/models/doctr_det_predictor/install.py
+++ b/torchbenchmark/models/doctr_det_predictor/install.py
@@ -3,9 +3,6 @@ import subprocess
 import sys
 
 def pip_install_requirements():
-    # install deps from conda-forge
-    # model doctr_det_predictor needs weasyprint, which needs libglib and pango
-    subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
 
 if __name__ == '__main__':

--- a/torchbenchmark/models/doctr_det_predictor/install.py
+++ b/torchbenchmark/models/doctr_det_predictor/install.py
@@ -1,8 +1,13 @@
 import os
+import warnings
 import subprocess
 import sys
 
 def pip_install_requirements():
+    try:
+        subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
+    except:
+        warnings.warn("The doctr_det_predictor model requires conda binary libaries to be installed. Missing conda packages might break this model.")
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
 
 if __name__ == '__main__':

--- a/torchbenchmark/models/doctr_reco_predictor/install.py
+++ b/torchbenchmark/models/doctr_reco_predictor/install.py
@@ -3,9 +3,6 @@ import subprocess
 import sys
 
 def pip_install_requirements():
-    # install deps from conda-forge
-    # model doctr_reco_predictor needs weasyprint, which needs libglib and pango
-    subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
 
 if __name__ == '__main__':

--- a/torchbenchmark/models/doctr_reco_predictor/install.py
+++ b/torchbenchmark/models/doctr_reco_predictor/install.py
@@ -1,8 +1,13 @@
 import os
+import warnings
 import subprocess
 import sys
 
 def pip_install_requirements():
+    try:
+        subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
+    except:
+        warnings.warn("The doctr_reco_predictor model requires conda binary libaries to be installed. Missing conda packages might break this model.")
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
 
 if __name__ == '__main__':

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -95,9 +95,6 @@ def install_torch_deps(cuda_version: str):
     torch_deps = ["numpy", "requests", "ninja", "pyyaml", "setuptools", "gitpython", "beautifulsoup4", "regex"]
     cmd = ["conda", "install", "-y"] + torch_deps
     subprocess.check_call(cmd)
-    # install deps from conda-forge
-    # model doctr_reco_predictor and doctr_det_predictor needs weasyprint, which needs libglib and pango
-    subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
     # install unittest-xml-reporting
     cmd = ["pip", "install", "unittest-xml-reporting"]
     subprocess.check_call(cmd)

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -95,6 +95,9 @@ def install_torch_deps(cuda_version: str):
     torch_deps = ["numpy", "requests", "ninja", "pyyaml", "setuptools", "gitpython", "beautifulsoup4", "regex"]
     cmd = ["conda", "install", "-y"] + torch_deps
     subprocess.check_call(cmd)
+    # install deps from conda-forge
+    # model doctr_reco_predictor and doctr_det_predictor needs weasyprint, which needs libglib and pango
+    subprocess.check_call(["conda", "install", "-y", "expecttest", "libglib", "pango", "-c", "conda-forge"])
     # install unittest-xml-reporting
     cmd = ["pip", "install", "unittest-xml-reporting"]
     subprocess.check_call(cmd)


### PR DESCRIPTION
After some thoughts I believe we should keep conda an optional dependency because users might want to setup their own binary libraries and environment. We will first try installing binary libraries from conda, if failed, print a warning.

Fixes https://github.com/pytorch/benchmark/issues/1512. 
