### PR TITLE
Add compilation time support

### DIFF
--- a/run.py
+++ b/run.py
@@ -353,4 +353,4 @@ if __name__ == "__main__":
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')
     if hasattr(m, 'dynamo_compilation_time'):
-        print('{:<20} {:>20}'.format("PT2 Compilation time: ", "%.3f milliseconds" % m.dynamo_compilation_time), sep='')
+        print('{:<20} {:>20}'.format("PT2 Compilation time: ", "%.3f seconds" % m.dynamo_compilation_time), sep='')

--- a/run.py
+++ b/run.py
@@ -353,4 +353,4 @@ if __name__ == "__main__":
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')
     if hasattr(m, 'dynamo_compilation_time'):
-        print('{:<20} {:>20}'.format("PT2 Compilation time: ", "%.3f seconds" % m.dynamo_compilation_time), sep='')
+        print('{:<20} {:>18}'.format("PT2 Compilation time: ", "%.3f seconds" % m.dynamo_compilation_time), sep='')

--- a/run.py
+++ b/run.py
@@ -352,3 +352,5 @@ if __name__ == "__main__":
                      stress=args.stress, metrics_needed=metrics_needed, metrics_gpu_backend=args.metrics_gpu_backend)
     if hasattr(m, 'correctness'):
         print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')
+    if hasattr(m, 'dynamo_compilation_time'):
+        print('{:<20} {:>20}'.format("PT2 Compilation time: ", "%.3f milliseconds" % m.dynamo_compilation_time), sep='')

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -57,19 +57,15 @@ def is_staged_train_test(model: 'torchbenchmark.util.model.BenchmarkModel') -> b
 
 def warmup(model: 'torchbenchmark.util.model.BenchmarkModel', niters=DEFAULT_WARMUP_NITERS):
     import torch
-    try:
-        if model.device == "cuda":
-            torch.cuda.reset_peak_memory_stats()
-            torch.cuda.empty_cache()
-        t0 = time.perf_counter()
-        for _ in range(niters):
-            model.invoke()
-        t1 = time.perf_counter()
-        latency = t1 - t0
-        return latency
-    except Exception as e:
-        print(f"Model {model.name} failed in warmup(): {str(e)}")
-        exit(-1)
+    if model.device == "cuda":
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+    t0 = time.perf_counter()
+    for _ in range(niters):
+        model.invoke()
+    t1 = time.perf_counter()
+    latency = t1 - t0
+    return latency
 
 def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim=True, deepcopy=True, rounds=STABLENESS_CHECK_ROUNDS) -> Tuple['torch.Tensor']:
     """Get the eager output. Run eager mode a couple of times to guarantee stableness.

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -67,8 +67,8 @@ def warmup(model: 'torchbenchmark.util.model.BenchmarkModel', niters=DEFAULT_WAR
         t1 = time.perf_counter()
         latency = (t1 - t0) * 1000.0
         return latency
-    except Exception:
-        print(f"Model {model.name} failed in warmup()")
+    except Exception as e:
+        print(f"Model {model.name} failed in warmup(): {str(e)}")
         exit(-1)
 
 def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim=True, deepcopy=True, rounds=STABLENESS_CHECK_ROUNDS) -> Tuple['torch.Tensor']:

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -65,7 +65,7 @@ def warmup(model: 'torchbenchmark.util.model.BenchmarkModel', niters=DEFAULT_WAR
         for _ in range(niters):
             model.invoke()
         t1 = time.perf_counter()
-        latency = (t1 - t0) * 1000.0
+        latency = t1 - t0
         return latency
     except Exception as e:
         print(f"Model {model.name} failed in warmup(): {str(e)}")

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -65,7 +65,7 @@ def warmup(model: 'torchbenchmark.util.model.BenchmarkModel', niters=DEFAULT_WAR
         for _ in range(niters):
             model.invoke()
         t1 = time.perf_counter()
-        latency = t1 - t0
+        latency = (t1 - t0) * 1000.0
         return latency
     except Exception:
         print(f"Model {model.name} failed in warmup()")

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -3,6 +3,7 @@ PyTorch benchmark env check utils.
 This file may be loaded without torch packages installed, e.g., in OnDemand CI.
 """
 import importlib
