### PR TITLE
Add dependency boto3 to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install --pre torch torchvision torchtext torchaudio -i https://download.pyt
 
 Install other necessary libraries:
 ```
-pip install pyyaml
+pip install boto3 pyyaml
 ```
 
 Install the benchmark suite, which will recursively install dependencies for all the models.  Currently, the repo is intended to be installed from the source tree.


### PR DESCRIPTION
There is an import error for `boto3` for a new install. This dependency has been added to https://github.com/pytorch/benchmark/blob/2b9de6b084b8da25bea45faf74ae267c374eb9ee/scripts/install_conda.sh#L11

and other places but missed in readme.