### PR TITLE
Make `test.py` device agnostic

### DIFF
--- a/test.py
+++ b/test.py
@@ -123,6 +123,8 @@ def _load_tests():
         devices.append('cuda')
     if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
         devices.append('mps')
+    if device := os.getenv('ACCELERATOR'):
+        devices.append(device)
 
     for path in _list_model_paths():
         # TODO: skipping quantized tests for now due to BC-breaking changes for prepare

--- a/test.py
+++ b/test.py
@@ -20,10 +20,10 @@ from torchbenchmark.util.metadata_utils import skip_by_metadata
 # Some of the models have very heavyweight setup, so we have to set a very
 # generous limit. That said, we don't want the entire test suite to hang if
 # a single test encounters an extreme failure, so we give up after a test is
-# unresponsive to 5 minutes. (Note: this does not require that the entire
-# test case completes in 5 minutes. It requires that if the worker is
+# unresponsive to 5 minutes by default. (Note: this does not require that the
+# entire test case completes in 5 minutes. It requires that if the worker is
 # unresponsive for 5 minutes the parent will presume it dead / incapacitated.)
-TIMEOUT = 300  # Seconds
+TIMEOUT = int(os.getenv("TIMEOUT", 300))  # Seconds
 
 class TestBenchmark(unittest.TestCase):
 

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -295,6 +295,8 @@ class ModelTask(base_task.TaskBase):
         diagnostic_msg = ""
         try:
             module = importlib.import_module(f'.models.{model_name}', package=package)
+            if accelerator_backend := os.getenv("ACCELERATOR_BACKEND"):
+                setattr(module, accelerator_backend, importlib.import_module(accelerator_backend))
             Model = getattr(module, 'Model', None)
             if Model is None:
                 diagnostic_msg = f"Warning: {module} does not define attribute Model, skip it"

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -162,10 +162,8 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 assert current_device_name, f"torch.cuda.get_device_name() returns None when device is set to cuda, please double check."
                 if current_device_name in SPECIAL_DEVICE_MAPPING:
                     current_device_name = SPECIAL_DEVICE_MAPPING[current_device_name]
-            elif self.device == "cpu":
-                current_device_name = "cpu"
-            elif self.device == "mps":
-                current_device_name = "mps"
+            else:
+                current_device_name = str(self.device)
             # use the device suggestion on CUDA inference tests, key should be either eval_batch_size or train_batch_size
             device_batch_size_key = f"{self.test}_batch_size"
             if self.metadata and "devices" in self.metadata and current_device_name in self.metadata["devices"] \


### PR DESCRIPTION
Allows the user to specify an arbitrary device and an arbitrary backend import using environment variables. The three added environment variables are:
- `TIMEOUT` - allows the timeout to be configured to suit the characteristics of the arbitrary device
- `ACCELERATOR` - a string which is added to the devices list, just like `'cpu'`, `'cuda'` & `'mps'` currently are
- `ACCELERATOR_BACKEND` - a string which is the name of the backend package (which doesn't yet exist in upstream `torch`) needed to use `ACCELERATOR`

These environment variables are used as follows:
```
TIMEOUT=100 ACCELERATOR=my_accelerator ACCELERATOR_BACKEND=my_accelerator_backend \
    python test.py -k "test_hf_Bert_check_device_my_accelerator"
```