### PR TITLE
Add new GPU arch supports for FMA count

### DIFF
--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -132,6 +132,7 @@ def ConvertSMVer2Cores(major, minor):
             (8, 0): 64,   # Ampere
             (8, 6): 128,
             (8, 7): 128,
+            (8, 9): 128,  # Ada
             (9, 0): 128,  # Hopper
             }.get((major, minor), 0)
 

--- a/components/model_analyzer/tb_dcgm_types/gpu_device.py
+++ b/components/model_analyzer/tb_dcgm_types/gpu_device.py
@@ -131,6 +131,7 @@ def ConvertSMVer2Cores(major, minor):
             (7, 5): 64,   # Turing
             (8, 0): 64,   # Ampere
             (8, 6): 128,
-            (8, 7): 128
+            (8, 7): 128,
+            (9, 0): 128,  # Hopper
             }.get((major, minor), 0)
 


### PR DESCRIPTION
Function [ConvertSMVer2Cores](https://github.com/pytorch/benchmark/blob/main/components/model_analyzer/tb_dcgm_types/gpu_device.py#L114) will return the # of FMA units of asked arch. It needs to be synced with the upstream [`_ConvertSMVer2Cores`](https://github.com/NVIDIA/cuda-samples/blob/master/Common/helper_cuda.h) file. 

This PR adds the supports for SM 8.7(Ada) SM 9.0(H100).