### PR TITLE
Improve bisection routine by creating GitHub issue only when the bisection is successful

### DIFF
--- a/.github/workflows/v3-bisection.yml
+++ b/.github/workflows/v3-bisection.yml
@@ -81,6 +81,15 @@ jobs:
                 --torchbench-repo-path "${PWD}" --config "${BISECT_WORKDIR}/regression-${REGRESSION_DATE}.yaml" \
                 --output "${BISECT_WORKDIR}/bisect-output-gh${GITHUB_RUN_ID}.json"
           cp -r "${BISECT_WORKDIR}" ../bisection-result
+      - name: Create the github issue
+        continue-on-error: true
+        if: env.TORCHBENCH_BISECTION_COMMIT_FOUND
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: V3 Performance Signal Detected by TorchBench Userbenchmark "torch-nightly" on ${{ env.TORCHBENCH_BISECTION_COMMIT_FOUND }}
+          content-filepath: ./benchmark/gh-issue.md
+          labels: |
+            torchbench-perf-report
       - name: Upload artifact
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -70,7 +70,6 @@ jobs:
           done
           rm -r ../benchmark-output || true
           cp -r ./.userbenchmark/torch-nightly ../benchmark-output
-
       - name: Copy artifact and upload to scribe and Amazon S3
         run: |
           . "${SETUP_SCRIPT}"

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -81,7 +81,7 @@ jobs:
           python ./scripts/userbenchmark/upload_scribe.py --userbenchmark_json "${LATEST_RESULT}" --userbenchmark_platform "${PLATFORM_NAME}"
           # Upload the result json to Amazon S3
           python ./scripts/userbenchmark/upload_s3.py --upload-file "${LATEST_RESULT}" --userbenchmark_platform "${PLATFORM_NAME}"
-      - name: Copy regression results to Amazon S3
+      - name: Copy regression results to Amazon S3 and kick off bisection
         if: env.TORCHBENCH_REGRESSION_DETECTED
         run: |
           . "${SETUP_SCRIPT}"

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -70,15 +70,7 @@ jobs:
           done
           rm -r ../benchmark-output || true
           cp -r ./.userbenchmark/torch-nightly ../benchmark-output
-      - name: Create the github issue
-        continue-on-error: true
-        if: env.TORCHBENCH_REGRESSION_DETECTED
-        uses: peter-evans/create-issue-from-file@v4
-        with:
-          title: V3 Performance Signal Detected by TorchBench Userbenchmark "torch-nightly" on ${{ env.TORCHBENCH_REGRESSION_DETECTED }}
-          content-filepath: ./benchmark/gh-issue.md
-          labels: |
-            torchbench-perf-report
+
       - name: Copy artifact and upload to scribe and Amazon S3
         run: |
           . "${SETUP_SCRIPT}"
@@ -97,6 +89,14 @@ jobs:
           LATEST_REGRESSION_RESULT=$(find ../benchmark-output/ -name "regression-*.yaml" | sort -r | head -1)
           # Upload the regression json to Amazon S3
           python ./scripts/userbenchmark/upload_s3.py --upload-file "${LATEST_REGRESSION_RESULT}" --userbenchmark_platform "${PLATFORM_NAME}"
+          # Get the workflow ID from
+          # https://api.github.com/repos/pytorch/benchmark/actions/workflows
+          # And dispatch the bisection workflow
+          curl -u xuzhao9:${{ secrets.TORCHBENCH_ACCESS_TOKEN }} \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/pytorch/benchmark/actions/workflows/57994037/dispatches \
+            -d '{"ref": "main", "inputs": {"regression_date": "${{ env.TORCHBENCH_REGRESSION_DETECTED }}" } }'
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/bisection.py
+++ b/bisection.py
@@ -21,21 +21,12 @@ from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
 import yaml
 
 from userbenchmark.utils import (
     parse_abtest_result_from_regression_file_for_bisect,
     TorchBenchABTestResult,
-    parse_abtest_result_from_regression_file_for_bisect
-)
-from regression_detector import generate_regression_result
-from utils import gitutils
-from utils.github import process_bisection_into_gh_issue
-from utils.build_utils import (
-    setup_bisection_build_env,
-    build_repo,
-    cleanup_torch_packages,
-    TorchRepo,
 )
 
 TORCHBENCH_BISECTION_TARGETS = {
@@ -72,7 +63,7 @@ try:
         TorchRepo,
     )
     from utils.cuda_utils import DEFAULT_CUDA_VERSION, prepare_cuda_env
-
+    from utils.github import process_bisection_into_gh_issue
     IS_FBCODE = False
 except (ImportError, ModuleNotFoundError):
     # Meta-Internal imports

