### PR TITLE
[optim][ub] Fix leftover __init__ to run rename mishap in userbenchmark/optim

### DIFF
--- a/userbenchmark/optim/run_optim_benchmarks.py
+++ b/userbenchmark/optim/run_optim_benchmarks.py
@@ -54,10 +54,8 @@ def main() -> None:
            f'{OUTPUT_DIR} must be empty or nonexistent. Its contents will be wiped by this script.'
 
     # Run benchmarks in subprocesses to take isolate contexts and memory
-    print(args.models)
-    print(args.devices)
     for m, d in itertools.product(args.models, args.devices):
-        command = [sys.executable, '-m', 'userbenchmark.optim.__init__', '--continue-on-error',
+        command = [sys.executable, '-m', 'userbenchmark.optim.run', '--continue-on-error',
                    '--output-dir', OUTPUT_DIR, '--models', m, '--devices', d] + optim_bm_args
         # Use check=True to force this process to go serially since our capacity
         # only safely allows 1 model at a time

--- a/userbenchmark/optim/run_optim_benchmarks.py
+++ b/userbenchmark/optim/run_optim_benchmarks.py
@@ -54,6 +54,8 @@ def main() -> None:
            f'{OUTPUT_DIR} must be empty or nonexistent. Its contents will be wiped by this script.'
 
     # Run benchmarks in subprocesses to take isolate contexts and memory
+    print(args.models)
+    print(args.devices)
     for m, d in itertools.product(args.models, args.devices):
         command = [sys.executable, '-m', 'userbenchmark.optim.__init__', '--continue-on-error',
                    '--output-dir', OUTPUT_DIR, '--models', m, '--devices', d] + optim_bm_args


### PR DESCRIPTION
2 weeks ago, when working on the bisection tool, Xu had rewritten infra and moved code from __init__.py to run.py in optim benchmarks. This caused a 2 week long "sev" where no benchmarks were running cuz the run_optim_benchmarks script was not updated. The first failing instance: https://github.com/pytorch/benchmark/actions/runs/5195849856

This PR just updates it to allow the benchmarks to run again.