### PR TITLE
Detect regression based on dates

### DIFF
--- a/regression_detector.py
+++ b/regression_detector.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
         assert args.name, f"To detect regression with S3, you must specify a userbenchmark name."
         userbenchmark_name = args.name
         end_date = datetime.strptime(args.end_date, "%Y-%m-%d")
-    available_metrics_jsons = get_latest_jsons_in_s3_from_last_n_days(7, userbenchmark_name, args.platform, end_date)
+    available_metrics_jsons = get_latest_jsons_in_s3_from_last_n_days(userbenchmark_name, args.platform, end_date, ndays=7)
     # Download control from S3
     if len(available_metrics_jsons) == 0:
         raise RuntimeWarning(f"No previous JSONS in a week found to compare towards the end date {end_date}. No regression info has been generated.")

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -176,6 +176,7 @@ def get_metrics_by_date(latest_metrics_jsons: List[str], pick_date: datetime):
         # Use the latest metric file on on the same day
         if metric_datetime.date() == pick_date.date():
             pick_metrics_json_key = metrics_json_key
+            break
     assert pick_metrics_json_key, f"Selected date {pick_date} is not found in the latest_metrics_jsons: {latest_metrics_jsons}"
     s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
     metrics_json = s3.get_file_as_json(pick_metrics_json_key)

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -159,7 +159,7 @@ def process_regressions_into_gh_issue(regressions_dict, owner: str, output_path:
         f.write(issue_body)
 
 
-def get_best_start_date(latest_metrics_jsons, end_date: str) -> Optional[datetime.datetime]:
+def get_best_start_date(latest_metrics_jsons, end_date: str) -> Optional[datetime]:
     """Get the date closest to `end_date` from `latest_metrics_jsons`"""
     end_datetime = datetime.strptime("%Y-%m-%d", end_date)
     for metrics_json in latest_metrics_jsons:
@@ -169,7 +169,7 @@ def get_best_start_date(latest_metrics_jsons, end_date: str) -> Optional[datetim
     return None
 
 
-def get_metrics_by_date(latest_metrics_jsons: List[str], pick_date: datetime.datetime):
+def get_metrics_by_date(latest_metrics_jsons: List[str], pick_date: datetime):
     pick_metrics_json_key: Optional[str] = None
     for metrics_json in latest_metrics_jsons:
         metric_datetime = datetime.strptime(metrics_json.split('/')[-1].split('-')[-1].split('.')[0],
@@ -226,7 +226,7 @@ if __name__ == "__main__":
     if not args.control and args.treatment:
         json_path = Path(args.treatment)
         assert json_path.exists(), f"Specified result json path {args.treatment} does not exist."
-        end_date: datetime.datetime = datetime.strptime(get_date_from_metrics(json_path.stem), "%Y-%m-%d")
+        end_date: datetime = datetime.strptime(get_date_from_metrics(json_path.stem), "%Y-%m-%d")
         userbenchmark_name: str = get_ub_name(args.treatment)
         with open(json_path, "r") as cfptr:
             treatment = json.load(cfptr)

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -131,10 +131,11 @@ def process_regressions_into_gh_issue(regressions_dict, owner: str, output_path:
         print(f"No regressions found between {control_commit} and {treatment_commit}.")
         return
 
-    fname = os.environ["GITHUB_ENV"]
-    content = f"TORCHBENCH_REGRESSION_DETECTED='{treatment_commit}'\n"
-    with open(fname, 'a') as fo:
-        fo.write(content)
+    if "GITHUB_ENV" in os.environ:
+        fname = os.environ["GITHUB_ENV"]
+        content = f"TORCHBENCH_REGRESSION_DETECTED='{treatment_commit}'\n"
+        with open(fname, 'a') as fo:
+            fo.write(content)
 
     github_run_id = os.environ.get("GITHUB_RUN_ID", None)
     github_run_url = "No URL found, please look for the failing action in " + \

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -177,9 +177,8 @@ def get_metrics_by_date(latest_metrics_jsons: List[str], pick_date: datetime):
             pick_metrics_json_key = metrics_json_key
     assert pick_metrics_json_key, f"Selected date {pick_date} is not found in the latest_metrics_jsons: {latest_metrics_jsons}"
     s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
-    metrics_json_file = s3.get_file_as_json(pick_metrics_json_key)
-    with open(metrics_json_file, "r") as metrics_fp:
-        return json.load(metrics_fp)
+    metrics_json = s3.get_file_as_json(pick_metrics_json_key)
+    return metrics_json
 
 
 if __name__ == "__main__":

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -40,6 +40,7 @@ GitHub workflow that triggered this issue: {github_run_url}
 cc {owner}
 """
 
+DEFAULT_GH_ISSUE_OWNER = "@xuzhao9"
 
 def call_userbenchmark_detector(detector, start_file: str, end_file: str) -> Optional[TorchBenchABTestResult]:
     return detector(start_file, end_file)
@@ -158,6 +159,18 @@ def process_regressions_into_gh_issue(regressions_dict, owner: str, output_path:
         f.write(issue_body)
 
 
+def get_best_start_date(latest_metrics_jsons, end_date: str):
+    """Get the date closest to `end_date` from `latest_metrics_jsons`"""
+    pass
+
+
+def get_metrics_by_date(date_str: str):
+    s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
+    metrics_json_file = s3.get_file_as_json(latest_metrics_jsons[date_str])
+    with open(metrics_json_file, "r") as metrics_fp:
+        return json.load(metrics_fp)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # Local metrics file comparison
@@ -180,6 +193,7 @@ if __name__ == "__main__":
                              "Its existence ONLY is used to detect whether runtime regressions occurred.")
     args = parser.parse_args()
 
+    # User provided both control and treatment files
     if args.control and args.treatment:
         with open(args.control, "r") as cfptr:
             control = json.load(cfptr)
@@ -188,30 +202,40 @@ if __name__ == "__main__":
         output_path = args.output if args.output else get_default_output_path(control["name"])
         regressions_dict = generate_regression_dict(control, treatment)
         process_regressions_into_yaml(regressions_dict, output_path, args.control, args.treatment)
-    elif not args.control and args.treatment:
-        if not args.platform:
-            raise ValueError("A platform must be specified with the --platform flag to retrieve the "
-                             "previous metrics JSONs as control from S3.")
-        # Download control from S3
+        exit(0)
+
+    # Query S3 to get control and treatment json files
+    if not args.platform:
+        raise ValueError("A platform must be specified with the --platform flag to retrieve the "
+                         "previous metrics JSONs as control from S3.")
+    # User only provide the treatement file, and expect us to download from S3
+    control, treatment = None, None
+    if not args.control and args.treatment:
         json_path = Path(args.treatment)
         assert json_path.exists(), f"Specified result json path {args.treatment} does not exist."
-        date: str = get_date_from_metrics(json_path.stem)
+        end_date: str = get_date_from_metrics(json_path.stem)
         userbenchmark_name: str = get_ub_name(args.treatment)
-        latest_metrics_jsons = get_latest_n_jsons_from_s3(1, userbenchmark_name, args.platform, date)
-
-        if len(latest_metrics_jsons) == 0:
-            raise RuntimeWarning("No previous JSONS found to compare against. No regression info has been generated.")
-
-        s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
-        control = s3.get_file_as_json(latest_metrics_jsons[0])
         with open(json_path, "r") as cfptr:
             treatment = json.load(cfptr)
-        regressions_dict = generate_regression_dict(control, treatment)
-        output_path = args.output if args.output else get_default_output_path(control["name"])
-        process_regressions_into_yaml(regressions_dict, output_path, args.control, args.treatment)
-
-        owner = " ".join(args.owner) if args.owner else "@xuzhao9"
-        process_regressions_into_gh_issue(regressions_dict, owner, args.gh_issue_path, args.errors_path)
     else:
-        # S3 path
-        print("Comparison for metrics from Amazon S3 given a userbenchmark name is WIP.")
+        assert args.name, f"To detect regression with S3, you must specify a userbenchmark name."
+        assert args.end_date and (end_date := datetime.strptime(args.end_date, "%YY%mm%dd")), f"To detect regression with dates, you must specify an end date in format YYmmdd."
+        userbenchmark_name = args.name
+        treatment = None
+    latest_metrics_jsons = get_latest_n_jsons_from_s3(7, userbenchmark_name, args.platform, end_date)
+    # Download control from S3
+    if len(latest_metrics_jsons) == 0:
+        raise RuntimeWarning(f"No previous JSONS in a week found to compare against the end date {end_date}. No regression info has been generated.")
+    start_date = args.start_date if args.start_date else get_best_start_date(latest_metrics_jsons, end_date)
+    if not start_date:
+        raise RuntimeWarning(f"No start date in previous JSONS found to compare against the end date {end_date}. No regression info has been generated.")
+
+    print(f"[TorchBench Regression Detector] Detecting regression of {userbenchmark_name} on platform {args.platform}, start date: {start_date}, end date: {end_date}.")
+    control = get_metrics_by_date(start_date) if not control else control
+    treatment = get_metrics_by_date(end_date) if not treatment else treatment
+    regressions_dict = generate_regression_dict(control, treatment)
+    output_path = args.output if args.output else get_default_output_path(control["name"])
+    process_regressions_into_yaml(regressions_dict, output_path, args.control, args.treatment)
+
+    owner = " ".join(args.owner) if args.owner else DEFAULT_GH_ISSUE_OWNER
+    process_regressions_into_gh_issue(regressions_dict, owner, args.gh_issue_path, args.errors_path)

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -176,7 +176,7 @@ def get_metrics_by_date(latest_metrics_jsons: List[str], pick_date: datetime):
         # Use the latest metric file on on the same day
         if metric_datetime.date() == pick_date.date():
             pick_metrics_json_key = metrics_json_key
-    assert pick_metrics_json_key, f"Selectd date {pick_date} is not found in the latest_metrics_jsons: {latest_metrics_jsons}"
+    assert pick_metrics_json_key, f"Selected date {pick_date} is not found in the latest_metrics_jsons: {latest_metrics_jsons}"
     s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
     metrics_json_file = s3.get_file_as_json(pick_metrics_json_key)
     with open(metrics_json_file, "r") as metrics_fp:
@@ -231,8 +231,8 @@ if __name__ == "__main__":
             treatment = json.load(cfptr)
     else:
         assert args.name, f"To detect regression with S3, you must specify a userbenchmark name."
-        end_date = datetime.strptime(args.end_date, "%Y-%m-%d")
         userbenchmark_name = args.name
+        end_date = datetime.strptime(args.end_date, "%Y-%m-%d")
     available_metrics_jsons = get_latest_n_day_jsons_from_s3(7, userbenchmark_name, args.platform, end_date)
     # Download control from S3
     if len(available_metrics_jsons) == 0:

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from typing import Any, List, Dict, Optional
 from userbenchmark.utils import PLATFORMS, USERBENCHMARK_OUTPUT_PREFIX, REPO_PATH, \
                                 TorchBenchABTestResult, get_date_from_metrics, \
-                                get_ub_name, get_latest_n_day_jsons_from_s3, get_date_from_metrics_s3_key
+                                get_ub_name, get_latest_jsons_in_s3_from_last_n_days, get_date_from_metrics_s3_key
 from utils.s3_utils import S3Client, USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT
 
 GITHUB_ISSUE_TEMPLATE = """
@@ -233,7 +233,7 @@ if __name__ == "__main__":
         assert args.name, f"To detect regression with S3, you must specify a userbenchmark name."
         userbenchmark_name = args.name
         end_date = datetime.strptime(args.end_date, "%Y-%m-%d")
-    available_metrics_jsons = get_latest_n_day_jsons_from_s3(7, userbenchmark_name, args.platform, end_date)
+    available_metrics_jsons = get_latest_jsons_in_s3_from_last_n_days(7, userbenchmark_name, args.platform, end_date)
     # Download control from S3
     if len(available_metrics_jsons) == 0:
         raise RuntimeWarning(f"No previous JSONS in a week found to compare towards the end date {end_date}. No regression info has been generated.")

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -159,12 +159,11 @@ def process_regressions_into_gh_issue(regressions_dict, owner: str, output_path:
         f.write(issue_body)
 
 
-def get_best_start_date(latest_metrics_jsons, end_date: str) -> Optional[datetime]:
+def get_best_start_date(latest_metrics_jsons: List[str], end_date: datetime) -> Optional[datetime]:
     """Get the date closest to `end_date` from `latest_metrics_jsons`"""
-    end_datetime = datetime.strptime("%Y-%m-%d", end_date)
     for metrics_json in latest_metrics_jsons:
         start_datetime = get_date_from_metrics_s3_key(metrics_json)
-        if start_datetime < end_datetime:
+        if start_datetime < end_date:
             return start_datetime
     return None
 

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -85,7 +85,7 @@ def get_output_dir(bm_name) -> Path:
     return target_dir
 
 
-def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str, date: datetime.datetime, limit: int=100) -> List[str]:
+def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
     """Retrieves the most recent n day metrics json filenames from S3 the WEEK BEFORE the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
        Returns maximum 100 results by default. """

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -91,7 +91,7 @@ def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
 
 
 def get_latest_jsons_in_s3_from_last_n_days(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
-    """Retrieves the most recent n day metrics json filenames from S3 the WEEK BEFORE the given date, inclusive of that date.
+    """Retrieves the most recent n day metrics json filenames from S3 before the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
        Returns maximum 100 results by default. """
     s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -90,7 +90,7 @@ def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
     return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json')
 
 
-def get_latest_jsons_in_s3_from_last_n_days(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
+def get_latest_jsons_in_s3_from_last_n_days(bm_name: str, platform_name: str, date: datetime, ndays: int=7, limit: int=100) -> List[str]:
     """Retrieves the most recent n day metrics json filenames from S3 before the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
        Returns maximum 100 results by default. """

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -85,9 +85,10 @@ def get_output_dir(bm_name) -> Path:
     return target_dir
 
 
-def get_latest_n_jsons_from_s3(n: int, bm_name: str, platform_name: str, date: str) -> List[str]:
-    """Retrieves the most recent n metrics json filenames from S3 the WEEK BEFORE the given date, exclusive of that date.
-       If fewer than n items are found, returns all found items without erroring, even if there were no items. """
+def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str, date: datetime.datetime, limit: int=100) -> List[str]:
+    """Retrieves the most recent n day metrics json filenames from S3 the WEEK BEFORE the given date, inclusive of that date.
+       If fewer than n days are found, returns all found items without erroring, even if there were no items.
+       Returns maximum 100 results by default. """
     s3 = S3Client(USERBENCHMARK_S3_BUCKET, USERBENCHMARK_S3_OBJECT)
     directory = f'{bm_name}/{platform_name}'
 
@@ -95,9 +96,8 @@ def get_latest_n_jsons_from_s3(n: int, bm_name: str, platform_name: str, date: s
         return []
 
     previous_json_files = []
-    start_date = datetime.strptime(date, '%Y-%m-%d')
-    current_date = start_date - timedelta(days=1)
-    while len(previous_json_files) < n and current_date >= start_date - timedelta(days=7):
+    current_date = date
+    while len(previous_json_files) < limit and current_date >= date - timedelta(days=ndays):
         current_date_str = current_date.strftime('%Y-%m-%d')
         current_directory = f'{directory}/{current_date_str}'
 
@@ -105,7 +105,7 @@ def get_latest_n_jsons_from_s3(n: int, bm_name: str, platform_name: str, date: s
             files = s3.list_directory(current_directory)
             metric_jsons = [f for f in files if f.endswith('.json') and 'metrics' in f]
             metric_jsons.sort(key=lambda x: datetime.strptime(x.split('/')[-1].split('-')[-1].split('.')[0], '%Y%m%d%H%M%S'), reverse=True)
-            previous_json_files.extend(metric_jsons[:n - len(previous_json_files)])
+            previous_json_files.extend(metric_jsons[:limit - len(previous_json_files)])
 
         # Move on to the previous date.
         current_date -= timedelta(days=1)

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -90,7 +90,7 @@ def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
     return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json')
 
 
-def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
+def get_latest_jsons_in_s3_from_last_n_days(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
     """Retrieves the most recent n day metrics json filenames from S3 the WEEK BEFORE the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
        Returns maximum 100 results by default. """

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -85,6 +85,11 @@ def get_output_dir(bm_name) -> Path:
     return target_dir
 
 
+def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
+    metrics_s3_json_filename = metrics_s3_key.split('/')[-1]
+    return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json')
+
+
 def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str, date: datetime, limit: int=100) -> List[str]:
     """Retrieves the most recent n day metrics json filenames from S3 the WEEK BEFORE the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
@@ -104,7 +109,7 @@ def get_latest_n_day_jsons_from_s3(ndays: int, bm_name: str, platform_name: str,
         if s3.exists(None, current_directory):
             files = s3.list_directory(current_directory)
             metric_jsons = [f for f in files if f.endswith('.json') and 'metrics' in f]
-            metric_jsons.sort(key=lambda x: datetime.strptime(x.split('/')[-1].split('-')[-1].split('.')[0], '%Y%m%d%H%M%S'), reverse=True)
+            metric_jsons.sort(key=lambda x: get_date_from_metrics_s3_key(x), reverse=True)
             previous_json_files.extend(metric_jsons[:limit - len(previous_json_files)])
 
         # Move on to the previous date.


### PR DESCRIPTION
Support using `--start_date` and `--end_date` to detect regressions by using files on Amazon S3.

Test plan (Need to set AWS credentials):
```
python regression_detector.py --platform gcp_a100 --end-date 2023-05-02 --name torch-nightly
```
```
control_env:
  pytorch_git_version: 521b386e57f357386caa821adb0d9bae140f272e
treatment_env:
  pytorch_git_version: f38a04a5c5ce632ba8b0534e3689e89f98e89d73
bisection: null
details:
  test_eval[phlippe_resnet-cuda-eager]_latency:
    control: 2.978329
    treatment: 3.53091
    delta: 0.18553390172811668
  test_eval[timm_resnest-cuda-eager]_gmem:
    control: 4.0126953125
    treatment: 4.5927734375
    delta: 0.14456072036991968
control_only_metrics: {}
treatment_only_metrics: {}
```

```

TorchBench CI has detected a performance signal or runtime regression.

Base PyTorch commit: 521b386e57f357386caa821adb0d9bae140f272e

Affected PyTorch commit: f38a04a5c5ce632ba8b0534e3689e89f98e89d73

Affected Tests:
- test_eval[phlippe_resnet-cuda-eager]_latency: +0.18553%
- test_eval[timm_resnest-cuda-eager]_gmem: +0.14456%


Tests that were no longer run on affected commit:


Tests that were newly added on affected commit:


Runtime regressions found?
No runtime errors were found in the new benchmarks run--you are all good there!

GitHub workflow that triggered this issue: No URL found, please look for the failing action in https://github.com/pytorch/benchmark/actions

cc @xuzhao9
```