### PR TITLE
Fix doctr model build failure

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -13,7 +13,8 @@ RUN sudo apt-get -y update && sudo apt -y update
 RUN sudo apt-get install -y git jq \
                             vim wget curl ninja-build cmake \
                             libgl1-mesa-glx libsndfile1-dev kmod libxml2-dev libxslt1-dev \
-                            fontconfig libfontconfig1-dev
+                            fontconfig libfontconfig1-dev \
+                            libpango-1.0-0 libpangoft2-1.0-0
 
 # get switch-cuda utility
 RUN sudo wget -q https://raw.githubusercontent.com/phohenecker/switch-cuda/master/switch-cuda.sh -O /usr/bin/switch-cuda.sh

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -112,6 +112,10 @@ def install_torch_build_deps(cuda_version: str):
     subprocess.check_call(cmd)
 
 def install_torchbench_deps():
+    # weasyprint requires ffi7, which requires glib > 2.69 on ubuntu 20.04
+    conda_deps = ["glib"]
+    cmd = ["conda", "install", "-y"] + conda_deps
+    subprocess.check_call(cmd)
     cmd = ["pip", "install", "unittest-xml-reporting", "boto3"]
     subprocess.check_call(cmd)
 


### PR DESCRIPTION
We need to upgrade the glib version from conda to make the weasyprint package compatible.