### PR TITLE
Migrate to use the correctness checking code in dynamo torchbench.py

### DIFF
--- a/.github/workflows/pr-a10g.yml
+++ b/.github/workflows/pr-a10g.yml
@@ -40,6 +40,7 @@ jobs:
             -e SETUP_SCRIPT \
             --tty \
             --detach \
+            --shm-size=32gb \
             -v "${PWD}/benchmark:/benchmark" \
             --gpus all \
             -w / \

--- a/run.py
+++ b/run.py
@@ -364,8 +364,8 @@ if __name__ == "__main__":
     else:
         run_one_step(test, model=m, export_metrics_file=export_metrics_file,
                      stress=args.stress, metrics_needed=metrics_needed, metrics_gpu_backend=args.metrics_gpu_backend)
-    if hasattr(m, 'correctness'):
-        print('{:<20} {:>20}'.format("Correctness: ", str(m.correctness)), sep='')
+    if hasattr(m, 'accuracy'):
+        print('{:<20} {:>20}'.format("Accuracy: ", str(m.accuracy)), sep='')
 
     # Print dynamo compilation metrics, if there are any.
     try:

--- a/test.py
+++ b/test.py
@@ -47,10 +47,10 @@ class TestBenchmark(unittest.TestCase):
 def _create_example_model_instance(task: ModelTask, device: str):
     skip = False
     try:
-        task.make_model_instance(test="eval", device=device, jit=False)
+        task.make_model_instance(test="eval", device=device, jit=False, extra_args=["--accuracy"])
     except NotImplementedError:
         try:
-            task.make_model_instance(test="train", device=device, jit=False)
+            task.make_model_instance(test="train", device=device, jit=False, extra_args=["--accuracy"])
         except NotImplementedError:
             skip = True
     finally:
@@ -71,7 +71,8 @@ def _load_test(path, device):
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
                 _create_example_model_instance(task, device)
-                task.check_example()
+                accuracy = task.get_model_attribute("accuracy")
+                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
                 task.del_model_instance()
             except NotImplementedError:
                 self.skipTest(f'Method `get_module()` on {device} is not implemented, skipping...')
@@ -81,9 +82,7 @@ def _load_test(path, device):
         task = ModelTask(path, timeout=TIMEOUT)
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="train", device=device, jit=False, batch_size=None, extra_args=["--accuracy"])
-                accuracy = task.get_model_attribute("accuracy")
-                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
+                task.make_model_instance(test="train", device=device, jit=False, batch_size=None)
                 task.invoke()
                 task.check_details_train(device=device, md=metadata)
                 task.del_model_instance()
@@ -95,9 +94,7 @@ def _load_test(path, device):
         task = ModelTask(path, timeout=TIMEOUT)
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="eval", device=device, jit=False, batch_size=None, extra_args=["--accuracy"])
-                accuracy = task.get_model_attribute("accuracy")
-                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
+                task.make_model_instance(test="eval", device=device, jit=False, batch_size=None)
                 task.invoke()
                 task.check_details_eval(device=device, md=metadata)
                 task.check_eval_output()

--- a/test.py
+++ b/test.py
@@ -47,10 +47,10 @@ class TestBenchmark(unittest.TestCase):
 def _create_example_model_instance(task: ModelTask, device: str):
     skip = False
     try:
-        task.make_model_instance(test="train", device=device, jit=False, extra_args=["--accuracy"])
+        task.make_model_instance(test="eval", device=device, jit=False, extra_args=["--accuracy"])
     except NotImplementedError:
         try:
-            task.make_model_instance(test="eval", device=device, jit=False, extra_args=["--accuracy"])
+            task.make_model_instance(test="train", device=device, jit=False, extra_args=["--accuracy"])
         except NotImplementedError:
             skip = True
     finally:

--- a/test.py
+++ b/test.py
@@ -79,12 +79,11 @@ def _load_test(path, device):
     def train_fn(self):
         metadata = get_metadata_from_yaml(path)
         task = ModelTask(path, timeout=TIMEOUT)
