### PR TITLE
[torch-nightly] Add feature to run nightly with regression yaml

### DIFF
--- a/.github/workflows/v3-bisection.yml
+++ b/.github/workflows/v3-bisection.yml
@@ -1,0 +1,64 @@
+name: TorchBench V3 bisection
+on:
+  workflow_dispatch:
+    inputs:
+      issue_name:
+        description: "Bisection Issue Name"
+        required: true
+        default: "example-issue"
+
+jobs:
+  bisection:
+    env:
+      CONDA_ENV: "bisection-ci-v3"
+      BASE_CONDA_ENV: "torchbench"
+      BISECT_WORKDIR: ".userbenchmark/torch-nightly/v3-bisection"
+    if: ${{ github.repository_owner == 'pytorch' }}
+    runs-on: [self-hosted, bm-runner]
+    timeout-minutes: 2880 # 48 hours
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: v3.0
+      - name: Checkout pytorch
+        uses: actions/checkout@v3
+        with:
+          name: pytorch/pytorch
+      - name: Checkout torchvision
+      - name: Checkout torchaudio
+      - name: Checkout torchdata
+      - name: Checkout torchtext
+      - name: Tune Nvidia GPU
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo nvidia-smi -ac 1215,1410
+          nvidia-smi
+      - name: Clone and setup conda env
+        run: |
+          CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
+          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
+      - name: Bisection
+        run: |
+          . "${SETUP_SCRIPT}"
+          TODAY=$(date +Ymd)
+          python bisection.py --work-dir "${BISECT_WORKDIR}" --torch-repos-path "${PWD}/srcs" \
+                --torchbench-repo-path "${PWD}" --config "${TODAY}" --output "${BISECT_WORKDIR}/bisect-output-gh${GITHUB_RUN_ID}.json" \
+                --skip-update torchbench
+      - name: Analyze bisection result
+        run: |
+          . "${SETUP_SCRIPT}"
+          export BISECT_BASE="${HOME}/${BISECT_DIR}/${BISECT_ISSUE}"
+          python ./.github/scripts/bmutils/analyze-bisection-result.py --bisection-root "${BISECT_BASE}" --gh-workflow-id "${GITHUB_RUN_ID}"
+          cp -r "${BISECT_BASE}" ./bisection-result
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Bisection result
+          path: bisection-result/
+      - name: Clean up Conda env
+        if: always()
+        run: |
+          . "${SETUP_SCRIPT}"
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/v3-bisection.yml
+++ b/.github/workflows/v3-bisection.yml
@@ -25,10 +25,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           name: pytorch/pytorch
-      - name: Checkout torchvision
-      - name: Checkout torchaudio
-      - name: Checkout torchdata
-      - name: Checkout torchtext
       - name: Tune Nvidia GPU
         run: |
           sudo nvidia-smi -pm 1

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -58,11 +58,23 @@ def get_output_json(bm_name, metrics) -> Dict[str, Any]:
     }
 
 
-def dump_output(bm_name, output, target_dir: Path=None) -> None:
+def get_output_dir(bm_name) -> Path:
+    current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    target_dir = current_dir.parent.joinpath(USERBENCHMARK_OUTPUT_PREFIX, bm_name)
+    target_dir.mkdir(exist_ok=True, parents=True)
+    return target_dir
+
+
+def get_default_output_json_path(bm_name: str, target_dir: Path=None) -> str:
     if target_dir is None:
         target_dir = get_output_dir(bm_name)
     fname = "metrics-{}.json".format(datetime.fromtimestamp(time.time()).strftime("%Y%m%d%H%M%S"))
     full_fname = os.path.join(target_dir, fname)
+    return full_fname
+
+
+def dump_output(bm_name: str, output: Any, target_dir: Path=None) -> None:
+    full_fname = get_default_output_json_path(bm_name, target_dir=target_dir)
     with open(full_fname, 'w') as f:
         json.dump(output, f, indent=4)
 
@@ -76,14 +88,6 @@ def get_ub_name(metrics_file_path: str) -> str:
     with open(metrics_file_path, "r") as mf:
         metrics = json.load(mf)
     return metrics["name"]
