### PR TITLE
Disable scheduled running distributed CI

### DIFF
--- a/.github/workflows/userbenchmark-ai-cluster.yml
+++ b/.github/workflows/userbenchmark-ai-cluster.yml
@@ -1,9 +1,5 @@
 name: TorchBench Userbenchmark on AI Cluster
 on:
-  schedule:
-    # on the AI cluster, the cron job runs at 8 PM UTC
-    # we expect the result to be available at 10 PM UTC
-    - cron: '0 22 * * *' # run at 10 PM UTC
   workflow_dispatch:
     inputs:
 


### PR DESCRIPTION
We are migrating away from AWS Cluster, so disabling the distributed CI.