### PR TITLE
Checkout repo submodules recursively

### DIFF
--- a/utils/gitutils.py
+++ b/utils/gitutils.py
@@ -137,6 +137,8 @@ def checkout_git_commit(repo: str, commit: str) -> bool:
         cleanup_local_changes(repo)
         command = ["git", "checkout", "--recurse-submodules", commit]
         subprocess.check_call(command, cwd=repo, shell=False)
+        command = ["git", "submodule", "update", "--init", "--recursive"]
+        subprocess.check_call(command, cwd=repo, shell=False)
         return True
     except subprocess.CalledProcessError:
         # Sleep 5 seconds for concurrent git process, remove the index.lock file if exists, and try again
@@ -147,6 +149,8 @@ def checkout_git_commit(repo: str, commit: str) -> bool:
                 os.remove(index_lock)
             cleanup_local_changes(repo)
             command = ["git", "checkout", "--recurse-submodules", commit]
+            subprocess.check_call(command, cwd=repo, shell=False)
+            command = ["git", "submodule", "update", "--init", "--recursive"]
             subprocess.check_call(command, cwd=repo, shell=False)
             return True
         except subprocess.CalledProcessError:


### PR DESCRIPTION
In bisection workflow, we found sometimes it fails to checkout recursive modules with `git checkout --recurse-submodules`, so we are adding another `git submodule update --init --recursive` command to make sure all submodules are being checked out.

Failed example workflow: https://github.com/pytorch/benchmark/actions/runs/6104757433

Successful workflow: https://github.com/pytorch/benchmark/actions/runs/6313591947/job/17141994764