### PR TITLE
Add boto3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 accelerate
+boto3
 bs4
 patch
 py-cpuinfo


### PR DESCRIPTION
This PR adds boto3 to the requirements.txt as install.py will error out without it installed.

The README.md list boto3 and pyyaml as packages to be installed before running, but requirements.txt only has pyyaml in the list