### PR TITLE
Support downloading yaml files from S3

### DIFF
--- a/regression_detector.py
+++ b/regression_detector.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-date", default=None, help="The start date to detect regression.")
     parser.add_argument("--end-date", default=None, help="The latest date to detect regression.")
     # download from S3
-    parser.add_argument("--download-from-s3", help="Download the regression yaml file from S3.")
+    parser.add_argument("--download-from-s3", action='store_true', help="Download the regression yaml file from S3.")
     # output file path
     parser.add_argument("--output", default=None, help="Output path to print the regression detection file.")
     # GitHub issue details
@@ -252,6 +252,7 @@ if __name__ == "__main__":
         with open(args.output, "w") as rf:
             yaml.safe_dump(regression_yaml, rf)
         print(f"Downloaded the regression yaml file to path {args.output}")
+        exit(0)
 
     metrics_json_cond = lambda x: x.endswith('.json') and 'metrics' in x
     available_metrics_jsons = get_latest_files_in_s3_from_last_n_days(userbenchmark_name, args.platform, end_date, metrics_json_cond, ndays=7)

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -103,7 +103,8 @@ def get_ub_name(metrics_file_path: str) -> str:
 
 def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
     metrics_s3_json_filename = metrics_s3_key.split('/')[-1]
-    return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json')
+    return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json') if metrics_s3_key.endswith('.json') \
+        else datetime.strptime(metrics_s3_json_filename, 'regression-%Y%m%d%H%M%S.yaml')
 
 
 def get_latest_files_in_s3_from_last_n_days(bm_name: str, platform_name: str, date: datetime, cond: Callable, ndays: int=7, limit: int=100) -> List[str]:

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -6,7 +6,7 @@ import json
 import yaml
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Callable
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
 USERBENCHMARK_OUTPUT_PREFIX = ".userbenchmark"
@@ -106,7 +106,7 @@ def get_date_from_metrics_s3_key(metrics_s3_key: str) -> datetime:
     return datetime.strptime(metrics_s3_json_filename, 'metrics-%Y%m%d%H%M%S.json')
 
 
-def get_latest_jsons_in_s3_from_last_n_days(bm_name: str, platform_name: str, date: datetime, ndays: int=7, limit: int=100) -> List[str]:
+def get_latest_files_in_s3_from_last_n_days(bm_name: str, platform_name: str, date: datetime, cond: Callable, ndays: int=7, limit: int=100) -> List[str]:
     """Retrieves the most recent n day metrics json filenames from S3 before the given date, inclusive of that date.
        If fewer than n days are found, returns all found items without erroring, even if there were no items.
        Returns maximum 100 results by default. """
@@ -124,7 +124,7 @@ def get_latest_jsons_in_s3_from_last_n_days(bm_name: str, platform_name: str, da
 
         if s3.exists(None, current_directory):
             files = s3.list_directory(current_directory)
-            metric_jsons = [f for f in files if f.endswith('.json') and 'metrics' in f]
+            metric_jsons = [f for f in files if cond(f)]
             metric_jsons.sort(key=lambda x: get_date_from_metrics_s3_key(x), reverse=True)
             previous_json_files.extend(metric_jsons[:limit - len(previous_json_files)])
 

--- a/utils/s3_utils.py
+++ b/utils/s3_utils.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional
 import boto3
 import os
 import json
+import yaml
 from pathlib import Path
 
 USERBENCHMARK_S3_BUCKET = "ossci-metrics"
@@ -28,6 +29,10 @@ class S3Client:
     def get_file_as_json(self, key: str) -> Any:
         obj = self.s3.get_object(Bucket=self.bucket, Key=key)
         return json.loads(obj['Body'].read().decode('utf-8'))
+
+    def get_file_as_yaml(self, key: str) -> Any:
+        obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return yaml.safe_load(obj['Body'].read().decode('utf-8'))
 
     def exists(self, prefix: str, file_name: str) -> Optional[str]:
         """Test if the key object/prefix/file_name exists in the S3 bucket.


### PR DESCRIPTION
In the bisection workflow, we need to download the regression yaml file from S3.

Test Plan:
```
python regression_detector.py --name torch-nightly --platform gcp_a100 --end-date 2023-05-19 --download-from-s3 --output 1.yaml
Downloaded the regression yaml file to path 1.yaml
```