-        allow_customize_batch_size = task.get_model_attribute("ALLOW_CUSTOMIZE_BSIZE", classattr=True)
-        # to speedup test, use batch size 1 if possible
-        batch_size = 1 if allow_customize_batch_size else None
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="train", device=device, jit=False, batch_size=batch_size)
+                task.make_model_instance(test="train", device=device, jit=False, batch_size=None, extra_args=["--accuracy"])
+                accuracy = task.get_model_attribute("accuracy")
+                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
                 task.invoke()
                 task.check_details_train(device=device, md=metadata)
                 task.del_model_instance()
@@ -94,12 +93,11 @@ def _load_test(path, device):
     def eval_fn(self):
         metadata = get_metadata_from_yaml(path)
         task = ModelTask(path, timeout=TIMEOUT)
-        allow_customize_batch_size = task.get_model_attribute("ALLOW_CUSTOMIZE_BSIZE", classattr=True)
-        # to speedup test, use batch size 1 if possible
-        batch_size = 1 if allow_customize_batch_size else None
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="eval", device=device, jit=False, batch_size=batch_size)
+                task.make_model_instance(test="eval", device=device, jit=False, batch_size=None, extra_args=["--accuracy"])
+                accuracy = task.get_model_attribute("accuracy")
+                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
                 task.invoke()
                 task.check_details_eval(device=device, md=metadata)
                 task.check_eval_output()

--- a/test.py
+++ b/test.py
@@ -80,9 +80,12 @@ def _load_test(path, device):
     def train_fn(self):
         metadata = get_metadata_from_yaml(path)
         task = ModelTask(path, timeout=TIMEOUT)
+        allow_customize_batch_size = task.get_model_attribute("ALLOW_CUSTOMIZE_BSIZE", classattr=True)
+        # to speedup test, use batch size 1 if possible
+        batch_size = 1 if allow_customize_batch_size else None
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="train", device=device, jit=False, batch_size=None)
+                task.make_model_instance(test="train", device=device, jit=False, batch_size=batch_size)
                 task.invoke()
                 task.check_details_train(device=device, md=metadata)
                 task.del_model_instance()
@@ -92,9 +95,12 @@ def _load_test(path, device):
     def eval_fn(self):
         metadata = get_metadata_from_yaml(path)
         task = ModelTask(path, timeout=TIMEOUT)
+        allow_customize_batch_size = task.get_model_attribute("ALLOW_CUSTOMIZE_BSIZE", classattr=True)
+        # to speedup test, use batch size 1 if possible
+        batch_size = 1 if allow_customize_batch_size else None
         with task.watch_cuda_memory(skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual):
             try:
-                task.make_model_instance(test="eval", device=device, jit=False, batch_size=None)
+                task.make_model_instance(test="eval", device=device, jit=False, batch_size=batch_size)
                 task.invoke()
                 task.check_details_eval(device=device, md=metadata)
                 task.check_eval_output()

--- a/test.py
+++ b/test.py
@@ -72,7 +72,7 @@ def _load_test(path, device):
             try:
                 _create_example_model_instance(task, device)
                 accuracy = task.get_model_attribute("accuracy")
-                assert accuracy == "pass", f"Expected accuracy pass, get {accuracy}"
+                assert accuracy == "pass" or accuracy == "eager_1st_run_OOM", f"Expected accuracy pass, get {accuracy}"
                 task.del_model_instance()
             except NotImplementedError:
                 self.skipTest(f'Method `get_module()` on {device} is not implemented, skipping...')

--- a/test.py
+++ b/test.py
@@ -47,10 +47,10 @@ class TestBenchmark(unittest.TestCase):
 def _create_example_model_instance(task: ModelTask, device: str):
     skip = False
     try:
-        task.make_model_instance(test="eval", device=device, jit=False, extra_args=["--accuracy"])
+        task.make_model_instance(test="train", device=device, jit=False, extra_args=["--accuracy"])
     except NotImplementedError:
         try:
