### PR TITLE
Fix require_grad typo

### DIFF
--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/model/embedding/position.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/model/embedding/position.py
@@ -10,7 +10,7 @@ class PositionalEmbedding(nn.Module):
 
         # Compute the positional encodings once in log space.
         pe = torch.zeros(max_len, d_model).float()
-        pe.require_grad = False
+        pe.requires_grad = False
 
         position = torch.arange(0, max_len).float().unsqueeze(1)
         div_term = (torch.arange(0, d_model, 2).float() * -(math.log(10000.0) / d_model)).exp()

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/model/embedding/position.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/model/embedding/position.py
@@ -10,6 +10,7 @@ class PositionalEmbedding(nn.Module):
 
         # Compute the positional encodings once in log space.
         pe = torch.zeros(max_len, d_model).float()
+        # Changed from upstream, see https://github.com/codertimo/BERT-pytorch/pull/104
         pe.requires_grad = False
 
         position = torch.arange(0, max_len).float().unsqueeze(1)


### PR DESCRIPTION
Fix require_grad typos (should be requires_grad).
Before the fix, the code doesn't cause any errors but doesn't do what it's supposed to do.

Fixed with TorchFix https://github.com/pytorch/test-infra/tree/main/tools/torchfix

Upstream PR: https://github.com/codertimo/BERT-pytorch/pull/104