### PR TITLE
Pin rotary-embedding-torch to 0.3.3

### DIFF
--- a/torchbenchmark/models/DALLE2_pytorch/requirements.txt
+++ b/torchbenchmark/models/DALLE2_pytorch/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/lucidrains/DALLE2-pytorch@00e07b7d61e21447d55e6d06d5c928cf8b67601d
 beartype==0.15.0
+rotary-embedding-torch==0.3.3
 tensorboard


### PR DESCRIPTION
Summary: A different rotary-embedding-torch version may cause a graph break count difference in PT2 tests, see https://github.com/pytorch/pytorch/pull/114598 for details