### PR TITLE
Update `detectron2` to fix Pillow errors

### DIFF
--- a/torchbenchmark/util/framework/detectron2/requirements.txt
+++ b/torchbenchmark/util/framework/detectron2/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/facebookresearch/detectron2.git@c470ca3
+git+https://github.com/facebookresearch/detectron2.git@57bdb21
 omegaconf==2.1.1
 numpy


### PR DESCRIPTION
As reported in https://github.com/facebookresearch/detectron2/issues/5010, `PIL.Image.LINEAR` no longer exists.

The Pillow requirement in `detectron2` isn't pinned, so old `detectron2` is installing the latest Pillow and causing errors in the TorchBench tests.