### PR TITLE
Pin v3 nightly workflow to Python 3.10

### DIFF
--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Clone and setup conda env
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
-          conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
+          conda create --name "${CONDA_ENV}" python=3.10
       - name: Install TorchBench
         run: |
           set -x


### PR DESCRIPTION
On the v3.0 branch, we will stick to using Python 3.10 to keep compatible models running.