### PR TITLE
Disable Deepcopy on stable_diffusion_unet.

### DIFF
--- a/torchbenchmark/models/stable_diffusion_unet/__init__.py
+++ b/torchbenchmark/models/stable_diffusion_unet/__init__.py
@@ -17,6 +17,8 @@ class Model(BenchmarkModel, HuggingFaceAuthMixin):
     DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
     ALLOW_CUSTOMIZE_BSIZE = False
+    # Skip deepcopy because it will oom on A100 40GB
+    DEEPCOPY = False
     # Default eval precision on CUDA device is fp16
     DEFAULT_EVAL_CUDA_PRECISION = "fp16"
 

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -71,6 +71,7 @@ SKIP_ACCURACY_CHECK_AS_EAGER_NON_DETERMINISTIC_MODELS = {
     "detectron2_fasterrcnn_r_50_dc5",
     "detectron2_fasterrcnn_r_50_fpn",
     "detectron2_maskrcnn",
+    "stable_diffusion_unet",
 }
 # Use the list from
 # https://github.com/pytorch/pytorch/blob/6c7410ddc350fea625e47744da9d6be7ec74b628/benchmarks/dynamo/torchbench.py#L382


### PR DESCRIPTION
Fix the A100 CI broken because of stable_diffusion_unet accuracy check OOM.