### PR TITLE
[bisector] checkout submodule one more time

### DIFF
--- a/utils/gitutils.py
+++ b/utils/gitutils.py
@@ -163,6 +163,8 @@ def update_git_repo(repo: str, branch: str="main") -> bool:
         subprocess.check_call(command, cwd=repo, shell=False)
         command = ["git", "checkout", "--recurse-submodules", branch]
         subprocess.check_call(command, cwd=repo, shell=False)
+        command = ["git", "submodule", "update", "--init", "--recursive"]
+        subprocess.check_call(command, cwd=repo, shell=False)
         return True
     except subprocess.CalledProcessError:
         # Sleep 5 seconds for concurrent git process, remove the index.lock file if exists, and try again
@@ -177,6 +179,8 @@ def update_git_repo(repo: str, branch: str="main") -> bool:
             command = ["git", "pull"]
             subprocess.check_call(command, cwd=repo, shell=False)
             command = ["git", "checkout", "--recurse-submodules", branch]
+            subprocess.check_call(command, cwd=repo, shell=False)
+            command = ["git", "submodule", "update", "--init", "--recursive"]
             subprocess.check_call(command, cwd=repo, shell=False)
             return True
         except subprocess.CalledProcessError:


### PR DESCRIPTION
To be safe, checkout the submodule code one more time after we checkout the bisection commit.

- [x] Test workflow (2023-06-29): https://github.com/pytorch/benchmark/actions/runs/5751991174, issue  https://github.com/pytorch/benchmark/issues/1748
- [x] Test workflow 2 (2023-07-08): https://github.com/pytorch/benchmark/actions/runs/5755031881, test issue: https://github.com/pytorch/benchmark/issues/1756
- [x] Test workflow 3 (2023-07-09): https://github.com/pytorch/benchmark/actions/runs/5755090470, test issue: https://github.com/pytorch/benchmark/issues/1757
- [x] Test workflow 4 (2023-08-03): https://github.com/pytorch/benchmark/actions/runs/5755093211, test issue: https://github.com/pytorch/benchmark/issues/1809
- [ ] Test workflow 5 (2023-07-07): https://github.com/pytorch/benchmark/actions/runs/5757420895, test issue: https://github.com/pytorch/benchmark/issues/1754