### PR TITLE
Enhance cpu userbenchmark deal with failures and timeout

### DIFF
--- a/.github/workflows/userbenchmark-c5-24xlarge.yml
+++ b/.github/workflows/userbenchmark-c5-24xlarge.yml
@@ -67,8 +67,8 @@ jobs:
               mkdir ../benchmark-output
             fi
           else
-            docker exec -t -w "/benchmark" "${CONTAINER_ID}" bash -c ". ${SETUP_SCRIPT} && conda activate ${CONDA_ENV} &&
-                              python run-benchmarks.py \
+            docker exec -t -w "/benchmark" "${CONTAINER_ID}" bash -c ". ${SETUP_SCRIPT} && conda activate ${CONDA_ENV} && \
+                              python run_benchmark.py \
                               \"${{ github.event.inputs.userbenchmark_name }}\" ${{ github.event.inputs.userbenchmark_options }}"
             cp -r ./.userbenchmark/"${{ github.event.inputs.userbenchmark_name }}" ../benchmark-output
           fi

--- a/.github/workflows/userbenchmark-c5-24xlarge.yml
+++ b/.github/workflows/userbenchmark-c5-24xlarge.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: benchmark
+      - name: Install Conda
+        run: |
+          cd benchmark
+          bash scripts/install_conda.sh
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:
@@ -75,6 +79,7 @@ jobs:
       - name: Upload result jsons to Scribe
         run: |
           pushd benchmark
+          . scripts/activate_conda.sh
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
           echo "Uploading result jsons: ${RESULTS}"
           for r in ${RESULTS[@]}; do

--- a/scripts/activate_conda.sh
+++ b/scripts/activate_conda.sh
@@ -1,0 +1,3 @@
+
+. ${HOME}/miniconda3/etc/profile.d/conda.sh
+conda activate

--- a/scripts/install_conda.sh
+++ b/scripts/install_conda.sh
@@ -1,0 +1,11 @@
+DEFAULT_PYTHON_VERSION=3.10
+CONDA=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+filename=$(basename "$CONDA")
+wget "$CONDA"
+chmod +x "$filename"
+./"$filename" -b -u
+
+. ${HOME}/miniconda3/etc/profile.d/conda.sh
+conda activate
+conda install -y python=${DEFAULT_PYTHON_VERSION}
+pip install boto3 pyyaml

--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -28,6 +28,7 @@ All parameters of `cpu` userbenchmark as below,
 - `--config, -c` YAML config to specify tests to run.
 - `--output, -o` output dir. By default will create folder under
   `.userbenchmark/cpu`.
+- `--timeout` limit single model test run time. Default `None` means no limitation.
 - `--launcher` whether to use `torch.backends.xeon.run_cpu` to get the peak
   performance on Intel(R) Xeon(R) Scalable Processors.
 - `--launcher-args` work with `--launcher` enabled, to provide the args of

