### PR TITLE
[optim] Check for errors.txt in the right dir and always run

### DIFF
--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -102,9 +102,11 @@ jobs:
           name: TorchBench result
           path: benchmark-output/
       - name: Finally, error if errors.txt exists
+        if: always()
         run: |
           # Do not error earlier as we want all artifacts and regressions to be reported first
           # TODO: potentially move errors.txt to benchmark-output so it gets uploaded to S3
+          pushd benchmark
           if [ -e errors.txt ]; then cat errors.txt && exit 1; fi
       - name: Remove conda environment
         if: always()


### PR DESCRIPTION
Forgot the classic line of moving into benchmark to check for errors.txt, since everything else is also run in benchmark.

Also adds the "always" so that even if prior things fail, we can see if errors.txt had anything.