### PR TITLE
Fix the broken CI by disabling warmup by default

### DIFF
--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -151,7 +151,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                     self.set_optimizer(current_optimizer)
         # apply decoration args
         apply_decoration_args(self, self.dargs)
-        eager_latency = warmup(self)
+        if should_check_correctness:
+            eager_latency = warmup(self)
         # apply optimization args
         if self.dynamo:
             from torchbenchmark.util.backends.torchdynamo import apply_torchdynamo_args


### PR DESCRIPTION
We should not run warmup rounds to get eager latency when eager mode is already used.
However, in non-eager mode, we need to do the following:
1. Run correctness rounds with fp32 precision to get accurate eager output
2. Run warmup rounds with default precision to get accurate eager latency
3. Run dynamo rounds to get the correctness result

Note that the warmup rounds here are different from the warmup iterations in `run.py`. Here, we use a few warmup rounds to approximate eager latency, which is later used to calculate PT2 compilation time. In `run.py`, we run warmup rounds for performance testing.

Fix https://github.com/pytorch/benchmark/issues/1581