### PR TITLE
Add test to the set_module() interface

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -465,7 +465,9 @@ class ModelTask(base_task.TaskBase):
             raise RuntimeError('Missing device in BenchmarkModel.')
 
         model, inputs = instance.get_module()
-        model_name = getattr(model, 'name', None)
+        # test set_module
+        instance.set_module(model)
+        model_name = model.name
 
         # Check the model tensors are assigned to the expected device.
         for t in model.parameters():

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -467,7 +467,7 @@ class ModelTask(base_task.TaskBase):
         model, inputs = instance.get_module()
         # test set_module
         instance.set_module(model)
-        model_name = model.name
+        model_name = instance.name
 
         # Check the model tensors are assigned to the expected device.
         for t in model.parameters():

--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -118,6 +118,9 @@ class Model(BenchmarkModel):
                 'image'], data['seg'], data['multi_fr'], data['seg-gt'], data['back-rnd']
             return self.netG, (image.to(self.device), bg.to(self.device), seg.to(self.device), multi_fr.to(self.device))
 
+    def set_module(self, module):
+        self.netG = module
+
     def train(self):
         self.netG.train()
         self.netD.train()

--- a/torchbenchmark/models/stable_diffusion_text_encoder/__init__.py
+++ b/torchbenchmark/models/stable_diffusion_text_encoder/__init__.py
@@ -47,6 +47,8 @@ class Model(BenchmarkModel, HuggingFaceAuthMixin):
         input_tensor = input_tensor.long().to(self.device)
         return self.pipe.text_encoder, [input_tensor]
 
+    def set_module(self, module):
+        self.pipe.text_encoder = module
 
     def train(self):
         raise NotImplementedError("Train test is not implemented for the stable diffusion model.")

--- a/torchbenchmark/models/stable_diffusion_unet/__init__.py
+++ b/torchbenchmark/models/stable_diffusion_unet/__init__.py
@@ -37,13 +37,14 @@ class Model(BenchmarkModel, HuggingFaceAuthMixin):
         # Make this function no-op.
         pass
 
-    
     def get_module(self):
         random_input = torch.randn(1, 4, 128, 128).to(self.device)
         timestep = torch.tensor([1.0]).to(self.device)
         encoder_hidden_states = torch.randn(1, 1, 1024).to(self.device)
         return self.pipe.unet, [random_input, timestep, encoder_hidden_states]
 
+    def set_module(self, module):
+        self.pipe.unet = module
 
     def train(self):
         raise NotImplementedError("Train test is not implemented for the stable diffusion model.")


### PR DESCRIPTION
All models should have a workable `set_module()` interface to work with the backends.