### PR TITLE
Update the NVIDIA driver installation step

### DIFF
--- a/.github/workflows/pr-a10g.yml
+++ b/.github/workflows/pr-a10g.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Install NVIDIA Driver, docker runtime, set GPU_FLAG
         id: install-nvidia-driver
         uses: pytorch/test-infra/.github/actions/setup-nvidia@main
-      - name: GPU Tuning
-        run: |
-          sudo nvidia-smi -pm 1
-          nvidia-smi
       - name: Setup Conda Env
         run: |
           . ${HOME}/miniconda3/etc/profile.d/conda.sh

--- a/.github/workflows/pr-a10g.yml
+++ b/.github/workflows/pr-a10g.yml
@@ -21,12 +21,13 @@ jobs:
       - name: Install Conda and basic packages
         run: |
           bash scripts/install_basics_amzn_linux_2.sh
-      - name: Install NVIDIA Driver
-        run: |
-          bash scripts/setup_nvda_11.7.sh
+      - name: Install NVIDIA Driver, docker runtime, set GPU_FLAG
+        id: install-nvidia-driver
+        uses: pytorch/test-infra/.github/actions/setup-nvidia@main
       - name: GPU Tuning
         run: |
           sudo nvidia-smi -pm 1
+          nvidia-smi
       - name: Setup Conda Env
         run: |
           . ${HOME}/miniconda3/etc/profile.d/conda.sh


### PR DESCRIPTION
Use the NOVA standard setup-nvidia action to install NVIDIA drivers on the A10G runner.

If the A10G runner workflow is stable, we will remove the A100 runner from PR testing.