### PR TITLE
Add the A100 bisection workflow

### DIFF
--- a/.github/workflows/userbenchmark-a100-bisection.yml
+++ b/.github/workflows/userbenchmark-a100-bisection.yml
@@ -1,0 +1,99 @@
+name: TorchBench A100 bisection
+on:
+  workflow_dispatch:
+    inputs:
+      start_commit:
+        description: "Start PyTorch commit hash"
+        required: true
+      end_commit:
+        description: "End PyTorch commit hash"
+        required: true
+      userbenchmark:
+        description: "Userbenchmark name"
+        required: true
+      userbenchmark_args:
+        description: "Userbenchmark arguments"
+        required: true
+
+jobs:
+  bisection:
+    environment: docker-s3-upload
+    env:
+      BASE_CONDA_ENV: "torchbench"
+      CONDA_ENV: "bisection-ci-a100"
+      PLATFORM_NAME: "gcp_a100"
+      SETUP_SCRIPT: "/workspace/setup_instance.sh"
+      BISECT_WORKDIR: ".userbenchmark/${{ github.env.userbenchmark }}/bisection"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    if: ${{ github.repository_owner == 'pytorch' }}
+    runs-on: [self-hosted, a100-runner]
+    timeout-minutes: 2880 # 48 hours
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: benchmark
+      - name: Checkout pytorch
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/pytorch
+          path: srcs/pytorch
+          fetch-depth: 0
+      - name: Checkout torchvision
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/vision
+          path: srcs/vision
+          fetch-depth: 0
+      - name: Checkout torchaudio
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/audio
+          path: srcs/audio
+          fetch-depth: 0
+      - name: Tune Nvidia GPU
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo nvidia-smi -ac 1215,1410
+          nvidia-smi
+      - name: Install Deps
+        run: |
+          sudo apt-get -y update && sudo apt -y update
+      - name: Setup conda env
+        run: |
+          CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
+          cd benchmark
+          python ./utils/python_utils.py --create-conda-env "${CONDA_ENV}"
+      - name: Setup bisection environment
+        run: |
+          . "${SETUP_SCRIPT}"; cd benchmark
+          python utils/cuda_utils.py --install-torch-build-deps
+          python utils/cuda_utils.py --install-torchbench-deps
+          mkdir -p "${BISECT_WORKDIR}"
+          python run_benchmark.py ${{ github.event.inputs.userbenchmark }} ${{ github.event.inputs.userbenchmark_args }} --dryrun \
+                 --output "${BISECT_WORKDIR}/metric-control.json"
+          python run_benchmark.py ${{ github.event.inputs.userbenchmark }} ${{ github.event.inputs.userbenchmark_args }} --dryrun \
+                 --output "${BISECT_WORKDIR}/metric-treatment.json"
+          python regression_detector.py --name "${USERBENCHMARK_NAME}" --platform "${PLATFORM_NAME}" \
+                 --control "${BISECT_WORKDIR}/metrics-control.json" --treatment "${BISECT_WORKDIR}/metrics-treatment.json" \
+                 --output "${BISECT_WORKDIR}/regression-gh${GITHUB_RUN_ID}.yaml"
+      - name: Bisection
+        run: |
+          . "${SETUP_SCRIPT}"; cd benchmark
+          python bisection.py --work-dir "${BISECT_WORKDIR}" --torch-repos-path "${PWD}/../srcs" \
+                --torchbench-repo-path "${PWD}" --config "${BISECT_WORKDIR}/regression-gh${GITHUB_RUN_ID}.yaml" \
+                --output "${BISECT_WORKDIR}/bisect-output-gh${GITHUB_RUN_ID}.json"
+          cp -r "${BISECT_WORKDIR}" ../bisection-result
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Bisection result
+          path: bisection-result/
+      - name: Clean up Conda env
+        if: always()
+        run: |
+          . "${SETUP_SCRIPT}"
+          conda deactivate && conda deactivate
+          conda remove -n "${CONDA_ENV}" --all

