### PR TITLE
Skip installing pytorch nightly.

### DIFF
--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"
           conda activate "${CONDA_ENV}"
+          pip uninstall -y dill pyarrow
           python install.py
       - name: Validate benchmark components (Worker)
         run: |

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  CONDA_ENV: "pr-test"
+  CONDA_ENV: "torchbench"
   SETUP_INSTANCE_SCRIPT: "/workspace/setup_instance.sh"
 
 jobs:
@@ -20,22 +20,9 @@ jobs:
       - name: GPU Tuning
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"
-          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -pm 1
-          sudo LD_LIBRARY_PATH=/usr/local/nvidia/lib64:$LD_LIBRARY_PATH nvidia-smi -ac 1215,1410
+          sudo nvidia-smi -pm 1
+          sudo nvidia-smi -ac 1215,1410
           nvidia-smi
-      - name: Setup Conda Env
-        run: |
-          . "${SETUP_INSTANCE_SCRIPT}"
-          python utils/python_utils.py --create-conda-env "${CONDA_ENV}"
-          conda activate "${CONDA_ENV}"
-          sudo python utils/cuda_utils.py --setup-cuda-softlink
-          python utils/cuda_utils.py --install-torch-deps
-      - name: Install PyTorch nightly
-        run: |
-          . "${SETUP_INSTANCE_SCRIPT}"
-          conda activate "${CONDA_ENV}"
-          python utils/cuda_utils.py --install-torch-nightly
-          python utils/cuda_utils.py --check-torch-nightly-version
       - name: Install TorchBench
         run: |
           . "${SETUP_INSTANCE_SCRIPT}"

--- a/torchbenchmark/models/DALLE2_pytorch/install.py
+++ b/torchbenchmark/models/DALLE2_pytorch/install.py
@@ -14,6 +14,12 @@ def patch_dalle2():
 
 def pip_install_requirements():
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+    # DALLE2_pytorch requires embedding-reader
+    # https://github.com/lucidrains/DALLE2-pytorch/blob/00e07b7d61e21447d55e6d06d5c928cf8b67601d/setup.py#L34
+    # embedding-reader requires an old version of pandas and pyarrow
+    # https://github.com/rom1504/embedding-reader/blob/a4fd55830a502685600ed8ef07947cd1cb92b083/requirements.txt#L5
+    # So we need to reinstall a newer version of pandas and pyarrow, to be compatible with other models
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-U', 'pandas', 'pyarrow'])
 
 if __name__ == '__main__':
     pip_install_requirements()

--- a/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
+++ b/torchbenchmark/models/attention_is_all_you_need_pytorch/requirements.txt
@@ -1,4 +1,4 @@
-dill==0.3.5.1
+dill
 tqdm
 iopath
 numpy


### PR DESCRIPTION
After we deploy the torchbench nightly docker, we do not need to install pytorch nightly.

Docker packages are available at: https://github.com/orgs/pytorch/packages/container/package/torchbench