### PR TITLE
Print complete traceback if unit test model import error.

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -289,6 +289,7 @@ class ModelTask(base_task.TaskBase):
     def _maybe_import_model(package: str, model_path: str) -> Dict[str, Any]:
         import importlib
         import os
+        import traceback
 
         model_name = os.path.basename(model_path)
         diagnostic_msg = ""
@@ -302,8 +303,8 @@ class ModelTask(base_task.TaskBase):
                 Model.name = model_name
 
         except ModuleNotFoundError as e:
-            Model = None
-            diagnostic_msg = f"Warning: Could not find dependent module {e.name} for Model {model_name}, skip it"
+            traceback.print_exc()
+            exit(-1)
 
         # Populate global namespace so subsequent calls to worker.run can access `Model`
         globals()["Model"] = Model


### PR DESCRIPTION
Fixes https://github.com/pytorch/benchmark/issues/1663

```
$ pip uninstall -y gym && python test.py -k "test_soft_actor_critic_eval_cpu"
SystemExit: -1

    working_dir: /var/folders/8w/tq7g1d094j7212pssdmrqp3w0000gn/T/tmpjyv14j94
Print complete traceback if unit test model import error.
    stdout:
        [2023-06-20] 13:00:44.338347: TIMER_SUBPROCESS_BEGIN_EXEC
        [2023-06-20] 13:00:44.450683: TIMER_SUBPROCESS_FAILED
        [2023-06-20] 13:00:44.450802: TIMER_SUBPROCESS_FINISHED
        [2023-06-20] 13:00:44.450834: TIMER_SUBPROCESS_BEGIN_READ

    stderr:
        Traceback (most recent call last):
          File "<subprocess-worker>", line 15, in _run_in_worker_f
          File "/Users/xzhao9/miniconda3/envs/py38/lib/python3.8/importlib/__init__.py", line 127, in import_module
            return _bootstrap._gcd_import(name[level:], package, level)
          File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
          File "<frozen importlib._bootstrap>", line 991, in _find_and_load
          File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
          File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
          File "<frozen importlib._bootstrap_external>", line 843, in exec_module
          File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
          File "/Users/xzhao9/git/benchmark/torchbenchmark/models/soft_actor_critic/__init__.py", line 13, in <module>
            from .envs import load_gym
          File "/Users/xzhao9/git/benchmark/torchbenchmark/models/soft_actor_critic/envs.py", line 6, in <module>
            import gym
        ModuleNotFoundError: No module named 'gym'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test.py", line 97, in eval_fn
    task = ModelTask(path, timeout=TIMEOUT)
  File "/Users/xzhao9/git/benchmark/torchbenchmark/__init__.py", line 266, in __init__
    **self._maybe_import_model(
  File "/Users/xzhao9/git/benchmark/components/_impl/tasks/base.py", line 275, in inner
    self.worker.run(src)
  File "/Users/xzhao9/git/benchmark/components/_impl/workers/subprocess_worker.py", line 155, in run
    self._run(snippet)
  File "/Users/xzhao9/git/benchmark/components/_impl/workers/subprocess_worker.py", line 320, in _run
    subprocess_rpc.SerializedException.raise_from(
  File "/Users/xzhao9/git/benchmark/components/_impl/workers/subprocess_rpc.py", line 458, in raise_from
    raise e from ChildTraceException(traceback_str)
components._impl.workers.subprocess_rpc.UnserializableException: ("<class 'SystemExit'>", '(-1,)')

----------------------------------------------------------------------
Ran 1 test in 2.757s

```