### PR TITLE
[optim][ub] Distinguish compile time from run time

### DIFF
--- a/userbenchmark/optim/regression_detector.py
+++ b/userbenchmark/optim/regression_detector.py
@@ -2,6 +2,7 @@ from typing import Optional
 from ..utils import TorchBenchABTestResult, TorchBenchABTestMetric
 
 DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.3
+COMPILE_TIME_REGRESSION_DELTA_THRESHOLD = 2.0
 
 def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     control_env = control["environ"]
@@ -11,10 +12,11 @@ def run(control, treatment) -> Optional[TorchBenchABTestResult]:
     details = {}
     for control_metric_name, control_metric in control_metrics.items():
         if control_metric_name in treatment_metrics:
+            regression_threshold = COMPILE_TIME_REGRESSION_DELTA_THRESHOLD if "compile_time" in control_metric_name else DEFAULT_REGRESSION_DELTA_THRESHOLD
             treatment_metric = treatment_metrics[control_metric_name]
             delta = (treatment_metric - control_metric) / control_metric
             # Trigger on BOTH slowdowns and speedups
-            if abs(delta) > DEFAULT_REGRESSION_DELTA_THRESHOLD:
+            if abs(delta) > regression_threshold:
                 details[control_metric_name] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
     # control_only_metrics/treatment_only_metrics will be filled in later by the main regression detector
     return TorchBenchABTestResult(name=control["name"],


### PR DESCRIPTION
This PR teases out the compile time and run time to track two numbers, where previously, the metrics measured e2e compile+runtime.

SGD with foreach, momentum, CUDA on pt2 today takes ~2.36s on average. I anticipate the runtime to be close to that after this change still, whereas the compile time will be a separate much larger value.

Current results:
<img width="1369" alt="image" src="https://github.com/pytorch/benchmark/assets/31798555/16d366da-3361-4540-a2a2-bc22f51965e6">


The metrics dictionary used to have entries like:
```
{
    "name": "optim",
    "environ": {
        "pytorch_git_version": "c527d0fadd27595ba2f98dd0f57aae5c56658d71"
    },
    "metrics": {
        "resnet18, Adam, cuda, (pt2) default": 0.0018993107215413507,
        "resnet18, Adam, cuda, default": 0.0010943956114351748,
        "resnet18, Adam, cuda, (pt2) amsgrad, maximize": 0.002033790648736135,
        "resnet18, Adam, cuda, amsgrad, maximize": 0.0013529009232297541,
        "resnet18, Adam, cuda, (pt2) no_foreach": 0.005578947072434757,
        ...
    }
}
```

But now, the keys will contain "compile_time" at the beginning if we're measuring compile time:
```
{
    "name": "optim",
    "environ": {
        "pytorch_git_version": "a005f70a4284152e00c8f6603feaf4ab9636f6aa"
    },
    "metrics": {
        "resnet18, SGD, cuda, (pt2) no_foreach": 0.0017500566132366657,
        "resnet18, SGD, cuda, no_foreach": 0.0025729038193821907,
        "resnet18, SGD, cuda, (pt2) foreach": 0.0017613966017961502,
        ...
        "resnet18, SGD, cpu, foreach, momentum=0.9": 0.08240865767002106,
        "compile_time, resnet18, SGD, cuda, (pt2) no_foreach": 14.877577589824796,
        "compile_time, resnet18, SGD, cuda, (pt2) foreach": 0.6698574535548687,
        "compile_time, resnet18, SGD, cuda, (pt2) foreach, momentum=0.9, nesterov": 0.32723781156043213,
        ...
        "compile_time, resnet18, SGD, cpu, (pt2) foreach, momentum=0.9": 0.29321490600705147
    }
}
```

