### PR TITLE
Fix a bug in cpu userbenchmark with launcher

### DIFF
--- a/userbenchmark/cpu/__init__.py
+++ b/userbenchmark/cpu/__init__.py
@@ -119,13 +119,14 @@ def run_benchmark(config, args):
     if args.launcher:
         cmd.extend(["-m", "torch.backends.xeon.run_cpu"])
         if args.launcher_args:
-            cmd.extend(args.launcher_args.split(" "))
+            import shlex
+            cmd.extend(shlex.split(args.launcher_args))
     cmd.append(str(benchmark_script))
     if config.name:
         cmd.append("-m")
         cmd.append(config.name)
     if config.device:
-        cmd.append("--device")
+        cmd.append("-d")
         cmd.append(config.device)
     if config.batch_size:
         cmd.append("-b")


### PR DESCRIPTION
Works for #1293 to enhance the cpu userbenchmark with launcher.

Fixes #1649

Before:
```shell
$ python run_benchmark.py cpu -m resnet50 --launcher --launcher-args=" --throughput-mode"

Running benchmark: /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -m torch.backends.xeon.run_cpu  --throughput-mode /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 --device cpu -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230514213153
Traceback (most recent call last):
  File "/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/localdisk/chuanqiw/PT/pytorch/torch/backends/xeon/run_cpu.py", line 699, in <module>
    main(args)
  File "/localdisk/chuanqiw/PT/pytorch/torch/backends/xeon/run_cpu.py", line 659, in main
    raise RuntimeError("For non Python script, you should use \"--no-python\" parameter.")
RuntimeError: For non Python script, you should use "--no-python" parameter.
```
After:
```shell
$ python run_benchmark.py cpu -m resnet50 --launcher --launcher-args=" --throughput-mode"

Running benchmark: /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -m torch.backends.xeon.run_cpu --throughput-mode /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 -d cpu -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230514222434
2023-05-14 22:24:35,964 - __main__ - WARNING - --throughput-mode is exclusive to --ninstances, --ncores-per-instance, --node-id and --use-logical-core. They won't take effect even they are set explicitly.
2023-05-14 22:24:35,969 - __main__ - INFO - Use JeMalloc memory allocator
2023-05-14 22:24:35,969 - __main__ - INFO - OMP_NUM_THREADS=28
2023-05-14 22:24:35,969 - __main__ - INFO - Using Intel OpenMP
2023-05-14 22:24:35,970 - __main__ - INFO - KMP_AFFINITY=granularity=fine,compact,1,0
2023-05-14 22:24:35,970 - __main__ - INFO - KMP_BLOCKTIME=1
2023-05-14 22:24:35,970 - __main__ - INFO - LD_PRELOAD=/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libiomp5.so:/localdisk/chuanqiw/miniconda3/envs/torchdynamo/lib/libjemalloc.so
2023-05-14 22:24:35,970 - __main__ - INFO - numactl -C 0-27 -m 0 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 -d cpu -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230514222434
2023-05-14 22:24:35,970 - __main__ - INFO - numactl -C 28-55 -m 1 /localdisk/chuanqiw/miniconda3/envs/torchdynamo/bin/python -u /localdisk/chuanqiw/PT/benchmark/userbenchmark/cpu/run_config.py -m resnet50 -d cpu -t eval -o /localdisk/chuanqiw/PT/benchmark/.userbenchmark/cpu/cpu-20230514222434
Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ...Running TorchBenchModelConfig(name='resnet50', device='cpu', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Done]
 [Done]
 ```