### PR TITLE
Add some better GNN benchmarks from pytorch_geometric

### DIFF
--- a/torchbenchmark/models/basic_gnn_edgecnn/__init__.py
+++ b/torchbenchmark/models/basic_gnn_edgecnn/__init__.py
@@ -1,0 +1,7 @@
+from torchbenchmark.util.framework.gnn.model_factory import BasicGNNModel
+from torchbenchmark.tasks import GNN
+
+class Model(BasicGNNModel):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(model_name="edgecnn", test=test, device=device, jit=jit,
+                         batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/basic_gnn_edgecnn/install.py
+++ b/torchbenchmark/models/basic_gnn_edgecnn/install.py
@@ -1,0 +1,4 @@
+from torchbenchmark.util.framework.gnn import install_pytorch_geometric
+
+if __name__ == '__main__':
+    install_pytorch_geometric()

--- a/torchbenchmark/models/basic_gnn_edgecnn/metadata.yaml
+++ b/torchbenchmark/models/basic_gnn_edgecnn/metadata.yaml
@@ -1,0 +1,7 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false
+not_implemented:
+  - jit: true

--- a/torchbenchmark/models/basic_gnn_gcn/__init__.py
+++ b/torchbenchmark/models/basic_gnn_gcn/__init__.py
@@ -1,0 +1,7 @@
+from torchbenchmark.util.framework.gnn.model_factory import BasicGNNModel
+from torchbenchmark.tasks import GNN
+
+class Model(BasicGNNModel):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(model_name="gcn", test=test, device=device, jit=jit,
+                         batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/basic_gnn_gcn/install.py
+++ b/torchbenchmark/models/basic_gnn_gcn/install.py
@@ -1,0 +1,4 @@
+from torchbenchmark.util.framework.gnn import install_pytorch_geometric
+
+if __name__ == '__main__':
+    install_pytorch_geometric()

--- a/torchbenchmark/models/basic_gnn_gcn/metadata.yaml
+++ b/torchbenchmark/models/basic_gnn_gcn/metadata.yaml
@@ -1,0 +1,7 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false
+not_implemented:
+  - jit: true

--- a/torchbenchmark/models/basic_gnn_gin/__init__.py
+++ b/torchbenchmark/models/basic_gnn_gin/__init__.py
@@ -1,0 +1,7 @@
+from torchbenchmark.util.framework.gnn.model_factory import BasicGNNModel
+from torchbenchmark.tasks import GNN
+
+class Model(BasicGNNModel):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(model_name="gin", test=test, device=device, jit=jit,
+                         batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/basic_gnn_gin/install.py
+++ b/torchbenchmark/models/basic_gnn_gin/install.py
@@ -1,0 +1,4 @@
+from torchbenchmark.util.framework.gnn import install_pytorch_geometric
+
+if __name__ == '__main__':
+    install_pytorch_geometric()

--- a/torchbenchmark/models/basic_gnn_gin/metadata.yaml
+++ b/torchbenchmark/models/basic_gnn_gin/metadata.yaml
@@ -1,0 +1,7 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false
+not_implemented:
+  - jit: true

--- a/torchbenchmark/models/basic_gnn_graphsage/__init__.py
+++ b/torchbenchmark/models/basic_gnn_graphsage/__init__.py
@@ -1,0 +1,7 @@
+from torchbenchmark.util.framework.gnn.model_factory import BasicGNNModel
+from torchbenchmark.tasks import GNN
+
+class Model(BasicGNNModel):
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(model_name="graphsage", test=test, device=device, jit=jit,
+                         batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/basic_gnn_graphsage/install.py
+++ b/torchbenchmark/models/basic_gnn_graphsage/install.py
@@ -1,0 +1,4 @@
+from torchbenchmark.util.framework.gnn import install_pytorch_geometric
+
+if __name__ == '__main__':
+    install_pytorch_geometric()

--- a/torchbenchmark/models/basic_gnn_graphsage/metadata.yaml
+++ b/torchbenchmark/models/basic_gnn_graphsage/metadata.yaml
@@ -1,0 +1,7 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false
+not_implemented:
+  - jit: true

--- a/torchbenchmark/util/framework/gnn/__init__.py
+++ b/torchbenchmark/util/framework/gnn/__init__.py
@@ -1,0 +1,11 @@
+import subprocess
+import os.path
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+def install_pytorch_geometric():
+    pip_install_requirements()
+
+def pip_install_requirements():
+    requirements_file = os.path.join(CURRENT_DIR, "requirements.txt")
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', requirements_file])

--- a/torchbenchmark/util/framework/gnn/model_factory.py
+++ b/torchbenchmark/util/framework/gnn/model_factory.py
@@ -1,9 +1,12 @@
 import torch
+import sys
 import typing
 from contextlib import nullcontext
 from torchbenchmark.util.model import BenchmarkModel
 
-from torch_geometric.nn import GAT, GCN, GraphSAGE
+import torch_geometric
+from torch_geometric.nn import GAT, GCN, GraphSAGE, GIN, EdgeCNN
+from torchbenchmark.tasks import GNN
 import torch.nn.functional as F
 from tqdm import tqdm
 from pathlib import Path
@@ -15,6 +18,8 @@ from torch import Tensor
 models_dict = {
     'gat': GAT,
     'gcn': GCN,
+    'edgecnn': EdgeCNN,
+    'gin': GIN,
     'sage': GraphSAGE,
 }
 
@@ -107,3 +112,40 @@ class GNNModel(BenchmarkModel):
             result = torch.cat(xs, dim=0)
         return (result, )
 
+# Variation of GNNModel based off of test/nn/models/test_basic_gnn.py; the
+# difference is we don't bother with data loading or optimizer step
+class BasicGNNModel(BenchmarkModel):
+    # This benchmark doesn't seem to have any batch size
+    ALLOW_CUSTOMIZE_BSIZE = False
+    DEFAULT_TRAIN_BSIZE = 1
+    DEFAULT_EVAL_BSIZE = 1
+    task = GNN.CLASSIFICATION
+    def __init__(self, model_name, test, device, jit=False, batch_size = None, extra_args=[]):
+        super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
+        Model = models_dict[model_name]
+        self.model = Model(64, 64, num_layers=3).to(device)
+        # Apply some global side effects to library (throw out the compiled
+        # model though, we don't need it yet)
+        torch_geometric.compile(self.model)
+        # Make the model jittable
+        # (TODO: This probably makes us overstate the speedup, as making the
+        # model jittable also probably reduces its performance; but this is
+        # matching the benchmark)
+        self.model = sys.modules["torch_geometric.compile"].to_jittable(self.model)
+        num_nodes, num_edges = 10_000, 200_000
+        x = torch.randn(num_nodes, 64, device=device)
+        edge_index = torch.randint(num_nodes, (2, num_edges), device=device)
+        self.example_inputs = (x, edge_index)
+
+    def eval(self):
+        return (self.model(*self.example_inputs),)
+
+    def train(self):
+        # NB: This is a little different than test_basic_gnn.py, as we
+        # are including the cost of randn_like in the overall computation here
+        out = self.model(*self.example_inputs)
+        out_grad = torch.randn_like(out)
+        out.backward(out_grad)
+
+    def get_module(self):
+        return self.model, self.example_inputs

--- a/torchbenchmark/util/framework/gnn/requirements.txt
+++ b/torchbenchmark/util/framework/gnn/requirements.txt
@@ -1,0 +1,1 @@
+torch_geometric @ git+https://github.com/pyg-team/pytorch_geometric.git@cabcd4097442ba60aa1efa11e1619dd9bb8fb527


### PR DESCRIPTION
Unlike the ones in canaries, these work with only a source install of
latest pytorch_geometric, without requiring C++ libraries.  I've also
taken care to make the models jittable, so that you actually get speedup
from torch.compile them.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
