### PR TITLE
Add initial cpu userbenchmark for torchbench

### DIFF
--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -1,0 +1,98 @@
+# CPU Userbenchmark
+
+The `cpu` userbenchmark is target for typical user scenarios for cpu benchmark
+of PyTorch. It can be used to track regression, prove performance benefit of cpu
+optimizations and reproduce performance easily. 
+
+To support this target, the `cpu` userbenchmark has implemented core binding
+option, multi-instances test, gomp/iomp option and memory allocator option. And
+it able to benchmark all enabled cpu features based on torchbench model, e.g.
+channels-last / fx_int8 / jit with fusers and so on.
+
+## Usage
+
+Samilar with other userbenchmarks, `cpu` userbenchmark can be launched by
+`run_benchmark.py` with below command,
+```shell
+python run_benchmark.py cpu <cpu userbenchmark specific parameters> <extra args supportted by torchbench model>
+```
+
+All parameters of `cpu` userbenchmark as below,
+- `--device, -d` devices to run, default value is `cpu`.
+- `--test, -t` tests to run, splited by comma. Default value is `eval`.
+- `--model, -m` only run the specifice models, split by comma. Default value is
+  `None`, means run all models.
+- `--batch-size, -b` run with the specifice batch size. Default value is `None`,
+  means run eith mdoel predifined default batch size.
+- `--jit` whether to convert and run the model with `jit` mode.
+- `--config, -c` YAML config to specify tests to run.
+- `--output, -o` output dir. By default will create folder under
+  `.userbenchmark/cpu`.
+- `--launcher` whether to use `torch.backends.xeon.run_cpu` to get the peak
+  performance on Intel(R) Xeon(R) Scalable Processors.
+- `--launcher-args` work with `--launcher` enabled, to provide the args of
+  torch.backends.xeon.run_cpu. The detail usage of the launcher can be found by
+  executing `python -m torch.backends.xeon.run_cpu --help`, or check the source
+  code in
+  [here](https://github.com/pytorch/pytorch/blob/main/torch/backends/xeon/run_cpu.py).
+- `--dryrun` whether dryrun the userbenchmark command.
+
+Besides those parameters provided by the `cpu` userbenchmark directly, user also
+can add all supported extra args defined in
+[`extra_args.py`](../../torchbenchmark/util/extra_args.py) and specific args
+defined in each [`backend`](../../torchbenchmark/util/backends). For example, if
+the extra arg `--precision fx_int8` with `-t eval` have been added into the test
+command, it will do fx int8 inference benchmark for specifice models. And if
+`torchdynamo` backend related args have been added, it will do torchdynamo
+related benchmarks accordingly.
+
+## Examples
+
+Below command tested 2 models fx_int8 inference with batch size 8 on CLX socket
+0 and 4 instances at the same time.
+```shell
+python run_benchmark.py cpu --model resnet50,alexnet --test eval -b 8 --precision fx_int8 --launcher --launcher-args "--node-id 0 --ninstances 4"
+```
+Test results can be found in `.userbenchmark/cpu/cpu-20230420004336` and
+`.userbenchmark/cpu/metrics-20230420004336.json`. The `cpu` userbenchmark will
+create a folder `cpu-YYmmddHHMMSS` for the test, and aggregate all test results
+into `metrics-YYmmddHHMMSS.json`. The `YYmmddHHMMSS` is the time to start the
+test. And for each single model test, it will create a subfolder under folder
+`cpu-YYmmddHHMMSS`. For each subfolder, it contains instances logs named with
+instance PID for that model test.
+```shell
+$ ls .userbenchmark/cpu/cpu-20230420004336
+eval_alexnet_eager/  eval_resnet50_eager/  
+$ ls .userbenchmark/cpu/cpu-20230420004336/eval_alexnet_eager/
+metrics-3347653.json  metrics-3347654.json  metrics-3347655.json  metrics-3347656.json
+$ cat .userbenchmark/cpu/metrics-20230420004336.json 
+{
+    "name": "cpu",
+    "environ": {
+        "pytorch_git_version": "de1114554c38322273c066c091d455519d45472d"
+    },
+    "metrics": {
+        "alexnet-eval-eager_latency": 58.309660750000006,
+        "alexnet-eval-eager_cmem": 0.416259765625,
+        "resnet50-eval-eager_latency": 335.04970325,
+        "resnet50-eval-eager_cmem": 0.90673828125
+    }
+}
+```
+
+Test with config YAML file,
+```shell
+python run_benchmark.py cpu -c cpu_test.yaml
+```
+
+Other typical cpu benchmark test examples.
+
+Benchmark jit with oneDNN fuser can use below comamnd,
+```shell
+python run_benchmark.py cpu --model resnet50 --test eval --jit --fuser fuser3
+```
+
+Benchmark `float32` eager inference with `channels-last` comamnd as below,
+```shell
+python run_benchmark.py cpu --model resnet50 --test eval --channels-last
+```

--- a/userbenchmark/cpu/__init__.py
+++ b/userbenchmark/cpu/__init__.py
@@ -1,0 +1,147 @@
+"""
+Run PyTorch cpu benchmarking.
+"""
+import argparse
+import itertools
+import os
+import yaml
+import numpy
+
+from typing import List, Tuple, Dict, Optional
+from ..utils import REPO_PATH, add_path, get_output_json, dump_output
+
+with add_path(REPO_PATH):
+    from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
+                                                            list_devices, list_tests
+    from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
+
+BM_NAME = 'cpu'
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+def generate_model_configs(devices: List[str], tests: List[str], model_names: List[str], jit: bool, extra_args: List[str]) -> List[TorchBenchModelConfig]:
+    """Use the default batch size and default mode."""
+    if not model_names:
+        model_names = list_models()
+    cfgs = itertools.product(*[devices, tests, model_names])
+    result = [TorchBenchModelConfig(
+        name=model_name,
+        device=device,
+        test=test,
+        batch_size=None,
+        jit=jit,
+        extra_args=extra_args,
+        extra_env=None,
+    ) for device, test, model_name in cfgs]
+    return result
+
+def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
+    return ["latencies", "cpu_peak_mem"]
+
+def result_to_output_metrics(results: List[Tuple[TorchBenchModelConfig, TorchBenchModelMetrics]]) -> Dict[str, float]:
+    # metrics name examples:
+    # test_eval[timm_regnet-cpu-eager]_latency
+    # test_eval[timm_regnet-cpu-eager]_cmem
+    result_metrics = {}
+    for config, metrics in results:
+        print(config)
+        mode = "jit" if config.jit else "eager"
+        metrics_base = f"test_{config.test}[{config.name}-{config.device}-{mode}]"
+        latency_metric = f"{metrics_base}_latency"
+        median_latency = numpy.median(metrics.latencies)
+        assert median_latency, f"Run failed for metric {latency_metric}"
+        result_metrics[latency_metric] = median_latency
+        if metrics.cpu_peak_mem:
+            cpu_peak_mem = f"{metrics_base}_cmem"
+            result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
+    return result_metrics
+
+def dump_result_to_json(metrics):
+    result = get_output_json(BM_NAME, metrics)
+    dump_output(BM_NAME, result)
+
+def validate(candidates: List[str], choices: List[str]) -> List[str]:
+    """Validate the candidates provided by the user is valid"""
+    for candidate in candidates:
+        assert candidate in choices, f"Specified {candidate}, but not in available list: {choices}."
+    return candidates
+
+def generate_model_configs_from_yaml(yaml_file: str) -> List[TorchBenchModelConfig]:
+    yaml_file_path = os.path.join(CURRENT_DIR, yaml_file)
+    with open(yaml_file_path, "r") as yf:
+        config_obj = yaml.safe_load(yf)
+    devices = config_obj.keys()
+    configs = []
+    for device in devices:
+        for c in config_obj[device]:
+            if not c["stable"]:
+                continue
+            config = TorchBenchModelConfig(
+                name=c["model"],
+                device=device,
+                test=c["test"],
+                batch_size=c["batch_size"] if "batch_size" in c else None,
+                jit=c["jit"] if "jit" in c else False,
+                extra_args=[],
+                extra_env=None,
+            )
+            configs.append(config)
+    return configs
+
+def parse_str_to_list(candidates):
+    if isinstance(candidates, list):
+        return candidates
+    candidates = list(map(lambda x: x.strip(), candidates.split(",")))
+    return candidates
+
+def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
+    """This function only handles NotImplementedError, all other errors will fail."""
+    metrics = get_metrics(config)
+    print(f"Running {config} ...", end='')
+    if dryrun:
+        return None
+    # We do not allow RuntimeError in this test
+    try:
+        # load the model instance within the same process
+        model = load_model_isolated(config)
+        # get the model test metrics
+        result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
+    except NotImplementedError as e:
+        print(" [NotImplemented]")
+        return None
+    print(" [Done]")
+    return result
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", "-d", default="cpu", help="Devices to run, splited by comma.")
+    parser.add_argument("--test", "-t", default="eval", help="Tests to run, splited by comma.")
+    parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice models, splited by comma.")
+    parser.add_argument("--jit", action="store_true", help="Convert the models to jit mode.")
+    parser.add_argument("--config", "-c", default=None, help="YAML config to specify tests to run.")
+    parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
+    return parser.parse_known_args()
+
+def run(args: List[str]):
+    args, extra_args = parse_args(args)
+    extra_args.remove(BM_NAME)
+    if args.config:
+        configs = generate_model_configs_from_yaml(args.config)
+    else:
+        # If not specified, use the entire model set
+        if not args.model:
+            args.model = list_models()
+        devices = validate(parse_str_to_list(args.device), list_devices())
+        tests = validate(parse_str_to_list(args.test), list_tests())
+        models = validate(parse_str_to_list(args.model), list_models())
+        configs = generate_model_configs(devices, tests, model_names=models, jit=args.jit, extra_args=extra_args)
+    results = []
+    try:
+        for config in configs:
+            metrics = run_config(config, dryrun=args.dryrun)
+            if metrics:
+                results.append([config, metrics])
+    except KeyboardInterrupt:
+        print("User keyboard interrupted!")
+    if not args.dryrun:
+        metrics = result_to_output_metrics(results)
+        dump_result_to_json(metrics)

--- a/userbenchmark/cpu/__init__.py
+++ b/userbenchmark/cpu/__init__.py
@@ -16,10 +16,10 @@ from .cpu_utils import REPO_PATH, get_output_dir, get_output_json, dump_output, 
 from ..utils import add_path
 
 with add_path(REPO_PATH):
-    from torchbenchmark.util.experiment.instantiator import list_models, TorchBenchModelConfig, \
-                                                            list_devices, list_tests
+    from torchbenchmark.util.experiment.instantiator import (list_models, TorchBenchModelConfig, 
+                                                            list_devices, list_tests)
 
-BM_NAME = 'cpu'
+BM_NAME = "cpu"
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 def generate_model_configs(devices: List[str], tests: List[str], model_names: List[str], batch_size: int, jit: bool, extra_args: List[str]) -> List[TorchBenchModelConfig]:

--- a/userbenchmark/cpu/cpu_test.yaml
+++ b/userbenchmark/cpu/cpu_test.yaml
@@ -1,0 +1,4 @@
+test: eval
+model: resnet50,mobilenet_v2
+jit: True
+extra_args: --fuser fuser3

--- a/userbenchmark/cpu/cpu_utils.py
+++ b/userbenchmark/cpu/cpu_utils.py
@@ -1,0 +1,93 @@
+"""
+Run PyTorch cpu benchmarking.
+"""
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+import re
+import time
+
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
+USERBENCHMARK_OUTPUT_PREFIX = ".userbenchmark"
+
+def get_output_dir(bm_name):
+    current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    bm_out_dir = current_dir.parent.parent.joinpath(USERBENCHMARK_OUTPUT_PREFIX, bm_name)
+    test_date = datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
+    output_dir = bm_out_dir.joinpath("cpu-" + test_date)
+    output_dir.mkdir(exist_ok=True, parents=True)
+    return output_dir
+
+def get_output_json(bm_name, metrics):
+    import torch
+    return {
+        "name": bm_name,
+        "environ": {"pytorch_git_version": torch.version.git_version},
+        "metrics": metrics,
+    }
+
+def dump_output(bm_name, output, output_dir=None, fname=None):
+    output_dir = output_dir if output_dir else get_output_dir(bm_name)
+    fname = fname if fname else "metrics-{}.json".format(os.getpid())
+    full_fname = os.path.join(output_dir, fname)
+    with open(full_fname, 'w') as f:
+        json.dump(output, f, indent=4)
+
+def get_run(test_dir: Path):
+    run = {}
+    testdir_name = test_dir.name
+    regex = "(.*)_(.*)_(.*)"
+    g = re.match(regex, testdir_name).groups()
+    run["test"] = g[0]
+    run["model"] = g[1]
+    run["mode"] = g[2]
+    run["results"] = []
+    ins_jsons = filter(lambda x: x.is_file(), test_dir.iterdir())
+    for ins_json in ins_jsons:
+        with open(ins_json, "r") as ij:
+            run["results"].append(json.load(ij))
+    return run
+
+def get_runs(work_dir: Path):
+    runs = []
+    for subdir in filter(lambda x: x.is_dir(), work_dir.iterdir()):
+        run = get_run(subdir)
+        runs.append(run)
+    return runs
+
+def add_test_results(runs, result_metrics):
+    # metrics name examples:
+    # timm_regnet-eval-eager_latency
+    # timm_regnet-eval-eager_cmem
+    for run in runs:
+        run_base_name = f"{run['model']}-{run['test']}-{run['mode']}"
+        ins_number = len(run['results'])
+        assert ins_number
+        latency_metric = 'latency' in run['results'][0]['metrics']
+        cmem_metric = 'cpu_peak_mem' in run['results'][0]['metrics']
+        latency_sum = 0
+        cmem_sum = 0
+        for ins_res in run['results']: 
+            if latency_metric:           
+                latency_sum += ins_res['metrics']['latency']
+            if cmem_metric:
+                cmem_sum += ins_res['metrics']['cpu_peak_mem']
+        if latency_metric:
+            result_metrics[f"{run_base_name}_latency"] = latency_sum / ins_number
+        if cmem_metric:
+            result_metrics[f"{run_base_name}_cmem"] = cmem_sum / ins_number
+    return result_metrics
+
+def analyze(result_dir):
+    result_dir = Path(result_dir)
+    assert result_dir.is_dir(), f"Expected directory {str(result_dir)} doesn't exist."
+    result_metrics = {}
+    runs = get_runs(result_dir)
+    cpu_train = list(filter(lambda x: x["test"] == "train", runs))
+    if len(cpu_train):
+        add_test_results(cpu_train, result_metrics)
+    cpu_eval = list(filter(lambda x: x["test"] == "eval", runs))
+    if len(cpu_eval):
+        add_test_results(cpu_eval, result_metrics)
+    return result_metrics

--- a/userbenchmark/cpu/cpu_utils.py
+++ b/userbenchmark/cpu/cpu_utils.py
@@ -3,18 +3,18 @@ Run PyTorch cpu benchmarking.
 """
 import json
 import os
-from datetime import datetime
-from pathlib import Path
 import re
 import time
+from datetime import datetime
+from pathlib import Path
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
 USERBENCHMARK_OUTPUT_PREFIX = ".userbenchmark"
 
-def get_output_dir(bm_name):
+def get_output_dir(bm_name, test_date=None):
     current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
     bm_out_dir = current_dir.parent.parent.joinpath(USERBENCHMARK_OUTPUT_PREFIX, bm_name)
-    test_date = datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
+    test_date = test_date if test_date else datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S")
     output_dir = bm_out_dir.joinpath("cpu-" + test_date)
     output_dir.mkdir(exist_ok=True, parents=True)
     return output_dir

--- a/userbenchmark/cpu/run_config.py
+++ b/userbenchmark/cpu/run_config.py
@@ -1,0 +1,105 @@
+
+"""
+Run PyTorch cpu benchmarking.
+"""
+import argparse
+import os
+import sys
+import numpy
+
+from typing import List, Tuple, Dict, Optional
+from pathlib import Path
+
+REPO_DIR = str(Path(__file__).parent.parent.parent.resolve())
+sys.path.append(REPO_DIR)
+
+from utils import add_path
+with add_path(REPO_DIR):
+    from userbenchmark.cpu.cpu_utils import REPO_PATH, get_output_json, dump_output
+    from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
+                                                            list_devices, list_tests
+    from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
+
+BM_NAME = 'cpu'
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
+    return ["latencies", "cpu_peak_mem"]
+
+def get_output_subdir(config: TorchBenchModelConfig) -> str:
+    mode = "jit" if config.jit else "eager"
+    subdir = f"{config.test}_{config.name}_{mode}"
+    return subdir
+
+def result_to_output_metrics(metrics: TorchBenchModelMetrics) -> Dict[str, float]:
+    result_metrics = {}
+    if metrics.latencies:
+        latency_metric = "latency"
+        median_latency = numpy.median(metrics.latencies)
+        assert median_latency, f"Run failed for metric {latency_metric}"
+        result_metrics[latency_metric] = median_latency
+    if metrics.cpu_peak_mem:
+        cpu_peak_mem = "cpu_peak_mem"
+        result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
+    return result_metrics
+
+def dump_result_to_json(metrics, output_dir):
+    result = get_output_json(BM_NAME, metrics)
+    dump_output(BM_NAME, result, output_dir)
+
+def validate(candidate: str, choices: List[str]) -> str:
+    """Validate the candidates provided by the user is valid"""
+    assert candidate in choices, f"Specified {candidate}, but not in available list: {choices}."
+    return candidate
+
+def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
+    """This function only handles NotImplementedError, all other errors will fail."""
+    metrics = get_metrics(config)
+    print(f"Running {config} ...", end='')
+    if dryrun:
+        return None
+    # We do not allow RuntimeError in this test
+    try:
+        # load the model instance within the same process
+        model = load_model_isolated(config)
+        # get the model test metrics
+        result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
+    except NotImplementedError as e:
+        print(" [NotImplemented]")
+        return None
+    print(" [Done]")
+    return result
+
+def run(args: List[str], extra_args: List[str]):
+    device = validate(args.device, list_devices())
+    test = validate(args.test, list_tests())
+    model = validate(args.model, list_models())
+    config = TorchBenchModelConfig(
+        name=model,
+        device=device,
+        test=test,
+        batch_size=args.batch_size,
+        jit=args.jit,
+        extra_args=extra_args,
+        extra_env=None)
+    try:
+        metrics = run_config(config, dryrun=args.dryrun)
+    except KeyboardInterrupt:
+        print("User keyboard interrupted!")
+    if not args.dryrun:
+        target_dir = Path(args.output).joinpath(get_output_subdir(config))
+        target_dir.mkdir(exist_ok=True, parents=True)
+        metrics_dict = result_to_output_metrics(metrics)
+        dump_result_to_json(metrics_dict, target_dir)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", "-d", default="cpu", help="Devices to run.")
+    parser.add_argument("--test", "-t", default="eval", help="Tests to run.")
+    parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice model.")
+    parser.add_argument("--batch-size", "-b", default=None, type=int, help="Run the specifice batch size.")
+    parser.add_argument("--jit", action="store_true", help="Convert the models to jit mode.")
+    parser.add_argument("--output", "-o", default=None, help="Output dir.")
+    parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
+    args, extra_args = parser.parse_known_args()
+    run(args, extra_args)

--- a/userbenchmark/cpu/run_config.py
+++ b/userbenchmark/cpu/run_config.py
@@ -15,7 +15,7 @@ sys.path.append(REPO_DIR)
 
 from utils import add_path
 with add_path(REPO_DIR):
-    from userbenchmark.cpu.cpu_utils import REPO_PATH, get_output_json, dump_output
+    from userbenchmark.cpu.cpu_utils import REPO_PATH, get_output_dir, get_output_json, dump_output
     from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
                                                             list_devices, list_tests
     from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
@@ -87,6 +87,7 @@ def run(args: List[str], extra_args: List[str]):
     except KeyboardInterrupt:
         print("User keyboard interrupted!")
     if not args.dryrun:
+        args.output = args.output if args.output else get_output_dir(BM_NAME)
         target_dir = Path(args.output).joinpath(get_output_subdir(config))
         target_dir.mkdir(exist_ok=True, parents=True)
         metrics_dict = result_to_output_metrics(metrics)

--- a/userbenchmark/cpu/run_config.py
+++ b/userbenchmark/cpu/run_config.py
@@ -4,103 +4,98 @@ Run PyTorch cpu benchmarking.
 """
 import argparse
 import os
-import sys
 import numpy
 
-from typing import List, Tuple, Dict, Optional
+from typing import List, Dict, Optional
 from pathlib import Path
 
-REPO_DIR = str(Path(__file__).parent.parent.parent.resolve())
-sys.path.append(REPO_DIR)
-
-from utils import add_path
-with add_path(REPO_DIR):
-    from userbenchmark.cpu.cpu_utils import REPO_PATH, get_output_dir, get_output_json, dump_output
-    from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
-                                                            list_devices, list_tests
+from cpu_utils import add_path, REPO_PATH, get_output_dir, get_output_json, dump_output
+with add_path(str(REPO_PATH)):
+    from torchbenchmark.util.experiment.instantiator import (list_models, load_model_isolated, TorchBenchModelConfig,
+                                                            list_devices, list_tests)
     from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
 
-BM_NAME = 'cpu'
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+    BM_NAME = 'cpu'
+    CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
-def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
-    return ["latencies", "cpu_peak_mem"]
+    def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
+        return ["latencies", "cpu_peak_mem"]
 
-def get_output_subdir(config: TorchBenchModelConfig) -> str:
-    mode = "jit" if config.jit else "eager"
-    subdir = f"{config.test}_{config.name}_{mode}"
-    return subdir
+    def get_output_subdir(config: TorchBenchModelConfig) -> str:
+        mode = "jit" if config.jit else "eager"
+        subdir = f"{config.test}_{config.name}_{mode}"
+        return subdir
 
-def result_to_output_metrics(metrics: TorchBenchModelMetrics) -> Dict[str, float]:
-    result_metrics = {}
-    if metrics.latencies:
-        latency_metric = "latency"
-        median_latency = numpy.median(metrics.latencies)
-        assert median_latency, f"Run failed for metric {latency_metric}"
-        result_metrics[latency_metric] = median_latency
-    if metrics.cpu_peak_mem:
-        cpu_peak_mem = "cpu_peak_mem"
-        result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
-    return result_metrics
+    def result_to_output_metrics(metrics: TorchBenchModelMetrics) -> Dict[str, float]:
+        result_metrics = {}
+        if metrics.latencies:
+            latency_metric = "latency"
+            median_latency = numpy.median(metrics.latencies)
+            assert median_latency, f"Run failed for metric {latency_metric}"
+            result_metrics[latency_metric] = median_latency
+        if metrics.cpu_peak_mem:
+            cpu_peak_mem = "cpu_peak_mem"
+            result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
+        return result_metrics
 
-def dump_result_to_json(metrics, output_dir):
-    result = get_output_json(BM_NAME, metrics)
-    dump_output(BM_NAME, result, output_dir)
+    def dump_result_to_json(metrics, output_dir):
+        result = get_output_json(BM_NAME, metrics)
+        dump_output(BM_NAME, result, output_dir)
 
-def validate(candidate: str, choices: List[str]) -> str:
-    """Validate the candidates provided by the user is valid"""
-    assert candidate in choices, f"Specified {candidate}, but not in available list: {choices}."
-    return candidate
+    def validate(candidate: str, choices: List[str]) -> str:
+        """Validate the candidates provided by the user is valid"""
+        assert candidate in choices, f"Specified {candidate}, but not in available list: {choices}."
+        return candidate
 
-def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
-    """This function only handles NotImplementedError, all other errors will fail."""
-    metrics = get_metrics(config)
-    print(f"Running {config} ...", end='')
-    if dryrun:
-        return None
-    # We do not allow RuntimeError in this test
-    try:
-        # load the model instance within the same process
-        model = load_model_isolated(config)
-        # get the model test metrics
-        result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
-    except NotImplementedError as e:
-        print(" [NotImplemented]")
-        return None
-    print(" [Done]")
-    return result
+    def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
+        """This function only handles NotImplementedError, all other errors will fail."""
+        metrics = get_metrics(config)
+        print(f"Running {config} ...", end='')
+        if dryrun:
+            return None
+        # We do not allow RuntimeError in this test
+        try:
+            # load the model instance within separate subprocess
+            model = load_model_isolated(config)
+            # get the model test metrics
+            result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
+        except NotImplementedError as e:
+            print(" [NotImplemented]")
+            return None
+        print(" [Done]")
+        return result
 
-def run(args: List[str], extra_args: List[str]):
-    device = validate(args.device, list_devices())
-    test = validate(args.test, list_tests())
-    model = validate(args.model, list_models())
-    config = TorchBenchModelConfig(
-        name=model,
-        device=device,
-        test=test,
-        batch_size=args.batch_size,
-        jit=args.jit,
-        extra_args=extra_args,
-        extra_env=None)
-    try:
-        metrics = run_config(config, dryrun=args.dryrun)
-    except KeyboardInterrupt:
-        print("User keyboard interrupted!")
-    if not args.dryrun:
-        args.output = args.output if args.output else get_output_dir(BM_NAME)
-        target_dir = Path(args.output).joinpath(get_output_subdir(config))
-        target_dir.mkdir(exist_ok=True, parents=True)
-        metrics_dict = result_to_output_metrics(metrics)
-        dump_result_to_json(metrics_dict, target_dir)
+    def run(args: List[str], extra_args: List[str]):
+        device = validate(args.device, list_devices())
+        test = validate(args.test, list_tests())
+        model = validate(args.model, list_models())
+        config = TorchBenchModelConfig(
+            name=model,
+            device=device,
+            test=test,
+            batch_size=args.batch_size,
+            jit=args.jit,
+            extra_args=extra_args,
+            extra_env=None)
+        try:
+            metrics = run_config(config, dryrun=args.dryrun)
+        except KeyboardInterrupt:
+            print("User keyboard interrupted!")
+        if not args.dryrun:
+            args.output = args.output if args.output else get_output_dir(BM_NAME)
+            target_dir = Path(args.output).joinpath(get_output_subdir(config))
+            target_dir.mkdir(exist_ok=True, parents=True)
+            metrics_dict = result_to_output_metrics(metrics)
+            dump_result_to_json(metrics_dict, target_dir)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--device", "-d", default="cpu", help="Devices to run.")
-    parser.add_argument("--test", "-t", default="eval", help="Tests to run.")
-    parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice model.")
-    parser.add_argument("--batch-size", "-b", default=None, type=int, help="Run the specifice batch size.")
-    parser.add_argument("--jit", action="store_true", help="Convert the models to jit mode.")
-    parser.add_argument("--output", "-o", default=None, help="Output dir.")
-    parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
-    args, extra_args = parser.parse_known_args()
-    run(args, extra_args)
+    if __name__ == "__main__":
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--device", "-d", default="cpu", help="Devices to run.")
+        parser.add_argument("--test", "-t", default="eval", help="Tests to run.")
+        parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice model.")
+        parser.add_argument("--batch-size", "-b", default=None, type=int, help="Run the specifice batch size.")
+        parser.add_argument("--jit", action="store_true", help="Convert the models to jit mode.")
+        parser.add_argument("--output", "-o", default=None, help="Output dir.")
+        parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
+        args, extra_args = parser.parse_known_args()
+        run(args, extra_args)


### PR DESCRIPTION
Add initial cpu userbenchmark for torchbench

Works for Roadmap #1293 for cpu userbenchmark extend with below functions.

- [x] Add core binding option, support multi-instances test.
- [x] Add gomp/iomp option.
- [x] Add memory allocator option.
- [x] Support all enabled cpu features test based on torchbench models, e.g. channels-last / fx_int8 / jit with fusers 
- [x] Support latency and cpu_peak_mem metrics for now, will extend to fps-like report
- [x] Add `README.md`

For example, in below cml, we tested 2 models fx_int8 inference with batch size 8 on CLX socket 0 and 4 instances at the same time.
```shell
$ python run_benchmark.py cpu --model resnet50,alexnet --test eval -b 8 --precision fx_int8 --launcher --launcher-args "--node-id 0 --ninstances 4"
Running benchmark: ['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '-m', 'torch.backends.xeon.run_cpu', '--node-id', '0', '--ninstances', '4', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'resnet50', '--device', 'cpu', '-b', '8', '-t', 'eval', '-o', PosixPath('/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336')]
2023-04-20 00:43:37,960 - __main__ - INFO - Use JeMalloc memory allocator
2023-04-20 00:43:37,960 - __main__ - INFO - OMP_NUM_THREADS=7
2023-04-20 00:43:37,960 - __main__ - INFO - Using Intel OpenMP
2023-04-20 00:43:37,960 - __main__ - INFO - KMP_AFFINITY=granularity=fine,compact,1,0
2023-04-20 00:43:37,960 - __main__ - INFO - KMP_BLOCKTIME=1
2023-04-20 00:43:37,960 - __main__ - INFO - LD_PRELOAD=/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libiomp5.so:/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libjemalloc.so
2023-04-20 00:43:37,960 - __main__ - INFO - numactl -C 0-6 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:37,960 - __main__ - INFO - numactl -C 7-13 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:37,960 - __main__ - INFO - numactl -C 14-20 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:37,960 - __main__ - INFO - numactl -C 21-27 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ... [Done]
 [Done]
 [Done]
 [Done]
Running benchmark: ['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '-m', 'torch.backends.xeon.run_cpu', '--node-id', '0', '--ninstances', '4', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'alexnet', '--device', 'cpu', '-b', '8', '-t', 'eval', '-o', PosixPath('/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336')]
2023-04-20 00:43:53,444 - __main__ - INFO - Use JeMalloc memory allocator
2023-04-20 00:43:53,444 - __main__ - INFO - OMP_NUM_THREADS=7
2023-04-20 00:43:53,444 - __main__ - INFO - Using Intel OpenMP
2023-04-20 00:43:53,444 - __main__ - INFO - KMP_AFFINITY=granularity=fine,compact,1,0
2023-04-20 00:43:53,444 - __main__ - INFO - KMP_BLOCKTIME=1
2023-04-20 00:43:53,444 - __main__ - INFO - LD_PRELOAD=/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libiomp5.so:/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libjemalloc.so
2023-04-20 00:43:53,445 - __main__ - INFO - numactl -C 0-6 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m alexnet --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:53,445 - __main__ - INFO - numactl -C 7-13 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m alexnet --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:53,445 - __main__ - INFO - numactl -C 14-20 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m alexnet --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
2023-04-20 00:43:53,445 - __main__ - INFO - numactl -C 21-27 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m alexnet --device cpu -b 8 -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230420004336
Running TorchBenchModelConfig(name='alexnet', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='alexnet', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='alexnet', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='alexnet', device='cpu', test='eval', batch_size=8, jit=False, extra_args=[], extra_env=None) ... [Done]
 [Done]
 [Done]
 [Done]
```
We can find the test results in `.userbenchmark/cpu/cpu-20230420004336`, `cpu` userbenchmark will create a subfolder for each test, and aggregate all test results into `metrics-20230420004336.json`. For each sub-folder, it contains instances logs named with instance PID for that model test.  
```shell
$ ls .userbenchmark/cpu/cpu-20230420004336
eval_alexnet_eager/  eval_resnet50_eager/  
$ ls .userbenchmark/cpu/cpu-20230420004336/eval_alexnet_eager/
metrics-3347653.json  metrics-3347654.json  metrics-3347655.json  metrics-3347656.json
$ cat .userbenchmark/cpu/metrics-20230420004336.json 
{
    "name": "cpu",
    "environ": {
        "pytorch_git_version": "de1114554c38322273c066c091d455519d45472d"
    },
    "metrics": {
        "alexnet-eval-eager_latency": 58.309660750000006,
        "alexnet-eval-eager_cmem": 0.416259765625,
        "resnet50-eval-eager_latency": 335.04970325,
        "resnet50-eval-eager_cmem": 0.90673828125
    }
}
```