### PR TITLE
[optim] disable issue creation temporarily

### DIFF
--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -74,7 +74,7 @@ jobs:
           done
       - name: Create the github issue
         continue-on-error: true
-        if: env.TORCHBENCH_REGRESSION_DETECTED
+        if: false
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: Optim Perf Signal Detected by TorchBench CI on ${{ env.TORCHBENCH_REGRESSION_DETECTED }}


### PR DESCRIPTION
I’m going to be in PTO so let’s disable the noisy issues in the meantime and we can reenable when I come back