### PR TITLE
[optim][ub] Set threshold to 30% and disable torch-nightly unstable models

### DIFF
--- a/userbenchmark/optim/__init__.py
+++ b/userbenchmark/optim/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 from torchbenchmark import load_model_by_name
 import torch
 from torch import _dynamo as torchdynamo
@@ -24,17 +24,17 @@ run_on_subset: bool = False
 ignore_skips: bool = False
 
 # Models that are unstable in torch-nightly should not run in the optim world either
-def get_unstable_models() -> List[str]:
-    unstable_models: List[str]= []
+def get_unstable_models() -> Set[str]:
+    unstable_models: Set[str]= set()
     yaml_file_path = REPO_PATH.joinpath('userbenchmark/torch-nightly/v3-cuda-tests.yaml')
     with open(yaml_file_path, "r") as yf:
         config_obj = yaml.safe_load(yf)
     for d in config_obj['cuda']:
         if not d['stable']:
-            unstable_models.append(d['model'])
+            unstable_models.add(d['model'])
     return unstable_models
 
-unstable_models: List[str] = get_unstable_models()
+unstable_models: Set[str] = get_unstable_models()
 
 MODEL_NAMES: List[str] = list_models()
 SUBSET_OF_MODEL_NAMES: List[str] = [

--- a/userbenchmark/optim/__init__.py
+++ b/userbenchmark/optim/__init__.py
@@ -11,6 +11,7 @@ import gc
 import sys
 import itertools
 import datetime
+import yaml
 
 with add_path(REPO_PATH):
     from torchbenchmark.util.experiment.instantiator import list_models
@@ -21,6 +22,19 @@ BM_NAME: str = 'optim'
 continue_on_error: bool = False
 run_on_subset: bool = False
 ignore_skips: bool = False
+
+# Models that are unstable in torch-nightly should not run in the optim world either
+def get_unstable_models() -> List[str]:
+    unstable_models: List[str]= []
+    yaml_file_path = REPO_PATH.joinpath('userbenchmark/torch-nightly/v3-cuda-tests.yaml')
+    with open(yaml_file_path, "r") as yf:
+        config_obj = yaml.safe_load(yf)
+    for d in config_obj['cuda']:
+        if not d['stable']:
+            unstable_models.append(d['model'])
+    return unstable_models
+
+unstable_models: List[str] = get_unstable_models()
 
 MODEL_NAMES: List[str] = list_models()
 SUBSET_OF_MODEL_NAMES: List[str] = [
@@ -208,6 +222,9 @@ DENSE_MODELS = [
 # {'optim': 'SparseAdam', 'model': 'BERT_pytorch'}, any configuration with
 # SparseAdam on BERT_pytorch will be skipped.
 EXCLUSIONS: List[Dict[str, Any]] = [
+    # Skip models deemed unstable by torch-nightly
+    {'model': m} for m in unstable_models
+] + [
     # SparseAdam does not support dense gradients
     {'optim': 'SparseAdam', 'model': m} for m in DENSE_MODELS
 ] + [

--- a/userbenchmark/optim/regression_detector.py
+++ b/userbenchmark/optim/regression_detector.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from ..utils import TorchBenchABTestResult, TorchBenchABTestMetric
 
-DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.1
+DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.3
 
 def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     control_env = control["environ"]


### PR DESCRIPTION
Skip models that are deemed unstable by torch-nightly entirely. Currently, that would be the following 16: 
```
['LearningToPaint', 'densenet121', 'detectron2_fasterrcnn_r_101_c4', 'detectron2_fasterrcnn_r_101_fpn', 'detectron2_fasterrcnn_r_50_c4', 'detectron2_fasterrcnn_r_50_c4', 'detectron2_fcos_r_50_fpn', 'detectron2_maskrcnn_r_50_c4', 'detectron2_maskrcnn_r_50_fpn', 'drq', 'functorch_dp_cifar10', 'functorch_maml_omniglot', 'lennard_jones', 'resnext50_32x4d', 'soft_actor_critic', 'timm_efficientdet']
```

Also drive the regression threshold to 30%!!! This _is_ a big leap, but we want to stop flooding torchbench with issues everyday and slowly push down the threshold. Based on stats in https://docs.google.com/spreadsheets/d/1r3a7UczDofej8p6KhAcbTf8moxnlbyQ1AWZKOo0kbh8/edit#gid=418753160, only 0.8% of noise will go beyond 30%, so this should make the issues much more manageable in conjunction with my nifty dashboard (unfortunately internal only atm) www.fburl.com/optim_benchmarks