### PR TITLE
Pin rapidfuzz dep to 2.15.1

### DIFF
--- a/torchbenchmark/models/doctr_det_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_det_predictor/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/mindee/doctr.git@acb9f64
+rapidfuzz==2.15.1

--- a/torchbenchmark/models/doctr_reco_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_reco_predictor/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/mindee/doctr.git@acb9f64
+rapidfuzz==2.15.1


### PR DESCRIPTION
As repo is incompatible with `rapidfuzz-3.0.0`:
```python
>>> import doctr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/__init__.py", line 1, in <module>
    from . import datasets, io, models, transforms, utils
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/__init__.py", line 4, in <module>
    from .recognition import *
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/__init__.py", line 5, in <module>
    from .zoo import *
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/zoo.py", line 12, in <module>
    from .predictor import RecognitionPredictor
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/__init__.py", line 6, in <module>
    from .pytorch import *  # type: ignore[misc]
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/pytorch.py", line 14, in <module>
    from ._utils import remap_preds, split_crops
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/predictor/_utils.py", line 10, in <module>
    from ..utils import merge_multi_strings
  File "/home/nshulga/miniconda3/envs/py310/lib/python3.10/site-packages/doctr/models/recognition/utils.py", line 8, in <module>
    from rapidfuzz.string_metric import levenshtein
ModuleNotFoundError: No module named 'rapidfuzz.string_metric'
```

Propose fix upstream in https://github.com/mindee/doctr/pull/1176