-            task.make_model_instance(test="train", device=device, jit=False, extra_args=["--accuracy"])
+            task.make_model_instance(test="eval", device=device, jit=False, extra_args=["--accuracy"])
         except NotImplementedError:
             skip = True
     finally:

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -469,11 +469,7 @@ class ModelTask(base_task.TaskBase):
     def check_eval_output() -> None:
         instance = globals()["model"]
         assert instance.test == "eval", "We only support checking output of an eval test. Please submit a bug report."
-        out = instance.invoke()
-        # check output stableness on CUDA device
-        from torchbenchmark.util.env_check import stableness_check
-        if instance.device == "cuda":
-            stableness_check(instance, cos_sim=False, deepcopy=instance.DEEPCOPY)
+        instance.invoke()
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -439,33 +439,6 @@ class ModelTask(base_task.TaskBase):
 
     @base_task.run_in_worker(scoped=True)
     @staticmethod
-    def check_example() -> None:
-        model = globals()["model"]
-        module, example_inputs = model.get_module()
-        if isinstance(example_inputs, dict):
-            # Huggingface and GNN models pass **kwargs as arguments, not *args
-            module(**example_inputs)
-        elif isinstance(example_inputs, tuple) or isinstance(example_inputs, list):
-            module(*example_inputs)
-        else:
-            assert False, "example_inputs from model.get_module() must be dict, tuple, or list"
-        # If model implements `gen_inputs()` interface, test the first example input it generates
-        try:
-            input_iter, _size = model.gen_inputs()
-            next_inputs = next(input_iter)
-
-            for input in next_inputs:
-                if isinstance(input, dict):
-                    # Huggingface models pass **kwargs as arguments, not *args
-                    module(**input)
-                else:
-                    module(*input)
-        except NotImplementedError:
-            # We allow models that don't implement this interface
-            pass
-
-    @base_task.run_in_worker(scoped=True)
-    @staticmethod
     def check_eval_output() -> None:
         instance = globals()["model"]
         assert instance.test == "eval", "We only support checking output of an eval test. Please submit a bug report."

--- a/torchbenchmark/models/Background_Matting/metadata.yaml
+++ b/torchbenchmark/models/Background_Matting/metadata.yaml
@@ -4,3 +4,5 @@ not_implemented:
   # Disabled due to excessively slow runtime - see GH Issue #100
   - test: train
     device: cpu
+  - test: example
+    device: cpu

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -28,11 +28,13 @@ from torchbenchmark.tasks import NLP
 import torch.nn.functional as F
 
 class WrappedModule(torch.nn.Module):
-    def __init__(self, inner_module: torch.nn.Module, inner_module_forward: str):
-        self._inner_module_forward = getattr(inner_module, inner_module_forward)
+    def __init__(self, inner_module: torch.nn.Module, inner_module_forward_name: str):
+        self.model = inner_module
+        self._inner_module_forward_name = inner_module_forward_name
 
     def forward(self, inputs):
-        return self._inner_module_forward(inputs)
+        inner_module_forward = getattr(self.model, self._inner_module_forward_name)
+        return inner_module_forward(inputs)
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING

--- a/torchbenchmark/models/fambench_xlmr/__init__.py
+++ b/torchbenchmark/models/fambench_xlmr/__init__.py
@@ -29,6 +29,7 @@ import torch.nn.functional as F
 
 class WrappedModule(torch.nn.Module):
     def __init__(self, inner_module: torch.nn.Module, inner_module_forward_name: str):
+        super().__init__()
         self.model = inner_module
         self._inner_module_forward_name = inner_module_forward_name
 