-
-
-def get_output_dir(bm_name) -> Path:
-    current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
-    target_dir = current_dir.parent.joinpath(USERBENCHMARK_OUTPUT_PREFIX, bm_name)
-    target_dir.mkdir(exist_ok=True, parents=True)
-    return target_dir
-
 
 def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
     metrics_s3_json_filename = metrics_s3_key.split('/')[-1]


### PR DESCRIPTION
To enable bisection, the userbenchmark needs to run with a regression yaml file.
This is an optimization: if there is only 1 test regresses, we should only run the regressed test as opposed to the entire test set.

Test Plan:
```
python run_benchmark.py torch-nightly --run-bisect ./.userbenchmark/torch-nightly/regression-20230522231642.yaml --dryrun
```

```
Running TorchBenchModelConfig(name='BERT_pytorch', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='DALLE2_pytorch', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='LearningToPaint', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='Super_SloMo', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='alexnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='attention_is_all_you_need_pytorch', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='dcgan', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='demucs', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_101_dc5', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_50_dc5', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_50_fpn', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_101_c4', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_101_fpn', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_50_fpn', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='dlrm', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='doctr_det_predictor', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='doctr_reco_predictor', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='fambench_xlmr', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='fastNLP_Bert', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='functorch_dp_cifar10', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Albert', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bart', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bert', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bert_large', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_BigBird', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_DistilBert', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_GPT2', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_GPT2_large', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Longformer', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Reformer', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_T5', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_T5_base', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_T5_large', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='llama', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='maml', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='maml_omniglot', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mnasnet1_0', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mobilenet_v2', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mobilenet_v3_large', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='moco', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='nvidia_deeprecommender', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='opacus_cifar10', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='phlippe_densenet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='phlippe_resnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pyhpc_equation_of_state', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pyhpc_isoneutral_mixing', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pyhpc_turbulent_kinetic_energy', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_CycleGAN_and_pix2pix', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_stargan', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_unet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet152', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet18', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet50', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnext50_32x4d', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='shufflenet_v2_x1_0', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='soft_actor_critic', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='speech_transformer', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='squeezenet1_1', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='tacotron2', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_efficientnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_nfnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_regnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_resnest', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_vision_transformer', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_vision_transformer_large', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_vovnet', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='torchrec_dlrm', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='tts_angular', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='vgg16', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='vision_maskrcnn', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='yolov3', device='cuda', test='eval', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='Background_Matting', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='DALLE2_pytorch', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='Super_SloMo', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='alexnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='attention_is_all_you_need_pytorch', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='dcgan', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='densenet121', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_101_c4', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_101_dc5', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_101_fpn', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_50_dc5', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_fasterrcnn_r_50_fpn', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_101_c4', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_101_fpn', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='detectron2_maskrcnn_r_50_c4', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='dlrm', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='drq', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='fambench_xlmr', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='fastNLP_Bert', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='functorch_maml_omniglot', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Albert', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bart', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bert', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Bert_large', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_BigBird', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_DistilBert', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_GPT2', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_GPT2_large', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Longformer', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_Reformer', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_T5', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='hf_T5_large', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='lennard_jones', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='maml_omniglot', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mnasnet1_0', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mobilenet_v2', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mobilenet_v2_quantized_qat', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='mobilenet_v3_large', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='moco', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='nvidia_deeprecommender', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='opacus_cifar10', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='phlippe_densenet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='phlippe_resnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_CycleGAN_and_pix2pix', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_stargan', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_struct', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='pytorch_unet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet152', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet18', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet50', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='resnet50_quantized_qat', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='shufflenet_v2_x1_0', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='speech_transformer', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='squeezenet1_1', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='tacotron2', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_efficientdet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_efficientnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_nfnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_regnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_resnest', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_vision_transformer', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='timm_vovnet', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='torchrec_dlrm', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='tts_angular', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='vgg16', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='vision_maskrcnn', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
Running TorchBenchModelConfig(name='yolov3', device='cuda', test='train', batch_size=None, jit=False, extra_args=[], extra_env=None) ... [Skip: Dryrun]
```