### PR TITLE
Fix TypeError in the e2e hf_t5

### DIFF
--- a/torchbenchmark/e2e_models/hf_t5/__init__.py
+++ b/torchbenchmark/e2e_models/hf_t5/__init__.py
@@ -361,6 +361,9 @@ class Model(E2EBenchmarkModel):
         if self.hf_args.val_max_target_length is None:
             self.hf_args.val_max_target_length = self.hf_args.max_target_length
 
+        if self.hf_args.num_beams is None:
+            self.hf_args.num_beams = 1
+
         gen_kwargs = {
             "max_length": self.hf_args.val_max_target_length if self.hf_args is not None else self.config.max_length,
             "num_beams": self.hf_args.num_beams,


### PR DESCRIPTION
When run e2e hf_t5, it gives following error:
```
Traceback (most recent call last):
  File "/home/ubuntu/pytorch/benchmark/run_e2e.py", line 56, in <module>
    result = gen_result(m, run(test))
  File "/home/ubuntu/pytorch/benchmark/run_e2e.py", line 18, in run
    func()
  File "/home/ubuntu/pytorch/benchmark/torchbenchmark/e2e_models/hf_t5/__init__.py", line 387, in eval
    generated_tokens = self.accelerator.unwrap_model(self.model).generate(
  File "/root/anaconda3/envs/torchbenchmark/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/root/anaconda3/envs/torchbenchmark/lib/python3.10/site-packages/transformers/generation/utils.py", line 1346, in generate
    (generation_config.num_beams > 1)
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```
The error is due to `None` value for `self.hf_args.num_beams` (LOC 369). Setting it to 1 as used in general for num_beams default and as used in model_factory.py for the huggingface framework code.