### PR TITLE
Support userbenchmarks to inject and replace the `model.invoke()` function

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -336,6 +336,23 @@ class ModelTask(base_task.TaskBase):
         })
 
     # =========================================================================
+    # == Replace the `invoke()` function in `model` instance ==================
+    # =========================================================================
+    @base_task.run_in_worker(scoped=True)
+    @staticmethod
+    def replace_invoke(module_name, func_name) -> None:
+        # import function from pkg
+        model = globals()["model"]
+        try:
+            module = importlib.import_module(module_name)
+            inject_func = getattr(module, func_name, None)
+            if inject_func is None:
+                diagnostic_msg = f"Warning: {module} does not define attribute {func_name}, skip it"
+        except ModuleNotFoundError as e:
+            diagnostic_msg = f"Warning: Could not find dependent module {e.name} for Model {model.name}, skip it"
+        model.invoke = inject_func
+
+    # =========================================================================
     # == Get Model attribute in the child process =============================
     # =========================================================================
     @base_task.run_in_worker(scoped=True)

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -341,6 +341,7 @@ class ModelTask(base_task.TaskBase):
     @base_task.run_in_worker(scoped=True)
     @staticmethod
     def replace_invoke(module_name: str, func_name: str) -> None:
+        import importlib
         # import function from pkg
         model = globals()["model"]
         try:
@@ -350,7 +351,7 @@ class ModelTask(base_task.TaskBase):
                 diagnostic_msg = f"Warning: {module} does not define attribute {func_name}, skip it"
         except ModuleNotFoundError as e:
             diagnostic_msg = f"Warning: Could not find dependent module {e.name} for Model {model.name}, skip it"
-        model.invoke = inject_func
+        model.invoke = inject_func.__get__(model)
 
     # =========================================================================
     # == Get Model attribute in the child process =============================

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -340,7 +340,7 @@ class ModelTask(base_task.TaskBase):
     # =========================================================================
     @base_task.run_in_worker(scoped=True)
     @staticmethod
-    def replace_invoke(module_name, func_name) -> None:
+    def replace_invoke(module_name: str, func_name: str) -> None:
         # import function from pkg
         model = globals()["model"]
         try:

--- a/torchbenchmark/util/experiment/instantiator.py
+++ b/torchbenchmark/util/experiment/instantiator.py
@@ -30,7 +30,7 @@ def _set_extra_env(extra_env):
         os.environ[env_key] = extra_env[env_key]
 
 def inject_model_invoke(model_task: ModelTask, inject_function):
-    model_task.replace_invoke(inject_function.__module__, inject_function.name)
+    model_task.replace_invoke(inject_function.__module__, inject_function.__name__)
 
 def load_model_isolated(config: TorchBenchModelConfig, timeout: float=WORKER_TIMEOUT) -> ModelTask:
     """ Load and return the model in a subprocess. """

--- a/torchbenchmark/util/experiment/instantiator.py
+++ b/torchbenchmark/util/experiment/instantiator.py
@@ -29,6 +29,9 @@ def _set_extra_env(extra_env):
     for env_key in extra_env:
         os.environ[env_key] = extra_env[env_key]
 
+def inject_model_invoke(model_task: ModelTask, inject_function):
+    model_task.replace_invoke(inject_function.__module__, inject_function.name)
+
 def load_model_isolated(config: TorchBenchModelConfig, timeout: float=WORKER_TIMEOUT) -> ModelTask:
     """ Load and return the model in a subprocess. """
     task = ModelTask(config.name, timeout=timeout, extra_env=config.extra_env)

--- a/userbenchmark/test-user-invoke/__init__.py
+++ b/userbenchmark/test-user-invoke/__init__.py
@@ -7,16 +7,20 @@ from ..utils import REPO_PATH, add_path, get_output_json, dump_output
 
 with add_path(REPO_PATH):
     from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
-                                                            list_devices, list_tests
+                                                            list_devices, list_tests, inject_model_invoke
     from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
 
 from typing import Optional
+
+def user_defined_invoke(model):
+    print(f"Model {model.name} invoke has been replaced!")
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", "-d", default="cuda", help="Devices to run, splited by comma.")
     parser.add_argument("--test", "-t", default="eval", help="Tests to run, splited by comma.")
     parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice models, splited by comma.")
+    parser.add_argument("--inject", action="store_true", help="Inject user defined invoke function to the model.")
     return parser.parse_args(args)
 
 def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
