### PR TITLE
Correctly handle OSError in test_bench script

### DIFF
--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       nightly_date:
-        description: "Date of the regression"
+        description: "PyTorch nightly version"
         required: false
 env:
   WITH_PUSH: "true"
@@ -35,7 +35,7 @@ jobs:
           full_ref="${{ github.ref }}"
           prefix="refs/heads/"
           branch_name=${full_ref#$prefix}
-          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" FORCE_DATE="${nightly_date}" \
+          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${nightly_date}" \
               -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:${DOCKER_TAG}
           docker tag ghcr.io/pytorch/torchbench:${DOCKER_TAG} ghcr.io/pytorch/torchbench:latest
       - name: Push docker to remote

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -4,6 +4,10 @@ on:
     # Push the nightly docker daily at 3 PM UTC
     - cron: '0 15 * * *'
   workflow_dispatch:
+    inputs:
+      nightly_date:
+        description: "Date of the regression"
+        required: false
 env:
   WITH_PUSH: "true"
 jobs:
@@ -31,7 +35,8 @@ jobs:
           full_ref="${{ github.ref }}"
           prefix="refs/heads/"
           branch_name=${full_ref#$prefix}
-          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:${DOCKER_TAG}
+          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" FORCE_DATE="${nightly_date}" \
+              -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:${DOCKER_TAG}
           docker tag ghcr.io/pytorch/torchbench:${DOCKER_TAG} ghcr.io/pytorch/torchbench:latest
       - name: Push docker to remote
         if: ${{ env.WITH_PUSH == 'true' }}

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -29,13 +29,18 @@ jobs:
           password: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
       - name: Build TorchBench nightly docker
         run: |
-          export TODAY=$(date +'%Y%m%d')
-          export DOCKER_TAG=dev${TODAY}
+          export NIGHTLY_DATE="${{ github.event.inputs.nightly_date }}"
+          if [ -z "${NIGHTLY_DATE}" ]; then
+            export TODAY=$(date +'%Y%m%d')
+            export DOCKER_TAG=dev${TODAY}
+          else
+            export DOCKER_TAG=dev${NIGHTLY_DATE}
+          fi
           cd benchmark/docker
           full_ref="${{ github.ref }}"
           prefix="refs/heads/"
           branch_name=${full_ref#$prefix}
-          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${nightly_date}" \
+          docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:${DOCKER_TAG}
           docker tag ghcr.io/pytorch/torchbench:${DOCKER_TAG} ghcr.io/pytorch/torchbench:latest
       - name: Push docker to remote

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -32,12 +32,12 @@ RUN cd /workspace/benchmark && \
 RUN cd /workspace/benchmark && \
     . ${SETUP_SCRIPT} && \
     if [ "${FORCE_DATE}" = "skip_check" ]; then \
-        true \
+        echo "torch version check skipped"; \
     elif [ -z "${FORCE_DATE}" ]; then \
         FORCE_DATE=$(date '+%Y%m%d') \
-        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}" \
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"; \
     else \
-        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}" \
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"; \
     fi
 
 # Install TorchBench conda and python dependencies

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -6,9 +6,7 @@ FROM ${BASE_IMAGE}
 ENV CONDA_ENV=torchbench
 ENV SETUP_SCRIPT=/workspace/setup_instance.sh
 ARG TORCHBENCH_BRANCH=${TORCHBENCH_BRANCH:-main}
-ARG FORCE_DATE=${FORCE_DATE:-$(date +'%Y%m%d')}
-
-RUN echo "Forcing to install the nightly date: ${FORCE_DATE}"
+ARG FORCE_DATE=${FORCE_DATE}
 
 # Setup Conda env and CUDA
 RUN git clone -b "${TORCHBENCH_BRANCH}" --single-branch \
@@ -28,8 +26,19 @@ RUN cd /workspace/benchmark && \
 RUN cd /workspace/benchmark && \
     . ${SETUP_SCRIPT} && \
     python utils/cuda_utils.py --install-torch-deps && \
-    python utils/cuda_utils.py --install-torch-nightly && \
-    python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
+    python utils/cuda_utils.py --install-torch-nightly
+
+# Check the installed version of nightly if needed
+RUN cd /workspace/benchmark && \
+    . ${SETUP_SCRIPT} && \
+    if [ "${FORCE_DATE}" = "skip_check" ]; then
+        echo "Version check is bypassed."
+    elif [ -z "${FORCE_DATE}" ]; then
+        FORCE_DATE=$(date '+%Y%m%d')
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
+    else
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
+    fi
 
 # Install TorchBench conda and python dependencies
 RUN cd /workspace/benchmark && \

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -6,6 +6,9 @@ FROM ${BASE_IMAGE}
 ENV CONDA_ENV=torchbench
 ENV SETUP_SCRIPT=/workspace/setup_instance.sh
 ARG TORCHBENCH_BRANCH=${TORCHBENCH_BRANCH:-main}
+ARG FORCE_DATE=${FORCE_DATE:-$(date +'%Y%m%d')}
+
+RUN echo "Forcing to install the nightly date: ${FORCE_DATE}"
 
 # Setup Conda env and CUDA
 RUN git clone -b "${TORCHBENCH_BRANCH}" --single-branch \
@@ -26,8 +29,7 @@ RUN cd /workspace/benchmark && \
     . ${SETUP_SCRIPT} && \
     python utils/cuda_utils.py --install-torch-deps && \
     python utils/cuda_utils.py --install-torch-nightly && \
-    TODAY_STR=$(date +'%Y%m%d') && \
-    python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
+    python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
 
 # Install TorchBench conda and python dependencies
 RUN cd /workspace/benchmark && \

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -31,13 +31,13 @@ RUN cd /workspace/benchmark && \
 # Check the installed version of nightly if needed
 RUN cd /workspace/benchmark && \
     . ${SETUP_SCRIPT} && \
-    if [ "${FORCE_DATE}" = "skip_check" ]; then
-        echo "Version check is bypassed."
-    elif [ -z "${FORCE_DATE}" ]; then
-        FORCE_DATE=$(date '+%Y%m%d')
-        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
-    else
-        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"
+    if [ "${FORCE_DATE}" = "skip_check" ]; then \
+        true \
+    elif [ -z "${FORCE_DATE}" ]; then \
+        FORCE_DATE=$(date '+%Y%m%d') \
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}" \
+    else \
+        python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}" \
     fi
 
 # Install TorchBench conda and python dependencies

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -125,7 +125,7 @@ def run_config(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=F
         print(" [oserror]", flush=True)
         result = {}
         for metric in metrics:
-            result[metric] = e
+            result[metric] = str(e)
         return result
 
 def run_config_accuracy(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=False) -> Dict[str, str]:
@@ -143,7 +143,7 @@ def run_config_accuracy(config: TorchBenchModelConfig, metrics: List[str], dryru
         return {"accuracy": "not_implemented"}
     except OSError as e:
         print(" [oserror]", flush=True)
-        return {"accuracy": f"{e.__str__}"}
+        return {"accuracy": str(e)}
 
 def parse_known_args(args):
     parser = argparse.ArgumentParser()

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -123,10 +123,7 @@ def run_config(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=F
         return dict.fromkeys(metrics, "not_implemented")
     except OSError as e:
         print(" [oserror]", flush=True)
-        result = {}
-        for metric in metrics:
-            result[metric] = str(e)
-        return result
+        return dict.fromkeys(metrics, str(e))
 
 def run_config_accuracy(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=False) -> Dict[str, str]:
     assert metrics == ["accuracy"], f"When running accuracy test, others metrics are not supported: {metrics}."

--- a/userbenchmark/test_bench/run.py
+++ b/userbenchmark/test_bench/run.py
@@ -120,7 +120,13 @@ def run_config(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=F
         return result
     except NotImplementedError as e:
         print(" [not_implemented]", flush=True)
-        return dict.fromkeys(metrics, "not_implemented")    
+        return dict.fromkeys(metrics, "not_implemented")
+    except OSError as e:
+        print(" [oserror]", flush=True)
+        result = {}
+        for metric in metrics:
+            result[metric] = e
+        return result
 
 def run_config_accuracy(config: TorchBenchModelConfig, metrics: List[str], dryrun: bool=False) -> Dict[str, str]:
     assert metrics == ["accuracy"], f"When running accuracy test, others metrics are not supported: {metrics}."
@@ -135,6 +141,9 @@ def run_config_accuracy(config: TorchBenchModelConfig, metrics: List[str], dryru
     except NotImplementedError:
         print(" [not_implemented]", flush=True)
         return {"accuracy": "not_implemented"}
+    except OSError as e:
+        print(" [oserror]", flush=True)
+        return {"accuracy": f"{e.__str__}"}
 
 def parse_known_args(args):
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Handle subprocess segmentation fault error in the test_bench script.

Example:

```
python run_benchmark.py test_bench -m yolov3 -d cuda -t train
```

```
{
    "name": "test_bench",
    "environ": {
        "pytorch_git_version": "f13a21cce50586b74c882ec8e9ef38d60458484e",
        "pytorch_version": "2.2.0.dev20231213+cu118",
        "device": "Tesla T4"
    },
    "metrics": {
        "model=yolov3, test=eval, device=cuda, bs=None, extra_args=[], metric=latencies": "Subprocess terminates with code 11",
        "model=yolov3, test=eval, device=cuda, bs=None, extra_args=[], metric=cpu_peak_mem": "Subprocess terminates with code 11",
        "model=yolov3, test=eval, device=cuda, bs=None, extra_args=[], metric=gpu_peak_mem": "Subprocess terminates with code 11"
    }
}
```

Nightly docker build workflow: https://github.com/pytorch/benchmark/actions/runs/7257082609