### PR TITLE
Add regression detection steps for torch-nightly

### DIFF
--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -65,6 +65,27 @@ jobs:
           if [ -d .userbenchmark ]; then rm -Rf .userbenchmark; fi
           python run_benchmark.py torch-nightly -c v3-cuda-tests.yaml
           cp -r ./.userbenchmark/torch-nightly ../benchmark-output
+      - name: Detect potential regressions
+        continue-on-error: true
+        run: |
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          pushd benchmark
+          RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
+          # TODO: the following assumes only one metrics-*.json is found. It will keep
+          # overwriting gh-issue.md if multiple are found.
+          for r in ${RESULTS[@]}; do
+            python regression_detector.py --platform "${PLATFORM_NAME}" --treatment "${r}" --owner @xuzhao9 \
+            --gh-issue-path gh-issue.md --errors-path errors.txt
+          done
+      - name: Create the github issue
+        continue-on-error: true
+        if: env.TORCHBENCH_REGRESSION_DETECTED
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: V2 Performance Signal Detected by TorchBench Userbenchmark "torch-nightly" on ${{ env.TORCHBENCH_REGRESSION_DETECTED }}
+          content-filepath: ./benchmark/gh-issue.md
+          labels: |
+            torchbench-perf-report
       - name: Copy artifact and upload to scribe and Amazon S3
         run: |
           . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -82,7 +82,7 @@ jobs:
         if: env.TORCHBENCH_REGRESSION_DETECTED
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: V2 Performance Signal Detected by TorchBench Userbenchmark "torch-nightly" on ${{ env.TORCHBENCH_REGRESSION_DETECTED }}
+          title: V3 Performance Signal Detected by TorchBench Userbenchmark "torch-nightly" on ${{ env.TORCHBENCH_REGRESSION_DETECTED }}
           content-filepath: ./benchmark/gh-issue.md
           labels: |
             torchbench-perf-report

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -45,6 +45,7 @@ def call_userbenchmark_detector(detector, start_file: str, end_file: str) -> Opt
     return detector(start_file, end_file)
 
 def get_default_output_path(bm_name: str) -> str:
+    # By default, write result to $REPO_DIR/.userbenchmark/<userbenchmark-name>/regression-<time>.json
     output_path = os.path.join(REPO_PATH, USERBENCHMARK_OUTPUT_PREFIX, bm_name)
     fname = "regression-{}.yaml".format(datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S"))
     return os.path.join(output_path, fname)
@@ -84,7 +85,6 @@ def generate_regression_dict(control, treatment) -> Dict[Any, Any]:
     return result_dict if result_dict else {}
     
 def process_regressions_into_yaml(regressions_dict, output_path: str, control_file: str, treatment_file: str) -> None:
-    # Write result to $REPO_DIR/.userbenchmark/<userbenchmark-name>/regression-<time>.json
     if regressions_dict == {}:
         print(f"No performance signal detected between file {control_file} and {treatment_file}.")
         return

--- a/userbenchmark/torch-nightly/regression_detector.py
+++ b/userbenchmark/torch-nightly/regression_detector.py
@@ -1,17 +1,20 @@
 from typing import Optional
 from ..utils import TorchBenchABTestResult, TorchBenchABTestMetric
 
+DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.07
+
 def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     control_env = control["environ"]
     treatment_env = treatment["environ"]
     control_metrics = control["metrics"]
-    treatment_metrics = control["metrics"]
+    treatment_metrics = treatment["metrics"]
     details = {}
     for metric_names in control_metrics.keys():
         control_metric = control_metrics[metric_names]
         treatment_metric = treatment_metrics[metric_names]
         delta = (treatment_metric - control_metric) / control_metric
-        details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
+        if delta > DEFAULT_REGRESSION_DELTA_THRESHOLD:
+            details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
     return TorchBenchABTestResult(control_env=control_env, \
                                   treatment_env=treatment_env, \
                                   details=details, \


### PR DESCRIPTION
Add regression detection feature to the torch-nightly userbenchmark.

The next step will be adding bisection.