### PR TITLE
Add canary model support to test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import yaml
 
 import torch
-from torchbenchmark import _list_model_paths, ModelTask, get_metadata_from_yaml
+from torchbenchmark import _list_model_paths, _list_canary_model_paths, ModelTask, get_metadata_from_yaml
 from torchbenchmark.util.metadata_utils import skip_by_metadata
 
 
@@ -125,8 +125,10 @@ def _load_tests():
         devices.append('mps')
     if device := os.getenv('ACCELERATOR'):
         devices.append(device)
-
-    for path in _list_model_paths():
+    model_paths = _list_model_paths()
+    if os.getenv('USE_CANARY_MODELS'):
+        model_paths.extend(_list_canary_model_paths())
+    for path in model_paths:
         # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
         # api, enable after PyTorch 1.13 release
         if "quantized" in path:

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -138,10 +138,11 @@ def setup(models: List[str] = [], verbose: bool = True, continue_on_fail: bool =
     failures = {}
     models = list(map(lambda p: p.lower(), models))
     model_paths = filter(lambda p: True if not models else os.path.basename(p).lower() in models, _list_model_paths())
+    
     if allow_canary:
-        canary_model_paths = filter(lambda p: os.path.basename(p).lower() in models, _list_canary_model_paths())
+        canary_model_paths = filter(lambda p: True if not models else os.path.basename(p).lower() in models, _list_canary_model_paths())
         model_paths = list(model_paths)
-        model_paths.extend(canary_model_paths)
+        model_paths += list(canary_model_paths)
     for model_path in model_paths:
         print(f"running setup for {model_path}...", end="", flush=True)
         if test_mode:

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -293,9 +293,11 @@ class ModelTask(base_task.TaskBase):
         import traceback
 
         model_name = os.path.basename(model_path)
+        model_dir = os.path.basename(os.path.dirname(model_path))
+
         diagnostic_msg = ""
         try:
-            module = importlib.import_module(f'.models.{model_name}', package=package)
+            module = importlib.import_module(f'.{model_dir}.{model_name}', package=package)
             if accelerator_backend := os.getenv("ACCELERATOR_BACKEND"):
                 setattr(module, accelerator_backend, importlib.import_module(accelerator_backend))
             Model = getattr(module, 'Model', None)

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -138,7 +138,6 @@ def setup(models: List[str] = [], verbose: bool = True, continue_on_fail: bool =
     failures = {}
     models = list(map(lambda p: p.lower(), models))
     model_paths = filter(lambda p: True if not models else os.path.basename(p).lower() in models, _list_model_paths())
-    
     if allow_canary:
         canary_model_paths = filter(lambda p: True if not models else os.path.basename(p).lower() in models, _list_canary_model_paths())
         model_paths = list(model_paths)
@@ -294,7 +293,6 @@ class ModelTask(base_task.TaskBase):
 
         model_name = os.path.basename(model_path)
         model_dir = os.path.basename(os.path.dirname(model_path))
-
         diagnostic_msg = ""
         try:
             module = importlib.import_module(f'.{model_dir}.{model_name}', package=package)

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -142,7 +142,7 @@ def setup(models: List[str] = [], verbose: bool = True, continue_on_fail: bool =
     if allow_canary:
         canary_model_paths = filter(lambda p: True if not models else os.path.basename(p).lower() in models, _list_canary_model_paths())
         model_paths = list(model_paths)
-        model_paths += list(canary_model_paths)
+        model_paths.extend(canary_model_paths)
     for model_path in model_paths:
         print(f"running setup for {model_path}...", end="", flush=True)
         if test_mode:


### PR DESCRIPTION
Summary:

Allow `test.py` to also collect `canary` models on top of the regular ones by setting the environment variable `USE_CANARY_MODELS`.

```
pytest test.py --collect-only -k "check_device_cpu"
94/376 tests collected (282 deselected) in 0.11s

export USE_CANARY_MODELS=1
pytest test.py --collect-only -k "check_device_cpu"
110/440 tests collected (330 deselected) in 0.13s
```

where:
```
tree torchbenchmark/models/ -L 1|tail -1
96 directories, 1 file

tree torchbenchmark/canary_models/ -L 1|tail -1
16 directories, 0 files
```

Make `--canary` consistent with the default behaviour when `install.py` is called with no models, and download all collected models. Now, if you run `python3 install.py --canary`, the script will install all the models inside `torchbenchmark/models` and `torchbenchmark/canary_models`.