--- a/.github/workflows/userbenchmark-a100-bisection.yml
+++ b/.github/workflows/userbenchmark-a100-bisection.yml
@@ -71,13 +71,15 @@ jobs:
           python utils/cuda_utils.py --install-torch-build-deps
           python utils/cuda_utils.py --install-torchbench-deps
           mkdir -p "${BISECT_WORKDIR}"
+          python utils/cuda_utils.py --install-torch-nightly
           python run_benchmark.py ${{ github.event.inputs.userbenchmark }} ${{ github.event.inputs.userbenchmark_args }} --dryrun \
                  --output "${BISECT_WORKDIR}/metric-control.json"
           python run_benchmark.py ${{ github.event.inputs.userbenchmark }} ${{ github.event.inputs.userbenchmark_args }} --dryrun \
                  --output "${BISECT_WORKDIR}/metric-treatment.json"
-          python regression_detector.py --name "${USERBENCHMARK_NAME}" --platform "${PLATFORM_NAME}" \
+          python regression_detector.py \
                  --control "${BISECT_WORKDIR}/metrics-control.json" --treatment "${BISECT_WORKDIR}/metrics-treatment.json" \
                  --output "${BISECT_WORKDIR}/regression-gh${GITHUB_RUN_ID}.yaml"
+          pip uninstall -y torch torchvision torchaudio torch_tensorrt
       - name: Bisection
         run: |
           . "${SETUP_SCRIPT}"; cd benchmark

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -104,9 +104,11 @@ def process_regressions_into_gh_issue(regression_result: TorchBenchABTestResult,
     troubled_tests = ""
     for test, stats in regressions_dict["details"].items():
         delta = stats["delta"]
-        if delta != 0:
+        if not isinstance(delta, str):
             sign = "+" if delta > 0 else ""
             troubled_tests += f"- {test}: {sign}{delta:.5%}\n"
+        else:
+            troubled_tests += f"- {test}: {delta}\n"
     
     control_only_tests = ""
     for test, stat in regressions_dict["control_only_metrics"].items():

--- a/userbenchmark/test_bench/regression_detector.py
+++ b/userbenchmark/test_bench/regression_detector.py
@@ -14,8 +14,6 @@ def run(control, treatment) -> TorchBenchABTestResult:
     for metric_names in control_metrics.keys():
         control_metric = control_metrics[metric_names]
         treatment_metric = treatment_metrics[metric_names]
-        print(type(control_metric))
-        print(type(treatment_metric))
         if (isinstance(control_metric, str) or isinstance(treatment_metric, str)):
             if control_metric == "skip_by_dryrun" or not control_metric == treatment_metric:
                 delta = f"{control_metric} -> {treatment_metric}"

--- a/userbenchmark/test_bench/regression_detector.py
+++ b/userbenchmark/test_bench/regression_detector.py
@@ -14,13 +14,16 @@ def run(control, treatment) -> TorchBenchABTestResult:
     for metric_names in control_metrics.keys():
         control_metric = control_metrics[metric_names]
         treatment_metric = treatment_metrics[metric_names]
-        if (not isinstance(control_metric, float) or not isinstance(treatment_metric, float)) and \
-            not control_metric == treatment_metric:
-            delta = f"{control_metric} -> {treatment_metric}"
-            details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
-        delta = (treatment_metric - control_metric) / control_metric
-        if abs(delta) > DEFAULT_REGRESSION_DELTA_THRESHOLD:
-            details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
+        print(type(control_metric))
+        print(type(treatment_metric))
+        if (isinstance(control_metric, str) or isinstance(treatment_metric, str)):
+            if control_metric == "skip_by_dryrun" or not control_metric == treatment_metric:
+                delta = f"{control_metric} -> {treatment_metric}"
+                details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
+        else:
+            delta = (treatment_metric - control_metric) / control_metric
+            if abs(delta) > DEFAULT_REGRESSION_DELTA_THRESHOLD:
+                details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
     return TorchBenchABTestResult(name=BM_NAME,
                                   control_env=control_env, \
                                   treatment_env=treatment_env, \

--- a/userbenchmark/test_bench/regression_detector.py
+++ b/userbenchmark/test_bench/regression_detector.py
@@ -1,0 +1,31 @@
+from ..utils import TorchBenchABTestResult, TorchBenchABTestMetric
+from . import BM_NAME
+
+DEFAULT_REGRESSION_DELTA_THRESHOLD = 0.07
+
+def run(control, treatment) -> TorchBenchABTestResult:
+    control_env = control["environ"]
+    control_env["git_commit_hash"] = control["environ"]["pytorch_git_version"]
+    control_metrics = control["metrics"]
+    treatment_env = treatment["environ"]
+    treatment_env["git_commit_hash"] = treatment["environ"]["pytorch_git_version"]
+    treatment_metrics = treatment["metrics"]
+    details = {}
+    for metric_names in control_metrics.keys():
+        control_metric = control_metrics[metric_names]
+        treatment_metric = treatment_metrics[metric_names]
+        if (not isinstance(control_metric, float) or not isinstance(treatment_metric, float)) and \
+            not control_metric == treatment_metric:
+            delta = f"{control_metric} -> {treatment_metric}"
+            details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
+        delta = (treatment_metric - control_metric) / control_metric
+        if abs(delta) > DEFAULT_REGRESSION_DELTA_THRESHOLD:
+            details[metric_names] = TorchBenchABTestMetric(control=control_metric, treatment=treatment_metric, delta=delta)
+    return TorchBenchABTestResult(name=BM_NAME,
+                                  control_env=control_env, \
+                                  treatment_env=treatment_env, \
+                                  details=details, \
+                                  control_only_metrics={}, \
+                                  treatment_only_metrics={}, \
+                                  bisection="pytorch")
+

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -155,10 +155,9 @@ def run(args: List[str]):
                 results[f"{config_str}, metric={metric}"] = metrics_dict[metric]
     except KeyboardInterrupt:
         print("User keyboard interrupted!")
-    if not args.dryrun:
-        result = get_output_json(BM_NAME, results)
-        if args.device == 'cuda':
-            import torch
-            result["environ"]["device"] = torch.cuda.get_device_name()
-        with open(args.output, 'w') as f:
-            json.dump(result, f, indent=4)
+    result = get_output_json(BM_NAME, results)
+    if args.device == 'cuda':
+        import torch
+        result["environ"]["device"] = torch.cuda.get_device_name()
+    with open(args.output, 'w') as f:
+        json.dump(result, f, indent=4)

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -22,7 +22,11 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 def config_to_str(config: TorchBenchModelConfig) -> str:
     metrics_base = f"model={config.name}, test={config.test}, device={config.device}," + \
+<<<<<<< HEAD
         f" bs={config.batch_size}, extra_args={config.extra_args}"
+=======
+        f" bs={config.batch_size}, extra_args='{config.extra_args}'"
+>>>>>>> 7eea5a34 (Save output to user directory)
     return metrics_base
 
 def generate_model_configs(devices: List[str], tests: List[str], batch_sizes: List[str], model_names: List[str], extra_args: List[str]) -> List[TorchBenchModelConfig]:
@@ -40,7 +44,11 @@ def generate_model_configs(devices: List[str], tests: List[str], batch_sizes: Li
     ) for device, test, batch_size, model_name in cfgs]
     return result
 
+<<<<<<< HEAD
 def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Path) -> List[TorchBenchModelConfig]:
