### PR TITLE
Fix & update `metadata.yaml` for hf_T5` variants and `timm_nfnet`

### DIFF
--- a/torchbenchmark/models/hf_T5/metadata.yaml
+++ b/torchbenchmark/models/hf_T5/metadata.yaml
@@ -5,6 +5,9 @@ eval_benchmark: false
 eval_deterministic: false
 eval_nograd: true
 not_implemented:
-- test: train
+  - device: cpu
+    test: train
+  - device: cuda
+    test: train
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/hf_T5_base/metadata.yaml
+++ b/torchbenchmark/models/hf_T5_base/metadata.yaml
@@ -5,7 +5,10 @@ train_benchmark: false
 train_deterministic: false
 not_implemented:
   # disable train test because of CI infra capacity issue
-  - test: train
+  - device: cpu
+    test: train
+  - device: cuda
+    test: train
   # CPU OOM on torchbench CI accuracy
   - device: cpu
     test: example

--- a/torchbenchmark/models/hf_T5_large/metadata.yaml
+++ b/torchbenchmark/models/hf_T5_large/metadata.yaml
@@ -5,4 +5,7 @@ train_benchmark: false
 train_deterministic: false
 not_implemented:
   # disable train test because of CI infra capacity issue
-  - test: train
+  - device: cpu
+    test: train
+  - device: cuda
+    test: train

--- a/torchbenchmark/models/timm_nfnet/metadata.yaml
+++ b/torchbenchmark/models/timm_nfnet/metadata.yaml
@@ -5,7 +5,7 @@ eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 not_implemented:
-- evice: cuda
+- device: cuda
   test: train
 train_benchmark: true
 train_deterministic: false


### PR DESCRIPTION
Changes:
- `timm_nfnet/metadata.yaml` had a typo which has been corrected (`evice` -> `device`)
- `hf_T5`/`hf_T5_base`/`hf_T5_large` train changed so that it is only skipped on machines used by upstream CI