### PR TITLE
Make models named argument

### DIFF
--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -139,7 +139,8 @@ def parse_known_args(args):
     parser = argparse.ArgumentParser()
     default_device = "cuda" if "cuda" in list_devices() else "cpu"
     parser.add_argument(
-        "models",
+        "--models",
+        "-m",
         nargs="*",
         help="Name of models to run, split by comma.",
     )


### PR DESCRIPTION
To run all models with a single command line, we need to make `models` a named argument.
For example, to test all models with the torchscript backend on CUDA, we can run the following command:

```
python run_benchmark.py test_bench -d cuda -t train,eval --backend torchscript
```