### PR TITLE
Cherry pick rapidfuzz dependency workaround

### DIFF
--- a/torchbenchmark/models/doctr_det_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_det_predictor/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/mindee/doctr.git@acb9f64
+rapidfuzz==2.15.1

--- a/torchbenchmark/models/doctr_reco_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_reco_predictor/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/mindee/doctr.git@acb9f64
+rapidfuzz==2.15.1


### PR DESCRIPTION
Rapidfuzz had BC breaking changes in 3.0.0, pin to an older version. This is a cherry pick from main branch and against v3.0. 