### PR TITLE
Add torch.no_grad() to inference tests

### DIFF
--- a/torchbenchmark/models/DALLE2_pytorch/__init__.py
+++ b/torchbenchmark/models/DALLE2_pytorch/__init__.py
@@ -84,7 +84,7 @@ class Model(BenchmarkModel):
 
     def eval(self):
         model, inputs = self.get_module()
-        with torch.inference_mode():
+        with torch.no_grad():
             images = model(*inputs)
         return (images,)
 

--- a/torchbenchmark/util/framework/diffusers/model_factory.py
+++ b/torchbenchmark/util/framework/diffusers/model_factory.py
@@ -32,5 +32,6 @@ class DiffuserModel(BenchmarkModel):
         raise NotImplementedError(f"Train is not implemented for model {self.name}")
 
     def eval(self):
-        images = self.pipe(*self.example_inputs).images
+        with torch.no_grad():
+            images = self.pipe(*self.example_inputs).images
         return images

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -85,8 +85,9 @@ class TorchVisionModel(BenchmarkModel):
             self.g.replay()
 
     def eval(self) -> typing.Tuple[torch.Tensor]:
-        with self.amp_context():
-            return self.model(*self.example_inputs)
+        with torch.no_grad():
+            with self.amp_context():
+                return self.model(*self.example_inputs)
 
     def cudagraph_eval(self):
         for data, target in zip(self.real_input, self.real_output):


### PR DESCRIPTION
Adding the necessary `torch.no_grad()` contexts to inference tests.