### PR TITLE
Add gpt-j-6b model into torchbench

### DIFF
--- a/torchbenchmark/models/hf_GPTJ/__init__.py
+++ b/torchbenchmark/models/hf_GPTJ/__init__.py
@@ -1,0 +1,10 @@
+from torchbenchmark.tasks import NLP
+from torchbenchmark.util.framework.huggingface.model_factory import HuggingFaceModel
+
+class Model(HuggingFaceModel):
+    task = NLP.LANGUAGE_MODELING
+    DEFAULT_TRAIN_BSIZE = 1
+    DEFAULT_EVAL_BSIZE = 1
+
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(name="hf_GPTJ", test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/hf_GPTJ/install.py
+++ b/torchbenchmark/models/hf_GPTJ/install.py
@@ -1,0 +1,14 @@
+
+import subprocess
+import sys
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()
+    patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_GPTJ/metadata.yaml
+++ b/torchbenchmark/models/hf_GPTJ/metadata.yaml
@@ -1,0 +1,13 @@
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: false
+train_deterministic: false
+not_implemented:
+  # hf_GPTJ model doesn't support JIT
+  - jit: true
+  # OOMs on torchbench CI
+  - device: cuda
+  # CPU OOM on torchbench CI
+  - device: cpu
+    test: train

--- a/torchbenchmark/models/hf_GPTJ/requirements.txt
+++ b/torchbenchmark/models/hf_GPTJ/requirements.txt
@@ -1,0 +1,2 @@
+sentencepiece
+datasets

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -15,6 +15,7 @@ class_models = {
     # 'name': (train_max_length, eval_max_length, config, model)
     'hf_GPT2': (512, 1024, 'AutoConfig.from_pretrained("gpt2")', 'AutoModelForCausalLM'),
     'hf_GPT2_large': (512, 1024, 'AutoConfig.from_pretrained("gpt2-large")', 'AutoModelForCausalLM'),
+    'hf_GPTJ': (512, 1024, 'AutoConfig.from_pretrained("EleutherAI/gpt-j-6B")', 'AutoModelForCausalLM'),
     'hf_T5': (1024, 2048, 'AutoConfig.from_pretrained("t5-small")', 'AutoModelForSeq2SeqLM'),
     'hf_T5_base': (1024, 2048, 'AutoConfig.from_pretrained("t5-base")', 'AutoModelForSeq2SeqLM'),
     'hf_T5_large': (512, 512, 'AutoConfig.from_pretrained("t5-large")', 'AutoModelForSeq2SeqLM'),


### PR DESCRIPTION
Add HF model gpt-j-6b into torchbench

Work for roadmap #1293 

```shell
$ python run.py hf_GPTJ --torchdynamo inductor
Running eval method from hf_GPTJ on cpu in dynamo inductor mode with input batch size 1 and precision fp32.
CPU Total Wall Time: 3891.941 milliseconds
CPU Peak Memory:               47.6953 GB
Correctness:                         True
PT2 Compilation time:      99.554 seconds
```