### PR TITLE
[optim][ub] always upload stats to s3+scribe

### DIFF
--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -65,6 +65,7 @@ jobs:
             --gh-issue-path gh-issue.md --errors-path errors.txt
           done
       - name: Create the github issue
+        continue-on-error: true
         if: env.TORCHBENCH_REGRESSION_DETECTED
         uses: peter-evans/create-issue-from-file@v4
         with:


### PR DESCRIPTION
I've noticed the workflows aren't creating issues because they're too long, and when that happens, nothing gets uploaded to Scribe or S3 :c 

We should continue the rest of the steps even when creating the GH issue fails.