### PR TITLE
Build the nightly docker

### DIFF
--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -7,9 +7,6 @@ ENV CONDA_ENV=torchbench
 ENV SETUP_SCRIPT=/workspace/setup_instance.sh
 ARG TORCHBENCH_BRANCH=${TORCHBENCH_BRANCH:-main}
 
-# Setup dependencies
-RUN sudo apt install -y libsdl2-dev libsdl2-2.0-0
-
 # Setup Conda env and CUDA
 RUN git clone -b "${TORCHBENCH_BRANCH}" --single-branch \
  https://github.com/pytorch/benchmark /workspace/benchmark


### PR DESCRIPTION
GCP has some issues accessing Ubuntu repo, move the system level package install to the base image.

Problematic docker build: https://github.com/pytorch/benchmark/actions/runs/6509843007

Test docker build: https://github.com/pytorch/benchmark/actions/runs/6517632118