+=======
+def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Path):
+>>>>>>> 7eea5a34 (Save output to user directory)
     result = []
     for config in configs:
         config_str = config_to_str(config)
@@ -49,7 +57,11 @@ def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Pa
             shutil.rmtree(config.output_dir)
         config.output_dir.mkdir(parents=True)
         result.append(config)
+<<<<<<< HEAD
     return result
+=======
+    return config
+>>>>>>> 7eea5a34 (Save output to user directory)
 
 def get_metrics(config: TorchBenchModelConfig) -> List[str]:
     if "--accuracy" in config.extra_args:

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -210,10 +210,9 @@ def run(args: List[str]):
                 results[f"{config_str}, metric={metric}"] = metrics_dict[metric]
     except KeyboardInterrupt:
         print("User keyboard interrupted!")
-    if not args.dryrun:
-        result = get_output_json(BM_NAME, results)
-        if args.device == 'cuda':
-            import torch
-            result["environ"]["device"] = torch.cuda.get_device_name()
-        with open(args.output, 'w') as f:
-            json.dump(result, f, indent=4)
+    result = get_output_json(BM_NAME, results)
+    if args.device == 'cuda':
+        import torch
+        result["environ"]["device"] = torch.cuda.get_device_name()
+    with open(args.output, 'w') as f:
+        json.dump(result, f, indent=4)

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -45,10 +45,14 @@ def generate_model_configs(devices: List[str], tests: List[str], batch_sizes: Li
     return result
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Path) -> List[TorchBenchModelConfig]:
 =======
 def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Path):
 >>>>>>> 7eea5a34 (Save output to user directory)
