### PR TITLE
Moco Inplace Update Params

### DIFF
--- a/torchbenchmark/models/moco/moco/builder.py
+++ b/torchbenchmark/models/moco/moco/builder.py
@@ -47,7 +47,7 @@ class MoCo(nn.Module):
         Momentum update of the key encoder
         """
         for param_q, param_k in zip(self.encoder_q.parameters(), self.encoder_k.parameters()):
-            param_k.data = param_k.data * self.m + param_q.data * (1. - self.m)
+            param_k.mul_(self.m).add_(param_q.mul(1. - self.m))
 
     @torch.no_grad()
     def _dequeue_and_enqueue(self, keys):


### PR DESCRIPTION
The out of place .data manipulation is slower/more memory, and doesnt work with cudagraphs.

Upstream pr link: https://github.com/facebookresearch/moco/pull/141