### PR TITLE
Reduce nanogpt gen sizes

### DIFF
--- a/torchbenchmark/models/nanogpt_generate/__init__.py
+++ b/torchbenchmark/models/nanogpt_generate/__init__.py
@@ -12,7 +12,7 @@ class Model(BenchmarkModel):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)
         # Use the default configs
         self.gpt_config = GPTConfig()
-        self.generator_config = GPTGenerationConfig(500, 0.8, 200)
+        self.generator_config = GPTGenerationConfig(32, 0.8, 200)
         self.model = SequenceGeneratorNanoGPT(GPT(self.gpt_config), self.generator_config).eval().to(self.device)
         self.prompt_size = 64
         self.example_inputs = (


### PR DESCRIPTION
# Summary
Inductor is timing out on compilation so this is used to reduce the number of gen steps