+=======
+def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Path) -> List[TorchBenchModelConfig]:
+>>>>>>> 4c74fc6a (Add debug options to enable debugging)
     result = []
     for config in configs:
         config_str = config_to_str(config)
@@ -58,10 +62,14 @@ def init_output_dir(configs: List[TorchBenchModelConfig], output_dir: pathlib.Pa
         config.output_dir.mkdir(parents=True)
         result.append(config)
 <<<<<<< HEAD
+<<<<<<< HEAD
     return result
 =======
     return config
 >>>>>>> 7eea5a34 (Save output to user directory)
+=======
+    return result
+>>>>>>> 4c74fc6a (Add debug options to enable debugging)
 
 def get_metrics(config: TorchBenchModelConfig) -> List[str]:
     if "--accuracy" in config.extra_args:

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -23,10 +23,14 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 def config_to_str(config: TorchBenchModelConfig) -> str:
     metrics_base = f"model={config.name}, test={config.test}, device={config.device}," + \
 <<<<<<< HEAD
+<<<<<<< HEAD
         f" bs={config.batch_size}, extra_args={config.extra_args}"
 =======
         f" bs={config.batch_size}, extra_args='{config.extra_args}'"
 >>>>>>> 7eea5a34 (Save output to user directory)
+=======
+        f" bs={config.batch_size}, extra_args={config.extra_args}"
+>>>>>>> b0d741d4 (Fix a bug)
     return metrics_base
 
 def generate_model_configs(devices: List[str], tests: List[str], batch_sizes: List[str], model_names: List[str], extra_args: List[str]) -> List[TorchBenchModelConfig]:

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -4,10 +4,9 @@ import yaml
 from datetime import datetime, timedelta
 import time
 import json
-import yaml
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Callable
+from typing import Any, Dict, List, Optional, Callable, Union
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
 USERBENCHMARK_OUTPUT_PREFIX = ".userbenchmark"
@@ -38,10 +37,9 @@ with add_path(str(REPO_PATH)):
 
 @dataclass
 class TorchBenchABTestMetric:
-    control: float
-    treatment: float
-    delta: float
-
+    control: Union[float, str]
+    treatment: Union[float, str]
+    delta: Union[float, str]
 
 @dataclass
 class TorchBenchABTestResult:

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -113,12 +113,17 @@ def get_default_debug_output_dir(metrics_json: str) -> Path:
     metrics_json_path = Path(metrics_json)
     metrics_json_dir = metrics_json_path.parent
 <<<<<<< HEAD
+<<<<<<< HEAD
     metrics_datetime = datetime.strptime(metrics_json_path.name, "metrics-%Y%m%d%H%M%S.json")
     debug_output_dir = metrics_json_dir.joinpath("output-" + datetime.strftime(metrics_datetime, "%Y%m%d%H%M%S"))
 =======
     metrics_datetime = datetime.strptime("metrics-%Y%m%d%H%M%S.json", metrics_json_path.name)
     debug_output_dir = metrics_json_dir.joinpath(metrics_datetime)
 >>>>>>> 7eea5a34 (Save output to user directory)
+=======
+    metrics_datetime = datetime.strptime(metrics_json_path.name, "metrics-%Y%m%d%H%M%S.json")
+    debug_output_dir = metrics_json_dir.joinpath("output-" + datetime.strftime(metrics_datetime, "%Y%m%d%H%M%S"))
+>>>>>>> 4c74fc6a (Add debug options to enable debugging)
     return debug_output_dir
 
 def dump_output(bm_name: str, output: Any, target_dir: Path=None) -> None:

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -110,18 +110,8 @@ def get_default_output_json_path(bm_name: str, target_dir: Path=None) -> str:
 def get_default_debug_output_dir(metrics_json: str) -> Path:
     metrics_json_path = Path(metrics_json)
     metrics_json_dir = metrics_json_path.parent
-<<<<<<< HEAD
-<<<<<<< HEAD
     metrics_datetime = datetime.strptime(metrics_json_path.name, "metrics-%Y%m%d%H%M%S.json")
     debug_output_dir = metrics_json_dir.joinpath("output-" + datetime.strftime(metrics_datetime, "%Y%m%d%H%M%S"))
-=======
-    metrics_datetime = datetime.strptime("metrics-%Y%m%d%H%M%S.json", metrics_json_path.name)
-    debug_output_dir = metrics_json_dir.joinpath(metrics_datetime)
->>>>>>> 7eea5a34 (Save output to user directory)
-=======
-    metrics_datetime = datetime.strptime(metrics_json_path.name, "metrics-%Y%m%d%H%M%S.json")
-    debug_output_dir = metrics_json_dir.joinpath("output-" + datetime.strftime(metrics_datetime, "%Y%m%d%H%M%S"))
->>>>>>> 4c74fc6a (Add debug options to enable debugging)
     return debug_output_dir
 
 def dump_output(bm_name: str, output: Any, target_dir: Path=None) -> None:

--- a/userbenchmark/utils.py
+++ b/userbenchmark/utils.py
@@ -112,8 +112,13 @@ def get_default_output_json_path(bm_name: str, target_dir: Path=None) -> str:
 def get_default_debug_output_dir(metrics_json: str) -> Path:
     metrics_json_path = Path(metrics_json)
     metrics_json_dir = metrics_json_path.parent
+<<<<<<< HEAD
     metrics_datetime = datetime.strptime(metrics_json_path.name, "metrics-%Y%m%d%H%M%S.json")
     debug_output_dir = metrics_json_dir.joinpath("output-" + datetime.strftime(metrics_datetime, "%Y%m%d%H%M%S"))
+=======
+    metrics_datetime = datetime.strptime("metrics-%Y%m%d%H%M%S.json", metrics_json_path.name)
+    debug_output_dir = metrics_json_dir.joinpath(metrics_datetime)
+>>>>>>> 7eea5a34 (Save output to user directory)
     return debug_output_dir
 
 def dump_output(bm_name: str, output: Any, target_dir: Path=None) -> None:


### PR DESCRIPTION
We are adding the generic A100 bisection workflow for bisecting any userbenchmark.

The workflow requires 4 arguments:
1. The start pytorch commit hash on the main branch
2. The treatment pytorch commit hash on the main branch
3. The userbenchmark name
4. The userbenchmark arguments to trigger the regression

Test plan:

Automatic bisection of the `test_bench` userbenchmark on the accuracy issue of llama_v2_7b_16h:

Start commit hash (2023-11-15): `a5a404865c01f86881f6b3ab0cd9a562d0b420de`

End commit hash (2023-11-16): `690c805c8b539501aad5fbf18914ac92afb65d5a`

Userbenchmark name: `test_bench`

Userbenchmark arguments: `llama_v2_7b_16h -d cuda -t eval --accuracy`

Known root cause commit: `12b2dd16b050e6495910fc564517fbb51dde1f20`
