### PR TITLE
rename optimizer() to optimizer_step()

### DIFF
--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -50,7 +50,7 @@ def is_fambench_model(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool
     return hasattr(model, 'FAMBENCH_MODEL') and model.FAMBENCH_MODEL
 
 def is_staged_train_test(model: 'torchbenchmark.util.model.BenchmarkModel') -> bool:
-    return hasattr(model, 'forward') and hasattr(model, 'backward') and hasattr(model, 'optimizer')
+    return hasattr(model, 'forward') and hasattr(model, 'backward') and hasattr(model, 'optimizer_step')
 
 def stableness_check(model: 'torchbenchmark.util.model.BenchmarkModel', cos_sim=True, deepcopy=True, rounds=STABLENESS_CHECK_ROUNDS) -> Tuple['torch.Tensor']:
     """Get the eager output. Run eager mode a couple of times to guarantee stableness.

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -273,7 +273,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
 
         if hasattr(self, "opt") and self.opt:
             with nested(*self.optimizer_contexts):
-                self.optimizer()
+                self.optimizer_step()
 
         return None
 


### PR DESCRIPTION
Summary: Renames API to be more clear and to avoid confusion with the class attribute optimizer that represents the object.

Differential Revision: D44934167

