### PR TITLE
Log both torch.version.git_version and torch.__version__

### DIFF
--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -87,7 +87,10 @@ def get_output_json(bm_name, metrics) -> Dict[str, Any]:
     import torch
     return {
         "name": bm_name,
-        "environ": {"pytorch_git_version": torch.version.git_version},
+        "environ": {
+            "pytorch_git_version": torch.version.git_version,
+            "pytorch_version": torch.__version__,
+        },
         "metrics": metrics,
     }
 


### PR DESCRIPTION
In the HUD dashboard, we will need to log both git version and `torch.__version__`. This is helpful to identify the date when the pytorch is built.

Address TODO item 1 in https://github.com/pytorch/benchmark/issues/1893