### PR TITLE
Fix pytorch branch ref to run userbenchmark instruction-count

### DIFF
--- a/userbenchmark/instruction-count/__init__.py
+++ b/userbenchmark/instruction-count/__init__.py
@@ -71,7 +71,7 @@ def parse_args(args: List[str], work_dir: Path):
     parser = argparse.ArgumentParser()
     parser.add_argument("--pytorch-src", default=str(work_dir.resolve()),
                         help="Location of PyTorch source repo")
-    parser.add_argument("--pytorch-branch", default="master",
+    parser.add_argument("--pytorch-branch", default="main",
                         help="The branch of pytorch to check out")
     parser.add_argument("--analyze-json", type=str, default=None, help="Only analyze an existing result")
     args = parser.parse_args(args)


### PR DESCRIPTION
The pytorch github default branch is recently changed to main. The userbenchmark instruction-count references to the master branch, and so running the benchmark fails git clone with error that remote branch master not found in upstream origin.

Error: 
```
Traceback (most recent call last):
  File "/workspace/benchmark/run_benchmark.py", line 36, in <module>
    run()
  File "/workspace/benchmark/run_benchmark.py", line 30, in run
    benchmark.run(bm_args)
  File "/workspace/benchmark/userbenchmark/instruction-count/__init__.py", line 91, in run
    checkout_pytorch_repo(args.pytorch_src, args.pytorch_branch)
  File "/workspace/benchmark/userbenchmark/instruction-count/__init__.py", line 57, in checkout_pytorch_repo
    git.Repo.clone_from(PYTORCH_SRC_URL, pytorch_repo, depth=1, branch=pytorch_branch)
  File "/opt/conda/lib/python3.10/site-packages/git/repo/base.py", line 1325, in clone_from
    return cls._clone(
  File "/opt/conda/lib/python3.10/site-packages/git/repo/base.py", line 1234, in _clone
    finalize_process(proc, stderr=stderr)
  File "/opt/conda/lib/python3.10/site-packages/git/util.py", line 419, in finalize_process
    proc.wait(**kwargs)
  File "/opt/conda/lib/python3.10/site-packages/git/cmd.py", line 604, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --depth=1 --branch=master -- https://github.com/pytorch/pytorch.git /workspace/benchmark/.userbenchmark/instruction-count/run-20230508150051
  stderr: 'Cloning into '/workspace/benchmark/.userbenchmark/instruction-count/run-20230508150051'...
warning: Could not find remote branch master to clone.
fatal: Remote branch master not found in upstream origin
```
