### PR TITLE
detectron2: require coco2017-minimal data

### DIFF
--- a/torchbenchmark/util/framework/detectron2/__init__.py
+++ b/torchbenchmark/util/framework/detectron2/__init__.py
@@ -54,7 +54,6 @@ def remove_tools_directory():
         pass
 
 def install_detectron2(model_name, model_dir):
-    s3_utils.checkout_s3_data("INPUT_TARBALLS", "coco128.tar.gz", decompress=True)
     s3_utils.checkout_s3_data("INPUT_TARBALLS", "coco2017-minimal.tar.gz", decompress=True)
     install_model_weights(model_name, model_dir)
     pip_install_requirements()

--- a/torchbenchmark/util/framework/detectron2/__init__.py
+++ b/torchbenchmark/util/framework/detectron2/__init__.py
@@ -55,6 +55,7 @@ def remove_tools_directory():
 
 def install_detectron2(model_name, model_dir):
     s3_utils.checkout_s3_data("INPUT_TARBALLS", "coco128.tar.gz", decompress=True)
+    s3_utils.checkout_s3_data("INPUT_TARBALLS", "coco2017-minimal.tar.gz", decompress=True)
     install_model_weights(model_name, model_dir)
     pip_install_requirements()
     remove_tools_directory()


### PR DESCRIPTION
It seems like detectron2 requires coco2017-minimal data. It gets installed with vision-maskrcnn, but if you want to install requirements only for one model we need the installer scripts for the detectron models to download coco2017-minimal.