### PR TITLE
fix the version of opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml
 # pytorch build script pins numpy version
 # https://github.com/pytorch/builder/blob/ae5c82e65cb3d8bac6df50e742a195019af91ad3/wheel/build_wheel.sh#L145
 numpy==1.21.2
-# https://github.com/pytorch/benchmark/tree/opencv-python-compatibility
+# https://github.com/opencv/opencv-python/issues/885
 opencv-python==4.7.0.72
 # Need https://github.com/kornia/kornia/commit/53808e5 to work on PyTorch nightly
 git+https://github.com/kornia/kornia.git@b7050c3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyyaml
 # pytorch build script pins numpy version
 # https://github.com/pytorch/builder/blob/ae5c82e65cb3d8bac6df50e742a195019af91ad3/wheel/build_wheel.sh#L145
 numpy==1.21.2
+# https://github.com/pytorch/benchmark/tree/opencv-python-compatibility
 opencv-python==4.7.0.72
 # Need https://github.com/kornia/kornia/commit/53808e5 to work on PyTorch nightly
 git+https://github.com/kornia/kornia.git@b7050c3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyyaml
 # pytorch build script pins numpy version
 # https://github.com/pytorch/builder/blob/ae5c82e65cb3d8bac6df50e742a195019af91ad3/wheel/build_wheel.sh#L145
 numpy==1.21.2
+opencv-python==4.7.0.72
 # Need https://github.com/kornia/kornia/commit/53808e5 to work on PyTorch nightly
 git+https://github.com/kornia/kornia.git@b7050c3
 scipy # for lazy_bench.py


### PR DESCRIPTION
According to the [upstream issue](https://github.com/opencv/opencv-python/issues/885), opencv-python has a compatibility problem with numpy. Since we fixed the numpy version in the requirements.txt, we also need to fix the opencv-python's verison too. I install the nightly Torch and TorchBench, there is an TorchBench installation error same with the above issue with opencv-python 4.8. But opencv-python 4.7.0.72 works well. I think we'd better fix its version until the latest opencv-python 4.9.0 released.