### PR TITLE
Bug fix for cpu userbenchmark

### DIFF
--- a/userbenchmark/cpu/run.py
+++ b/userbenchmark/cpu/run.py
@@ -131,9 +131,10 @@ def run_benchmark(config, args):
     cmd.append("--niter")
     cmd.append(args.niter)
     cmd.append("-o")
-    cmd.append(str(args.output))
+    cmd.append(args.output)
+    cmd = list(map(str, cmd))
 
-    print(f"\nRunning benchmark: {' '.join(map(str, cmd))}")
+    print(f"\nRunning benchmark: {' '.join(cmd)}")
     if not args.dryrun:
         timeout = int(args.timeout) if args.timeout else None
         try:


### PR DESCRIPTION
[commit 2d05303](https://github.com/pytorch/benchmark/commit/2d05303a5432c9b5b63558f22bfd43a51b029876) introduced a bug where `int`s get passed into `subprocess.run()` inside the `cmd` argument, causing a TypeError `expected str, bytes or os.PathLike object, not int` for every cpu benchmark. As a fix, convert `cmd` into a list of strings before using it. 