### PR TITLE
[optim][ub] Skip most pt2 forloop impls, add option to ignore skips

### DIFF
--- a/userbenchmark/optim/__init__.py
+++ b/userbenchmark/optim/__init__.py
@@ -19,6 +19,7 @@ BM_NAME: str = 'optim'
 
 continue_on_error: bool = False
 run_on_subset: bool = False
+ignore_skips: bool = False
 
 MODEL_NAMES: List[str] = list_models()
 SUBSET_OF_MODEL_NAMES: List[str] = [
@@ -207,6 +208,32 @@ EXCLUSIONS: List[Dict[str, Any]] = [
     # SparseAdam does not support dense gradients
     {'optim': 'SparseAdam', 'model': m} for m in DENSE_MODELS
 ] + [
+    # DALL-E 2, timm_efficientdet, tacotron2 Not Supported on CPU
+    {'model': 'DALLE2_pytorch', 'device': 'cpu'},
+    {'model': 'tacotron2', 'device': 'cpu'},
+    {'model': 'timm_efficientdet', 'device': 'cpu'},
+    # FCOS train is not supported by upstream detectron2.
+    # See GH issue: https://github.com/facebookresearch/detectron2/issues/4369.
+    {'model': 'detectron2_fcos_r_50_fpn'},
+    # moco uses DDP and DistributedDataParallel/allgather requires cuda
+    {'model': 'moco', 'device': 'cpu'},
+    # pyhpc_equation_of_state and pyhpc_isoneutral_mixing have no parameters
+    {'model': 'pyhpc_equation_of_state'},
+    {'model': 'pyhpc_isoneutral_mixing'},
+    {'model': 'pyhpc_turbulent_kinetic_energy'},
+    # fused/capturable requires params to be floats on CUDA
+    {'defaults': ['fused'], 'device': 'cpu'},
+    {'defaults': ['capturable'], 'device': 'cpu'},
+] + [
+    # PT2 dynamo tracing for the for-loop implementation takes over 30s.
+    # This is known + not going to be improved anytime soon, see
+    # https://github.com/pytorch/torchdynamo/issues/1803#issuecomment-1336688894
+    # Run PT2 on for-loop implementations for only the subset of models. Skip everything else.
+    {'model': m, 'device': d, 'func_str': 'pt2_', 'defaults': [df]}
+    for d in DEVICES
+    for m in set(MODEL_NAMES) - set(SUBSET_OF_MODEL_NAMES)
+    for df in ['no_foreach', 'differentiable'] + ([] if d == 'cuda' else ['default', 'maximize', 'amsgrad, maximize'])
+] + [
     # torch.compile()'d optimizer.step() has too many arguments in C++
     # See GH issue: https://github.com/pytorch/pytorch/issues/97361
     {'model': m, 'device': 'cpu', 'func_str': 'pt2_', 'defaults': []} for m in [
@@ -243,24 +270,7 @@ EXCLUSIONS: List[Dict[str, Any]] = [
        'densenet121', 'fambench_xlmr', 'hf_Bart', 'hf_Bert_large', 'hf_GPT2_large', 'hf_Longformer',
        'hf_T5_base', 'hf_T5_large', 'moco'
     ] for df in ['no_foreach', 'differentiable']
-] + [
-    # DALL-E 2, timm_efficientdet, tacotron2 Not Supported on CPU
-    {'model': 'DALLE2_pytorch', 'device': 'cpu'},
-    {'model': 'tacotron2', 'device': 'cpu'},
-    {'model': 'timm_efficientdet', 'device': 'cpu'},
-    # FCOS train is not supported by upstream detectron2.
-    # See GH issue: https://github.com/facebookresearch/detectron2/issues/4369.
-    {'model': 'detectron2_fcos_r_50_fpn'},
-    # moco uses DDP and DistributedDataParallel/allgather requires cuda
-    {'model': 'moco', 'device': 'cpu'},
-    # pyhpc_equation_of_state and pyhpc_isoneutral_mixing have no parameters
-    {'model': 'pyhpc_equation_of_state'},
-    {'model': 'pyhpc_isoneutral_mixing'},
-    {'model': 'pyhpc_turbulent_kinetic_energy'},
-    # fused/capturable requires params to be floats on CUDA
-    {'defaults': ['fused'], 'device': 'cpu'},
-    {'defaults': ['capturable'], 'device': 'cpu'},
-] 
+]
 
 # Returns clones of params and not a generator.
 def _get_model_params(m) -> List[torch.nn.Parameter]:
@@ -373,7 +383,7 @@ def run_benchmarks(optims: List[str], func_strs: List[str], models: List[str], d
         optim_cfgs = [(O, defaults) for (O, defaults) in optim_cfgs if (all([x in ['foreach', 'fused', 'lr'] for x in defaults]))]
     
     for mn, d, (O, defaults), func_str in itertools.product(models, devices, optim_cfgs, func_strs):
-        if (is_excluded(mn, d, O.__name__, func_str, defaults)):
+        if (not ignore_skips and is_excluded(mn, d, O.__name__, func_str, defaults)):
             continue
         bm = run_model(mn, d, O, defaults, func_str)
         if bm is not None:
@@ -437,6 +447,12 @@ def parse_args(args: List[str]):
         help='name of directory path in which to dump the metrics json, e.g., "./.userbenchmark/optim/tmp". ' +
              'If None, we will dump output the metrics json to "REPO_ROOT/.userbenchmark/optim".'
     )
+    parser.add_argument(
+        '--ignore-skips', '-i', action='store_true',
+        help='Runs ALL benchmarks ignoring any skips. This allows for easy testing of current skipped ' +
+             'benchmarks once one believes they should be fixed. Beware though! You may run into errors ' +
+             'that were previously hidden by the exclusions.'
+    )
     args = parser.parse_args(args)
     return args
 
@@ -450,9 +466,10 @@ def get_metrics(results: List[torch.utils.benchmark.utils.common.Measurement]) -
 
 def run(args: List[str]):
     args = parse_args(args)
-    global continue_on_error, run_on_subset
+    global continue_on_error, run_on_subset, ignore_skips
     continue_on_error = args.continue_on_error
     run_on_subset = args.subset
+    ignore_skips = args.ignore_skips
     target_dir = Path(args.output_dir) if args.output_dir is not None else None
     target_dir.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
1. The working benchmarks are now taking very long to run. I've rootcaused it as the dynamo tracing part of for-loop optimizers, which are known to be slow (see the comment). Thus, we should not waste resources => let's skip most of them! Now, we will run pt2 on only our designated subset of models (defined by SUBSET_OF_MODELS)
2. Since we now have many exclusions and @mlazos may want to start unskipping certain things, I've added an overall option to ignore all skips. This way, one does not have to parse the skips and remove the relevant exclusion to run a certain config.

Lastly, reorder skips so that the most likely to be hit ones are first (though this probably is negligible for perf).