### PR TITLE
update doctr to commit 56c8356 to fix BF16 mode

### DIFF
--- a/torchbenchmark/models/doctr_det_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_det_predictor/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/mindee/doctr.git@acb9f64
+git+https://github.com/mindee/doctr.git@56c8356
 rapidfuzz==2.15.1

--- a/torchbenchmark/models/doctr_det_predictor/requirements.txt
+++ b/torchbenchmark/models/doctr_det_predictor/requirements.txt
@@ -1,2 +1,1 @@
 git+https://github.com/mindee/doctr.git@56c8356
-rapidfuzz==2.15.1


### PR DESCRIPTION
Update the version of `doctr` to include the fix in https://github.com/mindee/doctr/pull/1342 for BF16 mode.

Remove the change of `rapidfuzz==2.15.1` in `requirements.txt` (https://github.com/pytorch/benchmark/pull/1555) since the version has been set in the model repo in the updated version (https://github.com/mindee/doctr/pull/1176).