### PR TITLE
Register grid buffers for Super_SloMo.

### DIFF
--- a/torchbenchmark/models/Super_SloMo/slomo_model.py
+++ b/torchbenchmark/models/Super_SloMo/slomo_model.py
@@ -249,8 +249,10 @@ class backWarp(nn.Module):
         
         # Use torch.meshgrid instead of np.meshgrid to imrpove performance
         # https://github.com/avinashpaliwal/Super-SloMo/pull/111
-        self.gridX, self.gridY = torch.meshgrid(torch.arange(W, requires_grad=False, device=device), 
-                                                torch.arange(H, requires_grad=False, device=device), indexing='xy')
+        gridX, gridY = torch.meshgrid(torch.arange(W, requires_grad=False, device=device), 
+                                      torch.arange(H, requires_grad=False, device=device), indexing='xy')
+        self.register_buffer("gridX", gridX)
+        self.register_buffer("gridY", gridY)
         
     def forward(self, img, flow):
         """


### PR DESCRIPTION
This PR registers both `gridX` and `gridY` as buffers for the `backWarp` module, which belongs to the `Super_SloMo` benchmark.

Without this PR, those buffers wouldn't be moved to a device on `model.to(device)`. This causes problems, specifically with XLA.

Test Plan:

```
PJRT_DEVICE=CPU python benchmarks/dynamo/torchbench.py --performance --trace-on-xla --backend openxla --inference --only Super_SloMo
```