### PR TITLE
Fix the batch size for maml_omniglot and speech_transformer

### DIFF
--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -45,8 +45,8 @@ class Model(BenchmarkModel):
     # K-shot means that each task only sees K data points.
     #
     # We've set the following variables to be equal to the task number.
-    DEFAULT_TRAIN_BSIZE = 32
-    DEFAULT_EVAL_BSIZE = 32
+    DEFAULT_TRAIN_BSIZE = 5
+    DEFAULT_EVAL_BSIZE = 5
     ALLOW_CUSTOMIZE_BSIZE = False
 
     # TODO: There _should_ be a way to plug in an optim here, but this
@@ -77,7 +77,6 @@ class Model(BenchmarkModel):
         root = str(Path(__file__).parent)
         self.meta_inputs = torch.load(f'{root}/batch.pt')
         self.meta_inputs = tuple([torch.from_numpy(i).to(self.device) for i in self.meta_inputs])
-
         self.example_inputs = (self.meta_inputs[0][0],)
 
     def get_module(self):

--- a/torchbenchmark/models/speech_transformer/__init__.py
+++ b/torchbenchmark/models/speech_transformer/__init__.py
@@ -22,9 +22,10 @@ class Model(BenchmarkModel):
     task = SPEECH.RECOGNITION
     # Original batch size: 32
     # Source: https://github.com/kaituoxu/Speech-Transformer/blob/e6847772d6a786336e117a03c48c62ecbf3016f6/src/bin/train.py#L68
-    # This model does not support adjusting eval bs
+    # This model does not support batch size customization
     DEFAULT_TRAIN_BSIZE = 32
     DEFAULT_EVAL_BSIZE = 1
+    ALLOW_CUSTOMIZE_BSIZE = False
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)


### PR DESCRIPTION
The default batch size for maml_omniglot should be the number of tasks, which is 5.

Disable the batch size customization of speech_transformer because of upstream issue.

Fixes https://github.com/pytorch/benchmark/issues/1561 and https://github.com/pytorch/benchmark/issues/1560