--- a/torchbenchmark/models/fambench_xlmr/install.py
+++ b/torchbenchmark/models/fambench_xlmr/install.py
@@ -13,9 +13,9 @@ def update_fambench_submodule():
 def pip_install_requirements():
     try:
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
-        # pin fairseq version to 0.12.2
+        # pin fairseq version
         # ignore deps specified in requirements.txt
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-deps', 'fairseq==0.12.2'])
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-deps', 'git+https://github.com/facebookresearch/fairseq.git@ae59bd6'])
     except subprocess.CalledProcessError:
         # We ignore the ResolutionImpossible error because fairseq requires omegaconf < 2.1
         # but detectron2 requires omegaconf >= 2.1

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -125,6 +125,7 @@ class Model(BenchmarkModel):
     # Source: https://github.com/dionhaefner/pyhpc-benchmarks/blob/650ecc650e394df829944ffcf09e9d646ec69691/run.py#L25
     # Pick data-point when i = 20, size = 1048576
     DEFAULT_EVAL_BSIZE = 1048576
+    ALLOW_CUSTOMIZE_BSIZE = False
     CANNOT_SET_CUSTOM_OPTIMIZER = True
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):

--- a/torchbenchmark/models/pytorch_struct/__init__.py
+++ b/torchbenchmark/models/pytorch_struct/__init__.py
@@ -55,6 +55,7 @@ class Model(BenchmarkModel):
   # Original train batch size: 200
   # Source: https://github.com/harvardnlp/pytorch-struct/blob/f4e374e894b94a9411fb3d2dfb44201a18e37b26/notebooks/Unsupervised_CFG.ipynb
   DEFAULT_TRAIN_BSIZE = 200
+  ALLOW_CUSTOMIZE_BSIZE = False
   NUM_OF_BATCHES = 1
 
   def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):

--- a/torchbenchmark/models/torchrec_dlrm/__init__.py
+++ b/torchbenchmark/models/torchrec_dlrm/__init__.py
@@ -34,6 +34,8 @@ class Model(BenchmarkModel):
     DEFAULT_TRAIN_BSIZE = 1024
     DEFAULT_EVAL_BSIZE = 1024
     CANNOT_SET_CUSTOM_OPTIMIZER = True
