### PR TITLE
Install `diffusers` before checking for token.

### DIFF
--- a/torchbenchmark/models/stable_diffusion_text_encoder/install.py
+++ b/torchbenchmark/models/stable_diffusion_text_encoder/install.py
@@ -10,8 +10,8 @@ def load_model_checkpoint():
     StableDiffusionPipeline.from_pretrained(MODEL_NAME, torch_dtype=torch.float16, safety_checker=None)
 
 if __name__ == "__main__":
+    install_diffusers()
     if not 'HUGGING_FACE_HUB_TOKEN' in os.environ:
         warnings.warn("Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights")
     else:
-        install_diffusers()
         load_model_checkpoint()

--- a/torchbenchmark/models/stable_diffusion_unet/install.py
+++ b/torchbenchmark/models/stable_diffusion_unet/install.py
@@ -10,8 +10,8 @@ def load_model_checkpoint():
     StableDiffusionPipeline.from_pretrained(MODEL_NAME, torch_dtype=torch.float16, safety_checker=None)
 
 if __name__ == "__main__":
+    install_diffusers()
     if not 'HUGGING_FACE_HUB_TOKEN' in os.environ:
         warnings.warn("Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights")
     else:
-        install_diffusers()
         load_model_checkpoint()


### PR DESCRIPTION
This PR moves the `install_diffusers()` call before checking whether HF token is in the environment. This is so users don't need to set the token at the time of installation.