### PR TITLE
Disable the auto-run of AI Cluster workflow

### DIFF
--- a/.github/workflows/userbenchmark-ai-cluster.yml
+++ b/.github/workflows/userbenchmark-ai-cluster.yml
@@ -1,9 +1,5 @@
 name: TorchBench Userbenchmark on AI Cluster
 on:
-  schedule:
-    # on the AI cluster, the cron job runs at 8 PM UTC
-    # we expect the result to be available at 10 PM UTC
-    - cron: '0 22 * * *' # run at 10 PM UTC
   workflow_dispatch:
     inputs:
 


### PR DESCRIPTION
PT-D team is not using AI Cluster runs anymore, and it is broken because of backend issue: https://github.com/pytorch/benchmark/actions/workflows/userbenchmark-ai-cluster.yml
So we are disabling the workflow to be automatically triggered.