@@ -32,6 +36,7 @@ def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[To
     try:
         # load the model instance within the same process
         model = load_model_isolated(config)
+        inject_model_invoke(model, user_defined_invoke)
         # get the model test metrics
         result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
     except NotImplementedError as e:

--- a/userbenchmark/test-user-invoke/__init__.py
+++ b/userbenchmark/test-user-invoke/__init__.py
@@ -1,0 +1,55 @@
+"""
+Test user-customized invoke function.
+"""
+import argparse
+from typing import List
+from ..utils import REPO_PATH, add_path, get_output_json, dump_output
+
+with add_path(REPO_PATH):
+    from torchbenchmark.util.experiment.instantiator import list_models, load_model_isolated, TorchBenchModelConfig, \
+                                                            list_devices, list_tests
+    from torchbenchmark.util.experiment.metrics import TorchBenchModelMetrics, get_model_test_metrics
+
+from typing import Optional
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", "-d", default="cuda", help="Devices to run, splited by comma.")
+    parser.add_argument("--test", "-t", default="eval", help="Tests to run, splited by comma.")
+    parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice models, splited by comma.")
+    return parser.parse_args(args)
+
+def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
+    return ["latencies", "cpu_peak_mem", "gpu_peak_mem"]
+
+def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
+    """This function only handles NotImplementedError, all other errors will fail."""
+    metrics = get_metrics(config)
+    print(f"Running {config} ...", end='')
+    if dryrun:
+        return None
+    # We do not allow RuntimeError in this test
+    try:
+        # load the model instance within the same process
+        model = load_model_isolated(config)
+        # get the model test metrics
+        result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
+    except NotImplementedError as e:
+        print(" [NotImplemented]")
+        return None
+    print(" [Done]")
+    return result
+
+def run(args: List[str]):
+    args = parse_args(args)
+    config = TorchBenchModelConfig(
+        name=args.model,
+        device=args.device,
+        test=args.test,
+        batch_size=None,
+        jit=False,
+        extra_args=[],
+        extra_env=None,
+    )
+    result = run_config(config)
+    print(result)

--- a/userbenchmark/test-user-invoke/__init__.py
+++ b/userbenchmark/test-user-invoke/__init__.py
@@ -14,6 +14,12 @@ from typing import Optional
 
 def user_defined_invoke(self):
     print(f"Model {self.name} invoke has been replaced!")
+    self.output_metrics_list = [1.0, 2.0, 3.0, 4.0]
+    self.output_metrics_dict ={
+        "m1": 1.0,
+        "m2": 2.0,
+        "m3": 3.0,
+    }
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
@@ -34,12 +40,15 @@ def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[To
     if dryrun:
         return None
     # We do not allow RuntimeError in this test
+    result ={}
     try:
         # load the model instance within the same process
         model = load_model_isolated(config)
         inject_model_invoke(model, user_defined_invoke)
         # get the model test metrics
-        result: TorchBenchModelMetrics = get_model_test_metrics(model, metrics=metrics)
+        model.invoke()
+        result["list_result"] = model.get_model_attribute("output_metrics_list")
+        result["dict_output"] = model.get_model_attribute("output_metrics_dict")
     except NotImplementedError as e:
         print(" [NotImplemented]")
         return None

--- a/userbenchmark/test-user-invoke/__init__.py
+++ b/userbenchmark/test-user-invoke/__init__.py
@@ -12,19 +12,20 @@ with add_path(REPO_PATH):
 
 from typing import Optional
 
-def user_defined_invoke(model):
-    print(f"Model {model.name} invoke has been replaced!")
+def user_defined_invoke(self):
+    print(f"Model {self.name} invoke has been replaced!")
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", "-d", default="cuda", help="Devices to run, splited by comma.")
     parser.add_argument("--test", "-t", default="eval", help="Tests to run, splited by comma.")
+    parser.add_argument("--bs", type=int, default=1, help="Test batch size")
     parser.add_argument("--model", "-m", default=None, type=str, help="Only run the specifice models, splited by comma.")
     parser.add_argument("--inject", action="store_true", help="Inject user defined invoke function to the model.")
     return parser.parse_args(args)
 
 def get_metrics(_config: TorchBenchModelConfig) -> List[str]:
-    return ["latencies", "cpu_peak_mem", "gpu_peak_mem"]
+    return ["latencies"]
 
 def run_config(config: TorchBenchModelConfig, dryrun: bool=False) -> Optional[TorchBenchModelMetrics]:
     """This function only handles NotImplementedError, all other errors will fail."""
@@ -51,7 +52,7 @@ def run(args: List[str]):
         name=args.model,
         device=args.device,
         test=args.test,
-        batch_size=None,
+        batch_size=args.bs,
         jit=False,
         extra_args=[],
         extra_env=None,


### PR DESCRIPTION
Support userbenchmarks to use their customized function to replace the original `model.invoke()`.
In the `user_defined_invoke()` function, users can run their own benchmark in subprocess workers, and return list or dict as metrics.
The output can be retrieved with the `get_model_attribute()` function.

Test:
```
$ python run_benchmark.py test-user-invoke -m resnet50 -d cpu -t train

Running TorchBenchModelConfig(name='resnet50', device='cpu', test='train', batch_size=1, jit=False, extra_args=[], extra_env=None) ... [Done]
{'list_result': [1.0, 2.0, 3.0, 4.0], 'dict_output': {'m1': 1.0, 'm2': 2.0, 'm3': 3.0}}
```