### PR TITLE
Skip the bisection when the start and end hash are the same

### DIFF
--- a/bisection.py
+++ b/bisection.py
@@ -425,6 +425,10 @@ if __name__ == "__main__":
                                     bisect_config=bisect_config,
                                     output_json=args.output,
                                     debug=args.debug)
+    if start_hash == end_hash:
+        print(f"Start and end hash are the same: {start_hash}. Skip bisection")
+        bisection.output()
+        exit(0)
     assert bisection.prep(), "The working condition of bisection is not satisfied."
     print("Preparation steps ok. Commit to bisect: " + " ".join([str(x) for x in bisection.target_repo.commits]))
     bisection.run()


### PR DESCRIPTION
Nightly releases could be built from the same commit on the main branch (e.g. [20231112](https://github.com/pytorch/pytorch/commit/63a5a14da9ef3ebd68ce0cebea4aa84e030a2cf8) and [20231113](https://github.com/pytorch/pytorch/commit/a45a8bf9e7e1530692f2703f8da430bc2825af7c)).

If it happens, we can just skip the bisection because there is no code change.


Test Plan:

https://github.com/pytorch/benchmark/actions/runs/6906833305