### PR TITLE
[optim][ub] disable PT2 benchmarks until we investigate the noisy reports

### DIFF
--- a/userbenchmark/optim/run.py
+++ b/userbenchmark/optim/run.py
@@ -60,7 +60,7 @@ DEVICES: List[str] = ['cuda', 'cpu']
 
 OPTIM_NAMES = [o.__name__ for o in [Adadelta, Adagrad, Adam, AdamW, Adamax, ASGD, SGD, RAdam, Rprop, RMSprop, NAdam, SparseAdam]]
 
-FUNC_STRS = ['pt2_' , '']
+FUNC_STRS = ['']
 
 OPTIMIZERS = [
     (Adadelta, {}),


### PR DESCRIPTION
There have been many reports lately and they're not very actionable. It is time to actually investigate them instead of creating more issues every night. Until we investigate, the stats are noisy and not useful anyway.