--- a/bisection.py
+++ b/bisection.py
@@ -515,28 +515,47 @@ class TorchBenchBisection:
 def main() -> None:
     global SKIP_INSTALL_TORCHBENCH
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--work-dir",
-                        required=True,
-                        help="bisection working directory for logs and results",
-                        type=exist_dir_path)
-    parser.add_argument("--torch-repos-path",
-                        required=True,
-                        help="the directory of pytorch/* source code repositories",
-                        type=exist_dir_path)
-    parser.add_argument("--torchbench-repo-path",
-                        default=None,
-                        help="the directory of torchbench source code git repository, if None, use `args.torch_repo_path/benchmark`.",
-                        type=exist_dir_path)
-    parser.add_argument("--config",
-                        required=True,
-                        help="the regression dict output of regression_detector.py in YAML",
-                        type=exist_file_path)
-    parser.add_argument("--skip-install-torchbench", action="store_true", help="Skip installing torchbench")
-    parser.add_argument("--output",
-                        required=True,
-                        help="the output json file")
-    parser.add_argument("--skip-update", type=str, default="torchbench", help="Repositories to skip update.")
-    parser.add_argument("--gh-issue-path", default="gh-issue.md", help="Output path to print the issue body")
+    parser.add_argument(
+        "--work-dir",
+        required=True,
+        help="bisection working directory for logs and results",
+        type=exist_dir_path,
+    )
+    parser.add_argument(
+        "--torch-repos-path",
+        required=True,
+        help="the directory of pytorch/* source code repositories, or fbcode repo if running internally",
+        type=exist_dir_path,
+    )
+    parser.add_argument(
+        "--torchbench-repo-path",
+        default=None,
+        help="the directory of torchbench source code git repository, if None, use `args.torch_repo_path/benchmark`.",
+        type=exist_dir_path,
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="the regression dict output of regression_detector.py in YAML",
+        type=exist_file_path,
+    )
+    parser.add_argument(
+        "--skip-install-torchbench",
+        action="store_true",
+        help="Skip installing torchbench",
+    )
+    parser.add_argument("--output", required=True, help="the output json file")
+    parser.add_argument(
+        "--skip-update",
+        type=str,
+        default="torchbench",
+        help="Repositories to skip update.",
+    )
+    parser.add_argument(
+        "--gh-issue-path",
+        default="gh-issue.md",
+        help="Output path to print the issue body"
+    )
     # by default, debug mode is disabled
     parser.add_argument(
         "--debug",

--- a/utils/github.py
+++ b/utils/github.py
@@ -1,0 +1,61 @@
+import json
+import os
+
+from typing import Dict
+
+GITHUB_ISSUE_TEMPLATE = """
+TorchBench CI has detected a performance signal or runtime regression, and bisected its result.
+
+Control PyTorch commit: {control_commit}
+Control PyTorch version: {control_version}
+
+Treatment PyTorch commit: {treatment_commit}
+Treatment PyTorch version: {treatment_version}
+
+Bisection result:
+
+```
+{result}
+```
+
+cc {owner}
+"""
+
+DEFAULT_GH_ISSUE_OWNER = "@xuzhao9"
+
+def process_bisection_into_gh_issue(bisection_output_json: str, output_path: str) -> None:
+    with open(bisection_output_json, "r") as fp:
+        bisection = json.load(fp)
+
+    result = json.dump(bisection, indent=4)
+    control_commit = bisection["start"]
+    control_version = bisection["start_version"]
+    treatment_commit = bisection["end"]
+    treatment_version = bisection["end_version"]
+
+    if "GITHUB_ENV" in os.environ:
+        fname = os.environ["GITHUB_ENV"]
+        content = f"TORCHBENCH_BISECTION_COMMIT_FOUND_OR_FAILED='{bisection.target_repo.end}'\n"
+        with open(fname, 'a') as fo:
+            fo.write(content)
+        process_bisection_into_gh_issue(bisection.output_json)
+
+    github_run_id = os.environ.get("GITHUB_RUN_ID", None)
+    github_run_url = "No URL found, please look for the failing action in " + \
+                     "https://github.com/pytorch/benchmark/actions"
+    if github_run_id is not None:
+        github_run_url = f"https://github.com/pytorch/benchmark/actions/runs/{github_run_id}"
+
+    issue_config: Dict[str, str] = {
+        "control_commit": control_commit,
+        "treatment_commit": treatment_commit,
+        "control_version": control_version,
+        "treatment_version": treatment_version,
+        "result": result,
+        "github_run_url": github_run_url,
+        "owner": DEFAULT_GH_ISSUE_OWNER
+    }
+
+    issue_body = GITHUB_ISSUE_TEMPLATE.format(**issue_config)
+    with open(output_path, "w") as f:
+        f.write(issue_body)


### PR DESCRIPTION
This is to resolve the noisy issues of the V3 nightly workflow.
When a regression is detected, we will first kick off a bisection workflow, and only create the GitHub issue when the bisection workflow fails or finds the root cause commit. If the bisection succeeds, but it does not find any result, we will not create an issue.

Test plan:
https://github.com/pytorch/benchmark/actions/runs/7506472200
