### PR TITLE
Add Falcon-7B HuggingFace model

### DIFF
--- a/torchbenchmark/models/hf_Falcon_7b/__init__.py
+++ b/torchbenchmark/models/hf_Falcon_7b/__init__.py
@@ -1,0 +1,10 @@
+from torchbenchmark.tasks import NLP
+from torchbenchmark.util.framework.huggingface.model_factory import HuggingFaceModel
+
+class Model(HuggingFaceModel):
+    task = NLP.LANGUAGE_MODELING
+    DEFAULT_TRAIN_BSIZE = 4
+    DEFAULT_EVAL_BSIZE = 1
+
+    def __init__(self, test, device, jit=False, batch_size=None, extra_args=[]):
+        super().__init__(name="hf_Falcon_7b", test=test, device=device, jit=jit, batch_size=batch_size, extra_args=extra_args)

--- a/torchbenchmark/models/hf_Falcon_7b/install.py
+++ b/torchbenchmark/models/hf_Falcon_7b/install.py
@@ -1,0 +1,14 @@
+
+import subprocess
+import sys
+import os
+from torchbenchmark.util.framework.huggingface.patch_hf import patch_transformers, cache_model
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()
+    patch_transformers()
+    model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
+    cache_model(model_name)

--- a/torchbenchmark/models/hf_Falcon_7b/install.py
+++ b/torchbenchmark/models/hf_Falcon_7b/install.py
@@ -11,4 +11,4 @@ if __name__ == '__main__':
     pip_install_requirements()
     patch_transformers()
     model_name = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
-    cache_model(model_name)
+    cache_model(model_name, trust_remote_code=True)

--- a/torchbenchmark/models/hf_Falcon_7b/metadata.yaml
+++ b/torchbenchmark/models/hf_Falcon_7b/metadata.yaml
@@ -1,0 +1,10 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 16
+eval_benchmark: false
+eval_deterministic: false
+eval_nograd: true
+not_implemented:
+- jit: true
+train_benchmark: false
+train_deterministic: false

--- a/torchbenchmark/models/hf_Falcon_7b/requirements.txt
+++ b/torchbenchmark/models/hf_Falcon_7b/requirements.txt
@@ -1,0 +1,2 @@
+sentencepiece
+datasets

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -27,6 +27,7 @@ class_models = {
     'hf_Bert': (512, 512, 'BertConfig()', 'AutoModelForMaskedLM'),
     # see https://huggingface.co/bert-large-cased
     'hf_Bert_large': (512, 512, 'BertConfig(hidden_size=1024, num_hidden_layers=24, num_attention_heads=16)', 'AutoModelForMaskedLM'),
+    'hf_Falcon_7b' : (512, 512, 'AutoConfig.from_pretrained("tiiuae/falcon-7b")', 'AutoModelForCausalLM')
 }
 
 cpu_input_slice = {

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -27,7 +27,7 @@ class_models = {
     'hf_Bert': (512, 512, 'BertConfig()', 'AutoModelForMaskedLM'),
     # see https://huggingface.co/bert-large-cased
     'hf_Bert_large': (512, 512, 'BertConfig(hidden_size=1024, num_hidden_layers=24, num_attention_heads=16)', 'AutoModelForMaskedLM'),
-    'hf_Falcon_7b' : (512, 512, 'AutoConfig.from_pretrained("tiiuae/falcon-7b")', 'AutoModelForCausalLM')
+    'hf_Falcon_7b' : (512, 512, 'AutoConfig.from_pretrained("tiiuae/falcon-7b", trust_remote_code=True)', 'AutoModelForCausalLM'),
 }
 
 cpu_input_slice = {

--- a/torchbenchmark/util/framework/huggingface/patch_hf.py
+++ b/torchbenchmark/util/framework/huggingface/patch_hf.py
@@ -6,14 +6,13 @@ import subprocess
 import sys
 from .model_factory import class_models
 from transformers import AutoConfig, ReformerConfig, BigBirdConfig, BertConfig
-
 PATCH_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "patches")
 
-def cache_model(name: str):
+def cache_model(name: str, **kwargs):
     import transformers
     model_config = eval(class_models[name][2])
     model_ctor = getattr(transformers, class_models[name][3])
-    model_ctor.from_config(model_config)
+    model_ctor.from_config(model_config, **kwargs)
 
 def patch_transformers():
     import transformers

--- a/torchbenchmark/util/framework/huggingface/patch_hf.py
+++ b/torchbenchmark/util/framework/huggingface/patch_hf.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from .model_factory import class_models
 from transformers import AutoConfig, ReformerConfig, BigBirdConfig, BertConfig
+
 PATCH_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "patches")
 
 def cache_model(name: str, **kwargs):


### PR DESCRIPTION
This PR adds two features to torchbenchmark:

1. Include [tiiuae/falcon-7b model from HuggingFace](https://huggingface.co/tiiuae/falcon-7b) in torchbenchmark suite.
2. Include code path to pass arguments from model's `__init__.py` into model constructor during benchmarking. **Running Falcon-7B in HuggingFace requires the parameter `trust_remote_code` to be passed**. 
    - There are two files that are executed when Falcon is loaded: [configuration_RW](https://huggingface.co/tiiuae/falcon-7b/blob/main/configuration_RW.py) and [modelling_RW](https://huggingface.co/tiiuae/falcon-7b/blob/main/modelling_RW.py) that both contain what seem to be safe code related to modeling specifics.