--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -62,8 +62,8 @@ test. And for each single model test, it will create a subfolder under folder
 instance PID for that model test.
 ```shell
 $ ls .userbenchmark/cpu/cpu-20230420004336
-eval_alexnet_eager/  eval_resnet50_eager/  
-$ ls .userbenchmark/cpu/cpu-20230420004336/eval_alexnet_eager/
+alexnet-eval-eager/  resnet50-eval-eager/  
+$ ls .userbenchmark/cpu/cpu-20230420004336/alexnet-eval-eager/
 metrics-3347653.json  metrics-3347654.json  metrics-3347655.json  metrics-3347656.json
 $ cat .userbenchmark/cpu/metrics-20230420004336.json 
 {

--- a/userbenchmark/cpu/__init__.py
+++ b/userbenchmark/cpu/__init__.py
@@ -84,6 +84,7 @@ def parse_args(args):
     parser.add_argument("--jit", action="store_true", help="Convert the models to jit mode.")
     parser.add_argument("--config", "-c", default=None, help="YAML config to specify tests to run.")
     parser.add_argument("--output", "-o", default=None, help="Output dir.")
+    parser.add_argument("--timeout", default=None, help="Limit single model test run time. Default None, means no limitation.")
     parser.add_argument("--launcher", action="store_true", help="Use torch.backends.xeon.run_cpu to get the peak performance on Intel(R) Xeon(R) Scalable Processors.")
     parser.add_argument("--launcher-args", default=None, help="Provide the args of torch.backends.xeon.run_cpu. See `python -m torch.backends.xeon.run_cpu --help`")
     parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
@@ -139,6 +140,10 @@ def run_benchmark(config, args):
     cmd.append("-o")
     cmd.append(str(args.output))
     
-    print(f"Running benchmark: {cmd}")
+    print(f"\nRunning benchmark: {' '.join(map(str, cmd))}")
     if not args.dryrun:
-        subprocess.check_call(cmd, cwd=REPO_PATH)
+        timeout = int(args.timeout) if args.timeout else None
+        try:
+            subprocess.run(cmd, cwd=REPO_PATH, check=False, timeout=timeout)
+        except Exception as e:
+            print(e)

--- a/userbenchmark/cpu/__init__.py
+++ b/userbenchmark/cpu/__init__.py
@@ -137,7 +137,7 @@ def run_benchmark(config, args):
 
     cmd.extend(config.extra_args)
     cmd.append("-o")
-    cmd.append(args.output)
+    cmd.append(str(args.output))
     
     print(f"Running benchmark: {cmd}")
     if not args.dryrun:

--- a/userbenchmark/cpu/cpu_utils.py
+++ b/userbenchmark/cpu/cpu_utils.py
@@ -51,10 +51,10 @@ def dump_output(bm_name, output, output_dir=None, fname=None):
 def get_run(test_dir: Path):
     run = {}
     testdir_name = test_dir.name
-    regex = "(.*)_(.*)_(.*)"
+    regex = "(.*)-(.*)-(.*)"
     g = re.match(regex, testdir_name).groups()
-    run["test"] = g[0]
-    run["model"] = g[1]
+    run["model"] = g[0]
+    run["test"] = g[1]
     run["mode"] = g[2]
     run["results"] = []
     ins_jsons = filter(lambda x: x.is_file(), test_dir.iterdir())

--- a/userbenchmark/cpu/run_config.py
+++ b/userbenchmark/cpu/run_config.py
@@ -23,19 +23,20 @@ with add_path(str(REPO_PATH)):
 
     def get_output_subdir(config: TorchBenchModelConfig) -> str:
         mode = "jit" if config.jit else "eager"
-        subdir = f"{config.test}_{config.name}_{mode}"
+        subdir = f"{config.name}-{config.test}-{mode}"
         return subdir
 
     def result_to_output_metrics(metrics: TorchBenchModelMetrics) -> Dict[str, float]:
         result_metrics = {}
-        if metrics.latencies:
-            latency_metric = "latency"
-            median_latency = numpy.median(metrics.latencies)
-            assert median_latency, f"Run failed for metric {latency_metric}"
-            result_metrics[latency_metric] = median_latency
-        if metrics.cpu_peak_mem:
-            cpu_peak_mem = "cpu_peak_mem"
-            result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
+        if metrics:
+            if metrics.latencies:
+                latency_metric = "latency"
+                median_latency = numpy.median(metrics.latencies)
+                assert median_latency, f"Run failed for metric {latency_metric}"
+                result_metrics[latency_metric] = median_latency
+            if metrics.cpu_peak_mem:
+                cpu_peak_mem = "cpu_peak_mem"
+                result_metrics[cpu_peak_mem] = metrics.cpu_peak_mem
         return result_metrics
 
     def dump_result_to_json(metrics, output_dir):


### PR DESCRIPTION
Fix cpu userbenchmark issue for not implemented models, and add timeout parameter for cpu userbenchmark
It also works for roadmap #1293 

For example:
```shell
$ python run_benchmark.py cpu -m resnet50,Background_Matting,resnet18 --timeout 10
Running benchmark: ['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'resnet50', '--device', 'cpu', '-t', 'eval', '-o', '/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230508013240']
Command '['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'resnet50', '--device', 'cpu', '-t', 'eval', '-o', '/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230508013240']' timed out after 10 seconds
Running benchmark: ['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'Background_Matting', '--device', 'cpu', '-t', 'eval', '-o', '/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230508013240']
Running TorchBenchModelConfig(name='Background_Matting', device='cpu', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [NotImplemented]

Running benchmark: ['/localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python', '/localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py', '-m', 'resnet18', '--device', 'cpu', '-t', 'eval', '-o', '/localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230508013240']
Running TorchBenchModelConfig(name='resnet18', device='cpu', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Done]
```