### PR TITLE
Remove installing NVIDIA driver and use the host images.

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -4,9 +4,6 @@ ARG BASE_IMAGE=summerwind/actions-runner-dind:latest
 FROM ${BASE_IMAGE}
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-# NVIDIA Driver version: 525.105.17, GKE version: 1.26.5-gke.1200
-# GKE release notes: https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
-ENV NVIDIA_VERSION="525.105.17"
 
 RUN sudo apt-get -y update && sudo apt -y update
 # fontconfig: needed by model doctr_det_predictor
@@ -23,13 +20,7 @@ RUN sudo chmod +x /usr/bin/switch-cuda.sh
 
 RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 
-# Download and the NVIDIA Driver files, NVIDIA Driver version is bundled together with GKE
-# Install runtime libraries only, do not compile the kernel modules
-# The kernel modules are already provided by the host GKE environment
-RUN cd /workspace && mkdir tmp_nvidia && cd tmp_nvidia && \
-    wget -q https://storage.googleapis.com/nvidia-drivers-us-public/tesla/${NVIDIA_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run && \
-    sudo bash ./NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run --no-kernel-modules -s --no-systemd --no-kernel-module-source --no-nvidia-modprobe
-
+# We assume that the host device provides NVIDIA driver libraries
 # Source of the CUDA installation scripts:
 # https://github.com/pytorch/builder/blob/main/common/install_cuda.sh
 


### PR DESCRIPTION
We should not install NVIDIA driver in the Docker image, instead, use the libraries mounted from the host.
