### PR TITLE
Fix the failed unit test on A100

### DIFF
--- a/scripts/torchbench_test.sh
+++ b/scripts/torchbench_test.sh
@@ -21,4 +21,4 @@ python -m components.test.test_subprocess
 python -m components.test.test_worker
 
 # Test models
-python test.py
+python test.py -v

--- a/torchbenchmark/models/hf_GPT2_large/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2_large/metadata.yaml
@@ -11,3 +11,6 @@ not_implemented:
   # CPU OOM on torchbench CI
   - device: cpu
     test: train
+  # CPU OOM on torchbench CI
+  - device: cpu
+    test: example

--- a/torchbenchmark/models/hf_GPT2_large/metadata.yaml
+++ b/torchbenchmark/models/hf_GPT2_large/metadata.yaml
@@ -11,6 +11,6 @@ not_implemented:
   # CPU OOM on torchbench CI
   - device: cpu
     test: train
-  # CPU OOM on torchbench CI
+  # CPU OOM on torchbench CI accuracy
   - device: cpu
     test: example

--- a/torchbenchmark/models/hf_T5_base/metadata.yaml
+++ b/torchbenchmark/models/hf_T5_base/metadata.yaml
@@ -8,3 +8,6 @@ not_implemented:
   - jit: true
   # disable train test because of CI infra capacity issue
   - test: train
+  # CPU OOM on torchbench CI accuracy
+  - device: cpu
+    test: example


### PR DESCRIPTION
Print detailed test info in unit testing.
Skip tests failed because of CPU OOM.