### PR TITLE
Delay the nightly and daily workflows by 2 hours

### DIFF
--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -1,8 +1,8 @@
 name: TorchBench nightly docker build
 on:
   schedule:
-    # Push the nightly docker daily at 1 PM UTC
-    - cron: '0 13 * * *'
+    # Push the nightly docker daily at 3 PM UTC
+    - cron: '0 15 * * *'
   workflow_dispatch:
 env:
   WITH_PUSH: "true"

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -25,6 +25,7 @@ jobs:
           nvidia-smi
       - name: Clone and setup Conda env
         run: |
+          . "${SETUP_SCRIPT}"
           conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
@@ -35,6 +36,7 @@ jobs:
       - name: Clean up Conda env
         if: always()
         run: |
+          . "${SETUP_SCRIPT}"
           conda deactivate && conda deactivate
           conda remove -n "${CONDA_ENV}" --all
 

--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -7,7 +7,8 @@ on:
       - main
 
 env:
-  CONDA_ENV: "torchbench"
+  BASE_CONDA_ENV: "torchbench"
+  CONDA_ENV: "pr-ci-a100"
   SETUP_SCRIPT: "/workspace/setup_instance.sh"
 
 jobs:
@@ -22,12 +23,20 @@ jobs:
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
+      - name: Clone and setup Conda env
+        run: |
+          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
           bash ./scripts/torchbench_install.sh
       - name: Validate benchmark components
         run: |
           bash ./scripts/torchbench_test.sh
+      - name: Clean up Conda env
+        if: always()
+        run: |
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -1,7 +1,7 @@
 name: TorchBench Userbenchmark on A100
 on:
   schedule:
-    - cron: '0 14 * * *' # run at 2 PM UTC
+    - cron: '0 16 * * *' # run at 4 PM UTC
   workflow_dispatch:
     inputs:
       userbenchmark_name:

--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -9,7 +9,8 @@ on:
       userbenchmark_options:
         description: "Option of the user benchmark to run"
 env:
-  CONDA_ENV_NAME: "torchbench"
+  BASE_CONDA_ENV: "torchbench"
+  CONDA_ENV: "userbenchmark-a100"
   PLATFORM_NAME: "gcp_a100"
   TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -33,20 +34,23 @@ jobs:
       - name: Check PyTorch nightly if scheduled
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           TODAY_STR=$(date +'%Y%m%d')
           python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
+      - name: Clone and setup conda env
+        run: |
+          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
           set -x
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           python install.py
       - name: Run user benchmark
         run: |
           set -x
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           # remove old results
           if [ -d benchmark-output ]; then rm -Rf benchmark-output; fi
           pushd benchmark
@@ -79,3 +83,8 @@ jobs:
         with:
           name: TorchBench result
           path: benchmark-output/
+      - name: Clean up Conda env
+        if: always()
+        run: |
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -34,12 +34,13 @@ jobs:
       - name: Check PyTorch nightly if scheduled
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
+          . "${SETUP_SCRIPT}" && conda activate "${BASE_CONDA_ENV}"
           pushd benchmark
           TODAY_STR=$(date +'%Y%m%d')
           python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
       - name: Clone and setup conda env
         run: |
+          . "${SETUP_SCRIPT}"
           conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
@@ -86,5 +87,6 @@ jobs:
       - name: Clean up Conda env
         if: always()
         run: |
+          . "${SETUP_SCRIPT}"
           conda deactivate && conda deactivate
           conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -9,7 +9,8 @@ on:
       userbenchmark_options:
         description: "Option of the user benchmark to run"
 env:
-  CONDA_ENV_NAME: "torchbench"
+  BASE_CONDA_ENV: "torchbench"
+  CONDA_ENV: "optim"
   PLATFORM_NAME: "gcp_a100"
   TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -30,16 +31,20 @@ jobs:
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
+      - name: Clone and setup Conda env
+        run: |
+          . "${SETUP_SCRIPT}"
+          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
           set -x
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           python install.py
       - name: Run optim user benchmark
         run: |
           set -x
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           # remove old results
           if [ -d benchmark-output ]; then rm -Rf benchmark-output; fi
           pushd benchmark
@@ -51,7 +56,7 @@ jobs:
       - name: Detect potential regressions
         continue-on-error: true
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
           # TODO: the following assumes only one metrics-*.json is found. It will keep 
@@ -70,7 +75,7 @@ jobs:
             torchbench-perf-report
       - name: Upload result jsons to Scribe and S3
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
           echo "Uploading result jsons: ${RESULTS}"
@@ -94,4 +99,5 @@ jobs:
         if: always()
         run: |
           . "${SETUP_SCRIPT}"
-          conda env remove --name "${CONDA_ENV_NAME}"
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -2,7 +2,7 @@ name: TorchBench V3 nightly (A100)
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *' # run at 2 PM UTC
+    - cron: '0 16 * * *' # run at 4 PM UTC
 
 jobs:
   run-benchmark:

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   run-benchmark:
     env:
-      CONDA_ENV_NAME:  "torchbench"
+      BASE_CONDA_ENV: "torchbench"
+      CONDA_ENV:  "torchbench-v3-nightly"
       PLATFORM_NAME: "gcp_a100"
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
@@ -36,15 +37,18 @@ jobs:
           pushd benchmark
           TODAY_STR=$(date +'%Y%m%d')
           python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
+      - name: Clone and setup conda env
+        run: |
+          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
           set -x
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           python install.py
       - name: Run the torch-nightly userbenchmark
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           # remove old results
           if [ -d benchmark-output ]; then rm -Rf benchmark-output; fi
           pushd benchmark
@@ -54,7 +58,7 @@ jobs:
       - name: Detect potential regressions
         continue-on-error: true
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           pushd benchmark
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
           # TODO: the following assumes only one metrics-*.json is found. It will keep
@@ -74,7 +78,7 @@ jobs:
             torchbench-perf-report
       - name: Copy artifact and upload to scribe and Amazon S3
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV}"
           TODAY=$(date "+%Y%m%d%H%M%S")
           pushd benchmark
           LATEST_RESULT=$(find ../benchmark-output/ -name "metrics-*.json" | sort -r | head -1)
@@ -88,3 +92,8 @@ jobs:
         with:
           name: TorchBench V3 result
           path: benchmark-output/
+      - name: Clean up Conda env
+        if: always()
+        run: |
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -33,12 +33,13 @@ jobs:
       - name: Check PyTorch nightly if scheduled
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          . "${SETUP_SCRIPT}" && conda activate "${CONDA_ENV_NAME}"
+          . "${SETUP_SCRIPT}" && conda activate "${BASE_CONDA_ENV}"
           pushd benchmark
           TODAY_STR=$(date +'%Y%m%d')
           python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
       - name: Clone and setup conda env
         run: |
+          . "${SETUP_SCRIPT}"
           conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
       - name: Install TorchBench
         run: |
@@ -95,5 +96,6 @@ jobs:
       - name: Clean up Conda env
         if: always()
         run: |
+          . "${SETUP_SCRIPT}"
           conda deactivate && conda deactivate
           conda remove -n "${CONDA_ENV}" --all


### PR DESCRIPTION
In practice we found we need to wait for another 2 hours before all nightly packages release, so we also need to delay the nightly docker build and the workflows.

Also, use forked conda env in the workflows, so that the consequent workflows won't use the same environment.

Test optim workflow: https://github.com/pytorch/benchmark/actions/runs/4929351284