### PR TITLE
Add throughputs metric and enable in cpu userbenchmark

### DIFF
--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -40,6 +40,7 @@ All parameters of `cpu` userbenchmark as below,
   executing `python -m torch.backends.xeon.run_cpu --help`, or check the source
   code in
   [here](https://github.com/pytorch/pytorch/blob/main/torch/backends/xeon/run_cpu.py).
+  Default value is `--throughput-mode`.
 - `--dryrun` whether dryrun the userbenchmark command.
 
 Besides those parameters provided by the `cpu` userbenchmark directly, user also

--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -27,7 +27,8 @@ All parameters of `cpu` userbenchmark as below,
 - `--jit` whether to convert and run the model with `jit` mode.
 - `--config, -c` YAML config to specify tests to run.
 - `--metrics` benchmark metrics, split by comma. Current support metrics
-  including `latencies` and `cpu_peak_mem`, default value is `latencies`.
+  including `latencies`, `throughputs` and `cpu_peak_mem`, default value is
+  `latencies`.
 - `--output, -o` output dir. By default will create folder under
   `.userbenchmark/cpu`.
 - `--timeout` limit single model test run time. Default `None` means no

--- a/userbenchmark/cpu/cpu_utils.py
+++ b/userbenchmark/cpu/cpu_utils.py
@@ -27,7 +27,7 @@ class add_path():
             pass
 
 def list_metrics() -> List[str]:
-    return ["latencies", "cpu_peak_mem"]
+    return ["latencies", "throughputs", "cpu_peak_mem"]
 
 def parse_str_to_list(candidates):
     if isinstance(candidates, list):
@@ -98,16 +98,22 @@ def add_test_results(runs, result_metrics):
         ins_number = len(run["results"])
         assert ins_number
         latency_metric = "latency" in run["results"][0]["metrics"]
+        throughput_metric = "throughput" in run["results"][0]["metrics"]
         cmem_metric = "cpu_peak_mem" in run["results"][0]["metrics"]
         latency_sum = 0
+        throughput_sum = 0
         cmem_sum = 0
         for ins_res in run["results"]: 
             if latency_metric:           
                 latency_sum += ins_res["metrics"]["latency"]
+            if throughput_metric:
+                throughput_sum += ins_res["metrics"]["throughput"]
             if cmem_metric:
                 cmem_sum += ins_res["metrics"]["cpu_peak_mem"]
         if latency_metric:
             result_metrics[f"{run_base_name}_latency"] = latency_sum / ins_number
+        if throughput_metric:
+            result_metrics[f"{run_base_name}_throughput"] = throughput_sum
         if cmem_metric:
             result_metrics[f"{run_base_name}_cmem"] = cmem_sum / ins_number
     return result_metrics

--- a/userbenchmark/cpu/run.py
+++ b/userbenchmark/cpu/run.py
@@ -75,7 +75,7 @@ def parse_args(args):
     parser.add_argument("--output", "-o", default=None, help="Output dir.")
     parser.add_argument("--timeout", default=None, help="Limit single model test run time. Default None, means no limitation.")
     parser.add_argument("--launcher", action="store_true", help="Use torch.backends.xeon.run_cpu to get the peak performance on Intel(R) Xeon(R) Scalable Processors.")
-    parser.add_argument("--launcher-args", default=None, help="Provide the args of torch.backends.xeon.run_cpu. See `python -m torch.backends.xeon.run_cpu --help`")
+    parser.add_argument("--launcher-args", default="--throughput-mode", help="Provide the args of torch.backends.xeon.run_cpu. See `python -m torch.backends.xeon.run_cpu --help`")
     parser.add_argument("--dryrun", action="store_true", help="Dryrun the command.")
     return parser.parse_known_args(args)
 


### PR DESCRIPTION
Add throughputs metric in torchbench model metrics, enable throughputs metric in cpu userbenchmark.

Work for roadmap #1293 to add fps-like report in cpu userbenchmark.