+import time
 import copy
 import warnings
 from typing import List, Dict, Tuple, Optional
@@ -12,6 +13,8 @@ MAIN_RANDOM_SEED = 1337
 STABLENESS_CHECK_ROUNDS: int = 3
 # rounds for correctness tests
 CORRECTNESS_CHECK_ROUNDS: int = 2
+# default warmup iterations
+DEFAULT_WARMUP_NITERS = 5
 
 def set_random_seed():
     import torch
@@ -51,6 +54,22 @@ def is_fambench_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool
 
 def is_staged_train_test(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
     return hasattr(model, 'forward') and hasattr(model, 'backward') and hasattr(model, 'optimizer_step')
+
+def warmup(model: 'torchbenchmark.util.model.BenchmarkModel', niters=DEFAULT_WARMUP_NITERS):
+    import torch
+    try:
+        if model.device == "cuda":
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.empty_cache()
+        t0 = time.perf_counter()
+        for _ in range(niters):
+            model.invoke()
+        t1 = time.perf_counter()
+        latency = t1 - t0
+        return latency
+    except Exception:
+        print(f"Model {model.name} failed in warmup()")
+        exit(-1)
 
 def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim=True, deepcopy=True, rounds=STABLENESS_CHECK_ROUNDS) -> Tuple['torch.Tensor']:
     """Get the eager output. Run eager mode a couple of times to guarantee stableness.

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -156,6 +156,9 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         if self.dynamo:
             from torchbenchmark.util.backends.torchdynamo import apply_torchdynamo_args
             apply_torchdynamo_args(self, self.opt_args, self.dargs.precision)
+            cache_entries = {}
+            from torch._inductor.utils import fresh_inductor_cache
+            fresh_inductor_cache(cache_entries)
             opt_latency = warmup(self)
             self.dynamo_compilation_time = (opt_latency - eager_latency)
         else:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -13,7 +13,7 @@ from torchbenchmark import REPO_PATH
 from torchbenchmark.util.extra_args import check_correctness_p, parse_opt_args, apply_opt_args, \
                                            parse_decoration_args, apply_decoration_args, is_staged_train_test, \
                                            TEST_STAGE
-from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check, is_hf_model
+from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check, is_hf_model, warmup
 from torchbenchmark.util.fx_int8 import get_sub_module, prepare_sub_module, convert_sub_module
 
 class PostInitProcessor(type):
@@ -151,10 +151,13 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                     self.set_optimizer(current_optimizer)
         # apply decoration args
         apply_decoration_args(self, self.dargs)
+        eager_latency = warmup(self)
         # apply optimization args
         if self.dynamo:
             from torchbenchmark.util.backends.torchdynamo import apply_torchdynamo_args
             apply_torchdynamo_args(self, self.opt_args, self.dargs.precision)
+            opt_latency = warmup(self)
+            self.dynamo_compilation_time = (opt_latency - eager_latency)
         else:
             apply_opt_args(self, self.opt_args)
         if should_check_correctness:


### PR DESCRIPTION
Measure warmup latency and use it to measure the PT2/inductor compilation time.

Fixes https://github.com/pytorch/benchmark/issues/1546

Test plan:

```
$ python run.py resnet50 -d cuda -t train --torchdynamo inductor
Running train method from resnet50 on cuda in dynamo inductor mode with input batch size 32 and precision fp32.
GPU Time:             35.727 milliseconds
CPU Total Wall Time:  35.774 milliseconds
GPU 0 Peak Memory:              6.5234 GB
CPU Peak Memory:                1.2148 GB
Correctness:                        False
PT2 Compilation time:      27.919 seconds
```