+    # Deepcopy will OOM in correctness testing
+    DEEPCOPY = False
 
     def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
         super().__init__(test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -526,7 +526,7 @@ def check_accuracy(tbmodel: 'torchbenchmark.util.model.BenchmarkModel') -> str:
         torch._dynamo.reset()
         optimize_ctx = functools.partial(
             torch.compile,
-            backend=model.opt_args.torchdynamo,
+            backend=tbmodel.opt_args.torchdynamo,
         )
         try:
             model_copy = deepcopy_model(model, is_deepcopy)

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -355,7 +355,7 @@ def forward_and_backward_pass(mod, inputs, optimizer, contexts, collect_outputs=
         return collect_results(mod, pred, loss, cloned_inputs)
     return None
 
-def run_n_iterations(mod, inputs, contexts, is_training, optimizer=None, iterations=STABLENESS_CHECK_ROUNDS):
+def run_n_iterations(mod, inputs, contexts, optimizer=None, is_training=False, iterations=STABLENESS_CHECK_ROUNDS):
     def _model_iter_fn(mod, inputs, contexts, optimizer, collect_outputs):
         if is_training:
             forward_and_backward_pass(mod, inputs, contexts, optimizer, collect_outputs)
@@ -444,7 +444,7 @@ def check_accuracy(tbmodel: 'torchbenchmark.util.model.BenchmarkModel') -> str:
             clone_inputs(example_inputs),
         )
         optimizer = init_optimizer(name, current_device, model_fp64.parameters(), is_training)
-        fp64_outputs = run_n_iterations(model_fp64, inputs_fp64, contexts, optimizer)
+        fp64_outputs = run_n_iterations(model_fp64, inputs_fp64, contexts, optimizer, is_training)
     except Exception:
         log.warning(
             "fp64 golden ref were not generated for %s. Setting accuracy check to cosine",
@@ -464,7 +464,7 @@ def check_accuracy(tbmodel: 'torchbenchmark.util.model.BenchmarkModel') -> str:
             model_copy = deepcopy_model(model, is_deepcopy)
             optimizer = init_optimizer(name, current_device, model_copy.parameters(), is_training)
             correct_result = run_n_iterations(
-                model_copy, clone_inputs(example_inputs), contexts, optimizer
+                model_copy, clone_inputs(example_inputs), contexts, optimizer, is_training
             )
         except Exception as e:
             accuracy_status = (
@@ -482,7 +482,7 @@ def check_accuracy(tbmodel: 'torchbenchmark.util.model.BenchmarkModel') -> str:
             model_copy = deepcopy_model(model, is_deepcopy)
             optimizer = init_optimizer(name, current_device, model_copy.parameters(), is_training)
             correct_rerun_result = run_n_iterations(
-                model_copy, clone_inputs(example_inputs), contexts, optimizer
+                model_copy, clone_inputs(example_inputs), contexts, optimizer, is_training
             )
         except Exception as e:
             accuracy_status = (
@@ -532,7 +532,7 @@ def check_accuracy(tbmodel: 'torchbenchmark.util.model.BenchmarkModel') -> str:
             model_copy = deepcopy_model(model, is_deepcopy)
             optimizer = init_optimizer(name, current_device, model_copy.parameters(), is_training)
             optimized_model_iter_fn = optimize_ctx(run_n_iterations)
-            new_result = optimized_model_iter_fn(model_copy, example_inputs, contexts, optimizer)
+            new_result = optimized_model_iter_fn(model_copy, example_inputs, contexts, optimizer, is_training)
         except Exception as e:
             log.exception(e)
             accuracy_status = (

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -326,7 +326,7 @@ def reduce_to_scalar_loss(out):
         )
     raise NotImplementedError("Don't know how to reduce", type(out))
 
-def compute_loss(self, pred):
+def compute_loss(pred):
     return reduce_to_scalar_loss(pred)
 
 def optimizer_zero_grad(optimizer, mod):
@@ -343,7 +343,7 @@ def forward_pass(mod, inputs, contexts, _collect_outputs=True):
     with nested(*contexts):
         return mod(*inputs)
 
-def forward_and_backward_pass(mod, inputs, optimizer, contexts, collect_outputs=True):
+def forward_and_backward_pass(mod, inputs, contexts, optimizer, collect_outputs=True):
     cloned_inputs = clone_inputs(inputs)
     optimizer_zero_grad(optimizer, mod)
     with nested(*contexts):

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -22,6 +22,7 @@ UNSUPPORTED_USE_DETERMINISTIC_ALGORITHMS = [
     "Background_Matting",
     "pytorch_CycleGAN_and_pix2pix",
     "pytorch_unet",
+    "sam",
     "Super_SloMo",
     "vgg16",
 ]
@@ -64,6 +65,13 @@ REQUIRE_COSINE_TOLERACE = {
 SKIP_ACCURACY_CHECK_AS_EAGER_NON_DETERMINISTIC_MODELS = {
     # Models that deterministic algorithms can not be turned on for eager mode.
     "Background_Matting",
+    "detectron2_fasterrcnn_r_101_c4",
+    "detectron2_fasterrcnn_r_101_dc5",
+    "detectron2_fasterrcnn_r_101_fpn",
+    "detectron2_fasterrcnn_r_50_c4",
+    "detectron2_fasterrcnn_r_50_dc5",
+    "detectron2_fasterrcnn_r_50_fpn",
+    "detectron2_maskrcnn",
 }
 # Use the list from
 # https://github.com/pytorch/pytorch/blob/6c7410ddc350fea625e47744da9d6be7ec74b628/benchmarks/dynamo/torchbench.py#L382

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -135,11 +135,12 @@ def _load_deterministic_dict(determinism_dict: Dict[str, bool]):
     torch.backends.cuda.matmul.allow_tf32 = determinism_dict["torch.backends.cuda.matmul.allow_tf32"]
 
 def deterministic_run(func):
-    def _inner(**kwargs):
-        name = kwargs["model"].name
+    def _inner(*args, **kwargs):
+        name = args[0].name
         determinism_dict = _save_deterministic_dict(name)
-        func(**kwargs)
+        result = func(*args, **kwargs)
         _load_deterministic_dict(determinism_dict)
+        return result
     return _inner
 
 @deterministic_run

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -98,8 +98,8 @@ def get_model_test_metrics(model: Union[BenchmarkModel, ModelTask], metrics=[], 
         cpu_peak_mem, _device_id, gpu_peak_mem = get_peak_memory(model.invoke, device, export_metrics_file=export_metrics_file, metrics_needed=metrics, metrics_gpu_backend=metrics_gpu_backend, cpu_monitored_pid=model.worker.proc_pid())
     return TorchBenchModelMetrics(latencies, cpu_peak_mem, gpu_peak_mem)
 
-def get_model_accuracy(model_name: str, device: str, test: str, extra_args=[]) -> Optional[str]:
-    from torchbenchmark.util.experiment.instantiator import TorchBenchModelConfig, load_model_isolated
+def get_model_accuracy(model_name: str, device: str, test: str, extra_args=[], isolated: bool=True) -> str:
+    from torchbenchmark.util.experiment.instantiator import TorchBenchModelConfig, load_model_isolated, load_model
     # Try load minimal batch size, if fail, load the default batch size
     full_extra_args = ["--accuracy"] + extra_args
     accuracy_config = TorchBenchModelConfig(
@@ -110,5 +110,8 @@ def get_model_accuracy(model_name: str, device: str, test: str, extra_args=[]) -
         jit=False,
         extra_args=full_extra_args,
     )
-    model = load_model_isolated(accuracy_config)
+    if isolated:
+        model = load_model_isolated(accuracy_config)
+    else:
+        model = load_model(accuracy_config)
     return model.accuracy

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -85,7 +85,7 @@ def get_peak_memory(func, device: str, num_iter=MEMPROF_ITER, export_metrics_fil
         mem_model_analyzer.export_all_records_to_csv()
     return cpu_peak_mem, device_id, gpu_peak_mem
 
-def get_model_test_metrics(model: Union[BenchmarkModel, ModelTask], metrics= [], export_metrics_file= False, metrics_gpu_backend='nvml') -> TorchBenchModelMetrics:
+def get_model_test_metrics(model: Union[BenchmarkModel, ModelTask], metrics=[], export_metrics_file=False, metrics_gpu_backend='nvml') -> TorchBenchModelMetrics:
     latencies = None
     cpu_peak_mem = None
     gpu_peak_mem = None
@@ -97,3 +97,11 @@ def get_model_test_metrics(model: Union[BenchmarkModel, ModelTask], metrics= [],
     if 'cpu_peak_mem' in metrics or 'gpu_peak_mem' in metrics:
         cpu_peak_mem, _device_id, gpu_peak_mem = get_peak_memory(model.invoke, device, export_metrics_file=export_metrics_file, metrics_needed=metrics, metrics_gpu_backend=metrics_gpu_backend, cpu_monitored_pid=model.worker.proc_pid())
     return TorchBenchModelMetrics(latencies, cpu_peak_mem, gpu_peak_mem)
+
+def get_model_accuracy(model_name: str, extra_args=[], isolated:bool=True) -> Optional[str]:
+    from torchbenchmark.util.experiment.instantiator import load_model_isolated, load_model, TorchBenchModelConfig
+    if isolated:
+        model = load_model_isolated(model_name)
+    else:
+        model = load_model()
+    return None

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -98,10 +98,17 @@ def get_model_test_metrics(model: Union[BenchmarkModel, ModelTask], metrics=[], 
         cpu_peak_mem, _device_id, gpu_peak_mem = get_peak_memory(model.invoke, device, export_metrics_file=export_metrics_file, metrics_needed=metrics, metrics_gpu_backend=metrics_gpu_backend, cpu_monitored_pid=model.worker.proc_pid())
     return TorchBenchModelMetrics(latencies, cpu_peak_mem, gpu_peak_mem)
 
-def get_model_accuracy(model_name: str, extra_args=[], isolated:bool=True) -> Optional[str]:
-    from torchbenchmark.util.experiment.instantiator import load_model_isolated, load_model, TorchBenchModelConfig
-    if isolated:
-        model = load_model_isolated(model_name)
-    else:
-        model = load_model()
-    return None
+def get_model_accuracy(model_name: str, device: str, test: str, extra_args=[]) -> Optional[str]:
+    from torchbenchmark.util.experiment.instantiator import TorchBenchModelConfig, load_model_isolated
+    # Try load minimal batch size, if fail, load the default batch size
+    full_extra_args = ["--accuracy"] + extra_args
+    accuracy_config = TorchBenchModelConfig(
+        name=model_name,
+        device=device,
+        test=test,
+        batch_size=None,
+        jit=False,
+        extra_args=full_extra_args,
+    )
+    model = load_model_isolated(accuracy_config)
+    return model.accuracy

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -10,25 +10,6 @@ TEST_STAGE = enum.Enum('TEST_STAGE', ['FORWARD', 'BACKWARD', 'OPTIMIZER', 'ALL']
 AVAILABLE_PRECISIONS = ["fp32", "tf32", "fp16", "amp", "fx_int8", "bf16","amp_fp16", "amp_bf16"]
 QUANT_ENGINES = ["x86", "fbgemm", "qnnpack", "onednn"]
 
-def check_correctness_p(
-    model: 'torchbenchmark.util.model.BenchmarkModel',
-    opt_args: argparse.Namespace,
-    dargs: argparse.Namespace,
-) -> bool:
-    "If correctness check should be enabled."
-    # if the model doesn't support correctness check (like detectron2), skip it
-    if hasattr(model, 'SKIP_CORRECTNESS_CHECK') and model.SKIP_CORRECTNESS_CHECK:
-        return False
-    if dargs.skip_correctness:
-        return False
-    # always check correctness with torchdynamo
-    if model.dynamo:
-        return True
-    opt_args_dict = vars(opt_args)
-    for k in opt_args_dict:
-        if opt_args_dict[k]:
-            return True
-    return False
 
 def add_bool_arg(parser: argparse.ArgumentParser, name: str, default_value: bool=True):
     group = parser.add_mutually_exclusive_group(required=False)
@@ -91,6 +72,7 @@ def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', ext
     parser.add_argument("--precision", choices=AVAILABLE_PRECISIONS, default=get_precision_default(model), help=f"choose precisions from {AVAILABLE_PRECISIONS}")
     parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
     parser.add_argument("--accuracy", action="store_true", help="Check accuracy of the model only instead of running the performance test.")
+    parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
     parser.add_argument("--quant-engine", choices=QUANT_ENGINES, default='x86', help=f"choose quantization engine for fx_int8 precision from {QUANT_ENGINES}")
     dargs, opt_args = parser.parse_known_args(extra_args)
     if not check_precision(model, dargs.precision):
@@ -146,7 +128,6 @@ def parse_opt_args(model: 'torchbenchmark.util.model.BenchmarkModel', opt_args: 
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", choices=list_backends(), help="enable backends")
     parser.add_argument("--flops", choices=["fvcore", "dcgm"], help="Return the flops result")
-    parser.add_argument("--use_cosine_similarity", action='store_true', help="use cosine similarity for correctness check")
     args, extra_args = parser.parse_known_args(opt_args)
     if model.jit:
         args.backend = "torchscript"

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -90,7 +90,7 @@ def parse_decoration_args(model: 'torchbenchmark.util.model.BenchmarkModel', ext
     )
     parser.add_argument("--precision", choices=AVAILABLE_PRECISIONS, default=get_precision_default(model), help=f"choose precisions from {AVAILABLE_PRECISIONS}")
     parser.add_argument("--channels-last", action='store_true', help="enable channels-last memory layout")
-    parser.add_argument("--skip_correctness", action='store_true', help="Skip correctness checks")
+    parser.add_argument("--accuracy", action="store_true", help="Check accuracy of the model only instead of running the performance test.")
     parser.add_argument("--quant-engine", choices=QUANT_ENGINES, default='x86', help=f"choose quantization engine for fx_int8 precision from {QUANT_ENGINES}")
     dargs, opt_args = parser.parse_known_args(extra_args)
     if not check_precision(model, dargs.precision):

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -177,7 +177,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             elif self.test == "eval" and (not self.batch_size == self.DEFAULT_EVAL_BSIZE):
                 raise NotImplementedError("Model doesn't support customizing batch size.")
         elif self.dargs.accuracy:
-            self.batch_size = 1
+            self.batch_size = 4
 
     def load_metadata(self):
         relative_path = self.__class__.__module__.split(".")

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -14,7 +14,7 @@ from torchbenchmark.util.extra_args import check_correctness_p, parse_opt_args, 
                                            parse_decoration_args, apply_decoration_args, is_staged_train_test, \
                                            TEST_STAGE
 from torchbenchmark.util.env_check import set_random_seed, correctness_check, stableness_check, is_hf_model, \
-                                          save_deterministic_mode, load_deterministic_mode
+                                          save_cublas_workspace_config, load_cublas_workspace_config
 from torchbenchmark.util.fx_int8 import get_sub_module, prepare_sub_module, convert_sub_module
 
 class PostInitProcessor(type):
@@ -98,7 +98,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         ]
 
         set_random_seed()
-        self._determinism_dict = save_deterministic_mode(self.name)
+        self._cublas_workspace_config = save_cublas_workspace_config()
         # sanity checks of the options
         assert self.test == "train" or self.test == "eval", f"Test must be 'train' or 'eval', but provided {self.test}."
         # parse the args
@@ -164,7 +164,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 # get tolerance of correctness check from os.environ
                 tol = float(os.environ.get("TORCHBENCH_TOL", "1e-4"))
                 self.correctness = correctness_check(self, cos_sim=False, deepcopy=self.DEEPCOPY, tol=tol)
-        load_deterministic_mode(self._determinism_dict)
+        load_cublas_workspace_config(self._cublas_workspace_config)
         # setup distributed trainer
         if self.dargs.distributed:
             if self.dargs.distributed_wrap_fn:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -1,4 +1,3 @@
-import copy
 import importlib
 import os
 import torch

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -117,12 +117,12 @@ class BenchmarkModel(metaclass=PostInitProcessor):
     def __post__init__(self):
         # All arguments should be parsed at this point.
         assert not self.extra_args, f"Expected no unknown args at this point, found {self.extra_args}"
-        # apply decoration args
-        apply_decoration_args(self, self.dargs)
         if self.dargs.accuracy:
             self.accuracy = check_accuracy(self)
             load_deterministic_dict(self.deterministic_dict)
             return
+        # apply decoration args
+        apply_decoration_args(self, self.dargs)
         # apply optimization args
         if self.dynamo:
             from torchbenchmark.util.backends.torchdynamo import apply_torchdynamo_args


### PR DESCRIPTION
https://github.com/pytorch/benchmark/commit/c1408a3a7e50482533e82b6a705dc56ccc62174d breaks the metadata checking code.

This PR migrates the entire correctness checking code to use the version in `check_accuracy()` at https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/common.py#L1354.


Test Plan:
```
$ python run.py resnet50 -d cuda -t train --torchdynamo inductor --accuracy
/data/home/xzhao9/cluster/miniconda3/envs/py310/lib/python3.10/site-packages/torch/_inductor/compile_fx.py:123: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
  warnings.warn(
Running train method from resnet50 on cuda in dynamo inductor mode with input batch size 1 and precision fp32.
GPU Time:             17.840 milliseconds
CPU Total Wall Time:  17.869 milliseconds
GPU 0 Peak Memory:              2.1889 GB
CPU Peak Memory:                0.5010 GB
Accuracy:                            pass
PT2 Compilation time:      22.195 seconds
```