### PR TITLE
Fix stable_diffusion_xl fp16

### DIFF
--- a/torchbenchmark/canary_models/stable_diffusion_xl/__init__.py
+++ b/torchbenchmark/canary_models/stable_diffusion_xl/__init__.py
@@ -36,7 +36,7 @@ class Model(BenchmarkModel, HuggingFaceAuthMixin):
 
         self.args_tuple = (random_input, timestep, encoder_hidden_states, None, None, None, None, added_cond_kwargs)
 
-    def enable_fp16_half(self):
+    def enable_fp16(self):
         pass
     
     def get_module(self):


### PR DESCRIPTION
Rename `enable_fp16_half` to `enable_fp16` to correctly override base class method