### PR TITLE
Strictly return Not Implemented for get/set_optimizer()

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -17,7 +17,7 @@ def check_correctness_p(
 ) -> bool:
     "If correctness check should be enabled."
     # if the model doesn't support correctness check (like detectron2), skip it
-    if hasattr(model, 'SKIP_CORRECTNESS_CHECK') and model.SKIP_CORRECTNESS_CHECK:
+    if getattr(model, 'SKIP_CORRECTNESS_CHECK', False) or getattr(model, 'CANNOT_SET_CUSTOM_OPTIMIZER', False):
         return False
     if dargs.skip_correctness:
         return False

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -257,10 +257,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             return self.optimizer
         if hasattr(self, "opt"):
             return self.opt
-        warnings.warn("The optimizer for this model is not stored in self.opt nor self.optimizer. "
-                      "Currently returning None! Please override this implementation with your own "
-                      "if there is an optimizer this should be returning instead.")
-        return None
+        raise NotImplementedError("The optimizer for this model is not stored in self.opt nor self.optimizer. "
+                                  "Please override this implementation with your own.")
 
     # Takes in an optimizer and sets that to be the optimizer used from now on.
     # There are special models like dcgan that would update multiple optimizers at once,


### PR DESCRIPTION
This cannot land yet as it will now exclude certain models from the correctness check (like yolov3) which should not be skipped for things like dynamo!

@xuzhao9  has a proposal to untangle the dependencies there and this depends on landing that first.