### PR TITLE
[optim][ub] Increase delta, exclude CPU reporting

### DIFF
--- a/userbenchmark/optim/regression_detector.py
+++ b/userbenchmark/optim/regression_detector.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from ..utils import TorchBenchABTestResult, TorchBenchABTestMetric
 
-DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.07
+DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.1
 
 def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     control_env = control["environ"]
@@ -10,6 +10,9 @@ def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     treatment_metrics = treatment["metrics"]
     details = {}
     for control_metric_name, control_metric in control_metrics.items():
+        # Don't report benchmark stats for CPU as CPU can be unstable
+        if "cpu" in control_metric_name:
+            continue
         if control_metric_name in treatment_metrics:
             treatment_metric = treatment_metrics[control_metric_name]
             delta = (treatment_metric - control_metric) / control_metric


### PR DESCRIPTION
Increases the delta to 10%, as optimizer step is a small step so noise is not unexpected.

Also removes reporting for CPU, though we still run the CPU benchmarks + record stats to S3 so that we leave a trace of numbers + ascertain functionality.