### PR TITLE
[optim] fix regression detector after #1710

### DIFF
--- a/regression_detector.py
+++ b/regression_detector.py
@@ -50,8 +50,8 @@ def get_default_output_path(bm_name: str) -> str:
     return os.path.join(output_path, fname)
 
 def generate_regression_result(control: Dict[str, Any], treatment: Dict[str, Any]) -> TorchBenchABTestResult:
-    def _call_userbenchmark_detector(detector, start_file: str, end_file: str) -> TorchBenchABTestResult:
-        return detector(start_file, end_file)
+    def _call_userbenchmark_detector(detector, control: Dict[str, Any], treatment: Dict[str, Any]) -> TorchBenchABTestResult:
+        return detector(control, treatment)
     assert control["name"] == treatment["name"], f'Expected the same userbenchmark name from metrics files, \
                                                 but getting {control["name"]} and {treatment["name"]}.'
     bm_name = control["name"]

--- a/userbenchmark/optim/regression_detector.py
+++ b/userbenchmark/optim/regression_detector.py
@@ -16,7 +16,8 @@ def run(control, treatment) -> Optional[TorchBenchABTestResult]:
             # Trigger on BOTH slowdowns and speedups
             if abs(delta) > DEFAULT_REGRESSION_DELTA_THRESHOLD:
                 details[control_metric_name] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
-    return TorchBenchABTestResult(control_env=control_env, \
-                                  treatment_env=treatment_env, \
-                                  details=details, \
-                                  bisection=None)
+    # control_only_metrics/treatment_only_metrics will be filled in later by the main regression detector
+    return TorchBenchABTestResult(name=control["name"],
+                                  control_env=control_env,
+                                  treatment_env=treatment_env,
+                                  details=details)

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -49,8 +49,8 @@ class TorchBenchABTestResult:
     control_env: Dict[str, str]
     treatment_env: Dict[str, str]
     details: Dict[str, TorchBenchABTestMetric]
-    control_only_metrics: Dict[str, float]
-    treatment_only_metrics: Dict[str, float]
+    control_only_metrics: Dict[str, float] = {}
+    treatment_only_metrics: Dict[str, float] = {}
     # the repository to bisect, default to "pytorch"
     bisection: str = "pytorch"
     # can be "abtest" or "bisect"


### PR DESCRIPTION
1. Fix longstanding issue where the optim benchmarks weren't able to calculate regressions
2. Fix type annotations to be correct
3. Add {} as default for the *_only_metrics.