### PR TITLE
Fix NVIDIA driver version in the dockerfile

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Tune Nvidia GPU
         run: |
           . "${SETUP_SCRIPT}"
-          # Copy the NVIDIA libraries to the default libraries path
-          sudo cp -r /usr/local/nvidia/lib64/* /lib/x86_64-linux-gnu/
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi

--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Tune Nvidia GPU
         run: |
           . "${SETUP_SCRIPT}"
-          # Copy the NVIDIA libraries to the default libraries path
-          sudo cp -r /usr/local/nvidia/lib64/* /lib/x86_64-linux-gnu/
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Tune Nvidia GPU
         run: |
           . "${SETUP_SCRIPT}"
-          # Copy the NVIDIA libraries to the default libraries path
-          sudo cp -r /usr/local/nvidia/lib64/* /lib/x86_64-linux-gnu/
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi

--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -19,19 +19,16 @@ RUN sudo chmod +x /usr/bin/switch-cuda.sh
 
 RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 
-# Install CUDA 11.6 and cudnn 8.3.2.44
-RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run -O cuda_11.6.2_510.47.03_linux.run && \
-    sudo bash ./cuda_11.6.2_510.47.03_linux.run --toolkit --silent && \
-    rm -f cuda_11.6.2_510.47.03_linux.run
-RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz \
-    -O /workspace/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz && \
-    tar xJf cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz && \
-    cd cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive && \
-    sudo cp include/* /usr/local/cuda/include && \
-    sudo cp lib/* /usr/local/cuda/lib64 && \
-    sudo ldconfig && \
-    cd .. && rm -rf cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive && rm -rf cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz
+# Download and the NVIDIA Driver files, NVIDIA Driver version is bundled together with GKE
+# NVIDIA Driver version: 525.60.13, GKE version: 1.26.2-gke.1000
+# GKE release notes: https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
+# Do not compile the kernel modules, which is provided by the host GKE environment
+RUN cd /workspace && mkdir tmp_nvidia && cd tmp_nvidia && \
+    wget -q https://storage.googleapis.com/nvidia-drivers-us-public/tesla/525.60.13/NVIDIA-Linux-x86_64-525.60.13.run && \
+    bash ./NVIDIA-Linux-x86_64-525.60.13.run --no-kernel-modules
 
+# Source of the CUDA installation scripts:
+# https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
 # Install CUDA 11.7 and cudnn 8.5.0.96
 RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux.run -O cuda_11.7.0_515.43.04_linux.run && \
     sudo bash ./cuda_11.7.0_515.43.04_linux.run --toolkit --silent && \
@@ -51,8 +48,8 @@ RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/cuda/
 RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.7.0/local_installers/11.8/cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz -O cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz && \
     tar xJf cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz && \
     cd cudnn-linux-x86_64-8.7.0.84_cuda11-archive && \
-    sudo cp include/* /usr/local/cuda-11.7/include && \
-    sudo cp lib/* /usr/local/cuda-11.7/lib64 && \
+    sudo cp include/* /usr/local/cuda-11.8/include && \
+    sudo cp lib/* /usr/local/cuda-11.8/lib64 && \
     sudo ldconfig && \
     cd .. && rm -rf cudnn-linux-x86_64-8.7.0.84_cuda11-archive && rm -f cudnn-linux-x86_64-8.7.0.84_cuda11-archive.tar.xz
 RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
@@ -63,6 +60,33 @@ RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
     cd .. && \
     rm -rf tmp_nccl && \
     sudo ldconfig
+
+# Install CUDA CUDA 12.1 and cuDNN 8.8 and NCCL 2.17.1
+RUN cd /workspace && mkdir tmp_cuda && cd tmp_cuda && \
+    wget -q https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run && \
+    chmod +x cuda_12.1.0_530.30.02_linux.run && \
+    ./cuda_12.1.0_530.30.02_linux.run --toolkit --silent && \
+    cd .. && \
+    rm -rf tmp_cuda && \
+    ldconfig
+# cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
+RUN cd /workspace && mkdir tmp_cudnn && cd tmp_cudnn && \
+    wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz -O cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
+    tar xf cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
+    cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/include/* /usr/local/cuda/include/ && \
+    cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/lib/* /usr/local/cuda/lib64/ && \
+    cd .. && \
+    rm -rf tmp_cudnn && \
+    ldconfig
+# NCCL license: https://docs.nvidia.com/deeplearning/nccl/#licenses
+RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
+    wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.17.1/nccl_2.17.1-1+cuda12.1_x86_64.txz && \
+    tar xf nccl_2.17.1-1+cuda12.1_x86_64.txz && \
+    cp -a nccl_2.17.1-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/ && \
+    cp -a nccl_2.17.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/ && \
+    cd .. && \
+    rm -rf tmp_nccl && \
+    ldconfig
 
 # Setup the default CUDA version to 11.7
 RUN sudo rm -f /usr/local/cuda && sudo ln -s /usr/local/cuda-11.7 /usr/local/cuda
@@ -84,8 +108,8 @@ RUN echo "\
 export CONDA_HOME=\${HOME}/miniconda3\n\
 export NVIDIA_HOME=/usr/local/nvidia\n\
 export CUDA_HOME=/usr/local/cuda\n\
-export PATH=\${NVIDIA_HOME}/bin:\${CUDA_HOME}/bin\${PATH:+:\${PATH}}\n\
-export LD_LIBRARY_PATH=\${NVIDIA_HOME}/lib64:\${CUDA_HOME}/lib64\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\n" >> ${HOME}/.bashrc
+export PATH=\${CUDA_HOME}/bin\${PATH:+:\${PATH}}\n\
+export LD_LIBRARY_PATH=\${CUDA_HOME}/lib64\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\n" >> ${HOME}/.bashrc
 
 RUN echo "\
 . \${HOME}/miniconda3/etc/profile.d/conda.sh\n\
@@ -93,5 +117,5 @@ conda activate base\n\
 export CONDA_HOME=\${HOME}/miniconda3\n\
 export NVIDIA_HOME=/usr/local/nvidia\n\
 export CUDA_HOME=/usr/local/cuda\n\
-export PATH=\${NVIDIA_HOME}/bin:\${CUDA_HOME}/bin\${PATH:+:\${PATH}}\n\
-export LD_LIBRARY_PATH=\${NVIDIA_HOME}/lib64:\${CUDA_HOME}/lib64\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\n" >> /workspace/setup_instance.sh
+export PATH=\${CUDA_HOME}/bin\${PATH:+:\${PATH}}\n\
+export LD_LIBRARY_PATH=\${CUDA_HOME}/lib64\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}\n" >> /workspace/setup_instance.sh

--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -4,10 +4,10 @@ FROM ${BASE_IMAGE}
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN sudo apt-get -y update
+RUN sudo apt-get -y update && sudo apt -y update
 RUN sudo apt-get install -y git jq \
                             vim wget curl ninja-build cmake \
-                            libgl1-mesa-glx libsndfile1-dev
+                            libgl1-mesa-glx libsndfile1-dev kmod
 
 # Install gcc-11, needed by the latest fbgemm
 RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && \

--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -55,8 +55,8 @@ RUN cd /workspace && wget -q https://developer.download.nvidia.com/compute/redis
 RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
     wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.15.5/nccl_2.15.5-1+cuda11.8_x86_64.txz && \
     tar xf nccl_2.15.5-1+cuda11.8_x86_64.txz && \
-    sudo cp -a nccl_2.15.5-1+cuda11.8_x86_64/include/* /usr/local/cuda/include/ && \
-    sudo cp -a nccl_2.15.5-1+cuda11.8_x86_64/lib/* /usr/local/cuda/lib64/ && \
+    sudo cp -a nccl_2.15.5-1+cuda11.8_x86_64/include/* /usr/local/cuda-11.8/include/ && \
+    sudo cp -a nccl_2.15.5-1+cuda11.8_x86_64/lib/* /usr/local/cuda-11.8/lib64/ && \
     cd .. && \
     rm -rf tmp_nccl && \
     sudo ldconfig
@@ -73,8 +73,8 @@ RUN cd /workspace && mkdir tmp_cuda && cd tmp_cuda && \
 RUN cd /workspace && mkdir tmp_cudnn && cd tmp_cudnn && \
     wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz -O cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
     tar xf cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
-    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/include/* /usr/local/cuda/include/ && \
-    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/lib/* /usr/local/cuda/lib64/ && \
+    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/include/* /usr/local/cuda-12.1/include/ && \
+    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/lib/* /usr/local/cuda-12.1/lib64/ && \
     cd .. && \
     rm -rf tmp_cudnn && \
     sudo ldconfig
@@ -82,8 +82,8 @@ RUN cd /workspace && mkdir tmp_cudnn && cd tmp_cudnn && \
 RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
     wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.17.1/nccl_2.17.1-1+cuda12.1_x86_64.txz && \
     tar xf nccl_2.17.1-1+cuda12.1_x86_64.txz && \
-    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/ && \
-    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/ && \
+    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/include/* /usr/local/cuda-12.1/include/ && \
+    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda-12.1/lib64/ && \
     cd .. && \
     rm -rf tmp_nccl && \
     sudo ldconfig

--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -25,7 +25,7 @@ RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 # Do not compile the kernel modules, which is provided by the host GKE environment
 RUN cd /workspace && mkdir tmp_nvidia && cd tmp_nvidia && \
     wget -q https://storage.googleapis.com/nvidia-drivers-us-public/tesla/525.60.13/NVIDIA-Linux-x86_64-525.60.13.run && \
-    bash ./NVIDIA-Linux-x86_64-525.60.13.run --no-kernel-modules
+    sudo bash ./NVIDIA-Linux-x86_64-525.60.13.run --no-kernel-modules -s --no-systemd --no-kernel-module-source --no-nvidia-modprobe
 
 # Source of the CUDA installation scripts:
 # https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
@@ -65,28 +65,28 @@ RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
 RUN cd /workspace && mkdir tmp_cuda && cd tmp_cuda && \
     wget -q https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run && \
     chmod +x cuda_12.1.0_530.30.02_linux.run && \
-    ./cuda_12.1.0_530.30.02_linux.run --toolkit --silent && \
+    sudo ./cuda_12.1.0_530.30.02_linux.run --toolkit --silent && \
     cd .. && \
     rm -rf tmp_cuda && \
-    ldconfig
+    sudo ldconfig
 # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
 RUN cd /workspace && mkdir tmp_cudnn && cd tmp_cudnn && \
     wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz -O cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
     tar xf cudnn-linux-x86_64-8.8.1.3_cuda12-archive.tar.xz && \
-    cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/include/* /usr/local/cuda/include/ && \
-    cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/lib/* /usr/local/cuda/lib64/ && \
+    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/include/* /usr/local/cuda/include/ && \
+    sudo cp -a cudnn-linux-x86_64-8.8.1.3_cuda12-archive/lib/* /usr/local/cuda/lib64/ && \
     cd .. && \
     rm -rf tmp_cudnn && \
-    ldconfig
+    sudo ldconfig
 # NCCL license: https://docs.nvidia.com/deeplearning/nccl/#licenses
 RUN cd /workspace && mkdir tmp_nccl && cd tmp_nccl && \
     wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.17.1/nccl_2.17.1-1+cuda12.1_x86_64.txz && \
     tar xf nccl_2.17.1-1+cuda12.1_x86_64.txz && \
-    cp -a nccl_2.17.1-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/ && \
-    cp -a nccl_2.17.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/ && \
+    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/ && \
+    sudo cp -a nccl_2.17.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/ && \
     cd .. && \
     rm -rf tmp_nccl && \
-    ldconfig
+    sudo ldconfig
 
 # Setup the default CUDA version to 11.7
 RUN sudo rm -f /usr/local/cuda && sudo ln -s /usr/local/cuda-11.7 /usr/local/cuda


### PR DESCRIPTION
This PR also removes the requirement of copying NVIDIA driver files to /lib/x86_64-linux-gnu.

However, it pins the NVIDIA driver version to 525.60.13. When we update infra, we need to update the NVIDIA driver version in the docker file too.

Test Plan:
Optim Benchmark
https://github.com/pytorch/benchmark/actions/runs/4634904570