### PR TITLE
Rename aot_runtime to aoti_runtime

### DIFF
--- a/userbenchmark/dynamo/common.py
+++ b/userbenchmark/dynamo/common.py
@@ -1134,7 +1134,7 @@ class AOTInductorModelCache:
 
             # Use a utility function for easier benchmarking
             source = """
-            #include <torch/csrc/inductor/aot_runtime/model.h>
+            #include <torch/csrc/inductor/aoti_runtime/model.h>
 
             torch::aot_inductor::AOTInductorModel model;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/110007

Make the naming more explicit

Differential Revision: D49593528


