### PR TITLE
pytorch_CycleGAN_and_pix2pix: benchmark converge for custom devices

### DIFF
--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -35,16 +35,12 @@ class Model(BenchmarkModel):
         results_arg = f"--results_dir {results_dir}"
         data_root = os.path.join(DATA_PATH, "pytorch_CycleGAN_and_pix2pix_inputs")
         device_arg = ""
-        device_type = ""
+        device_type = f"--device_type {self.device}"
         if self.device == "cpu":
             device_arg = "--gpu_ids -1"
-            device_type = "--device cpu"
-        elif self.device == "cuda":
+        else:
             device_arg = "--gpu_ids 0"
-            device_type = "--device cuda"
-        elif self.device == "xpu":
-            device_arg = "--gpu_ids 0"
-            device_type = "--device xpu"
+
         if self.test == "train":
             train_args = f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 " + \
                          f"--n_epochs_decay 3 {device_type} {device_arg} {checkpoints_arg}"

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -35,18 +35,22 @@ class Model(BenchmarkModel):
         results_arg = f"--results_dir {results_dir}"
         data_root = os.path.join(DATA_PATH, "pytorch_CycleGAN_and_pix2pix_inputs")
         device_arg = ""
+        device_type = ""
         if self.device == "cpu":
             device_arg = "--gpu_ids -1"
+            device_type = "--device cpu"
         elif self.device == "cuda":
             device_arg = "--gpu_ids 0"
+            device_type = "--device cuda"
         elif self.device == "xpu":
-            device_arg = "--gpu_ids -2"
+            device_arg = "--gpu_ids 0"
+            device_type = "--device xpu"
         if self.test == "train":
             train_args = f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 " + \
-                         f"--n_epochs_decay 3 {device_arg} {checkpoints_arg}"
+                         f"--n_epochs_decay 3 {device_type} {device_arg} {checkpoints_arg}"
             self.training_loop = prepare_training_loop(train_args.split(' '))
         args = f"--dataroot {data_root}/datasets/horse2zebra/testA --name horse2zebra_pretrained --model test " + \
-               f"--no_dropout {device_arg} {checkpoints_arg} {results_arg}"
+               f"--no_dropout {device_type} {device_arg} {checkpoints_arg} {results_arg}"
         self.model, self.input = get_model(args, self.device)
 
     def get_module(self):

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -39,6 +39,8 @@ class Model(BenchmarkModel):
             device_arg = "--gpu_ids -1"
         elif self.device == "cuda":
             device_arg = "--gpu_ids 0"
+        elif self.device == "xpu":
+            device_arg = "--gpu_ids -2"
         if self.test == "train":
             train_args = f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 " + \
                          f"--n_epochs_decay 3 {device_arg} {checkpoints_arg}"

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -35,7 +35,7 @@ class Model(BenchmarkModel):
         results_arg = f"--results_dir {results_dir}"
         data_root = os.path.join(DATA_PATH, "pytorch_CycleGAN_and_pix2pix_inputs")
         device_arg = ""
-        device_type = f"--device_type {self.device}"
+        device_type_arg = f"--device_type {self.device}"
         if self.device == "cpu":
             device_arg = "--gpu_ids -1"
         else:
@@ -43,10 +43,10 @@ class Model(BenchmarkModel):
 
         if self.test == "train":
             train_args = f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 " + \
-                         f"--n_epochs_decay 3 {device_type} {device_arg} {checkpoints_arg}"
+                         f"--n_epochs_decay 3 {device_type_arg} {device_arg} {checkpoints_arg}"
             self.training_loop = prepare_training_loop(train_args.split(' '))
         args = f"--dataroot {data_root}/datasets/horse2zebra/testA --name horse2zebra_pretrained --model test " + \
-               f"--no_dropout {device_type} {device_arg} {checkpoints_arg} {results_arg}"
+               f"--no_dropout {device_type_arg} {device_arg} {checkpoints_arg} {results_arg}"
         self.model, self.input = get_model(args, self.device)
 
     def get_module(self):

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -31,9 +31,9 @@ class BaseModel(ABC):
         """
         self.opt = opt
         self.gpu_ids = opt.gpu_ids
-        self.device_str = opt.device
+        self.device_type = opt.device_type
         self.isTrain = opt.isTrain
-        self.device = torch.device(('{}:{}').format(self.device_str, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
+        self.device = torch.device(('{}:{}').format(self.device_type, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
         self.save_dir = os.path.join(opt.checkpoints_dir, opt.name)  # save all the checkpoints to save_dir
         if opt.preprocess != 'scale_width':  # with [scale_width], input images might have different sizes, which hurts the performance of cudnn.benchmark.
             torch.backends.cudnn.benchmark = True

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -33,7 +33,7 @@ class BaseModel(ABC):
         self.gpu_ids = opt.gpu_ids
         self.device_type = opt.device_type
         self.isTrain = opt.isTrain
-        self.device = torch.device(('{}:{}').format(self.device_type, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
+        self.device = torch.device('{}:{}'.format(self.device_type, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
         self.save_dir = os.path.join(opt.checkpoints_dir, opt.name)  # save all the checkpoints to save_dir
         if opt.preprocess != 'scale_width':  # with [scale_width], input images might have different sizes, which hurts the performance of cudnn.benchmark.
             torch.backends.cudnn.benchmark = True

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -31,8 +31,12 @@ class BaseModel(ABC):
         """
         self.opt = opt
         self.gpu_ids = opt.gpu_ids
+        self.use_xpu = opt.use_xpu
         self.isTrain = opt.isTrain
-        self.device = torch.device('cuda:{}'.format(self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
+        if self.use_xpu:
+            self.device = torch.device('xpu')
+        else:
+            self.device = torch.device('cuda:{}'.format(self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
         self.save_dir = os.path.join(opt.checkpoints_dir, opt.name)  # save all the checkpoints to save_dir
         if opt.preprocess != 'scale_width':  # with [scale_width], input images might have different sizes, which hurts the performance of cudnn.benchmark.
             torch.backends.cudnn.benchmark = True

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -31,12 +31,9 @@ class BaseModel(ABC):
         """
         self.opt = opt
         self.gpu_ids = opt.gpu_ids
-        self.use_xpu = opt.use_xpu
+        self.device_str = opt.device
         self.isTrain = opt.isTrain
-        if self.use_xpu:
-            self.device = torch.device('xpu')
-        else:
-            self.device = torch.device('cuda:{}'.format(self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
+        self.device = torch.device(('{}:{}').format(self.device_str, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
         self.save_dir = os.path.join(opt.checkpoints_dir, opt.name)  # save all the checkpoints to save_dir
         if opt.preprocess != 'scale_width':  # with [scale_width], input images might have different sizes, which hurts the performance of cudnn.benchmark.
             torch.backends.cudnn.benchmark = True

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
@@ -71,15 +71,15 @@ class CycleGANModel(BaseModel):
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
         self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,
-                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
             self.netD_B = networks.define_D(opt.input_nc, opt.ndf, opt.netD,
-                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:
             if opt.lambda_identity > 0.0:  # only works when input and output images have the same number of channels

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
@@ -71,9 +71,9 @@ class CycleGANModel(BaseModel):
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
         self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -97,13 +97,14 @@ def init_weights(net, init_type='normal', init_gain=0.02):
     net.apply(init_func)  # apply the initialization function <init_func>
 
 
-def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[]):
+def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
     """Initialize a network: 1. register CPU/GPU device (with multi-GPU support); 2. initialize the network weights
     Parameters:
         net (network)      -- the network to be initialized
         init_type (str)    -- the name of an initialization method: normal | xavier | kaiming | orthogonal
         gain (float)       -- scaling factor for normal, xavier and orthogonal.
         gpu_ids (int list) -- which GPUs the network runs on: e.g., 0,1,2
+        device             -- device type: cpu/cuda/xpu
 
     Return an initialized network.
     """
@@ -111,11 +112,13 @@ def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[]):
         assert(torch.cuda.is_available())
         net.to(gpu_ids[0])
         net = torch.nn.DataParallel(net, gpu_ids)  # multi-GPUs
+    else:
+        net.to(device)
     init_weights(net, init_type, init_gain=init_gain)
     return net
 
 
-def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[]):
+def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[], device=torch.device('cpu')):
     """Create a generator
 
     Parameters:
@@ -128,6 +131,7 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
         init_type (str)    -- the name of our initialization method.
         init_gain (float)  -- scaling factor for normal, xavier and orthogonal.
         gpu_ids (int list) -- which GPUs the network runs on: e.g., 0,1,2
+        device (torch.device) -- device type: cpu/cuda/xpu
 
     Returns a generator
 
@@ -155,21 +159,22 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
         net = UnetGenerator(input_nc, output_nc, 8, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
     else:
         raise NotImplementedError('Generator model name [%s] is not recognized' % netG)
-    return init_net(net, init_type, init_gain, gpu_ids)
+    return init_net(net, init_type, init_gain, gpu_ids, device)
 
 
-def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[]):
+def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[], device=torch.device('cpu')):
     """Create a discriminator
 
     Parameters:
-        input_nc (int)     -- the number of channels in input images
-        ndf (int)          -- the number of filters in the first conv layer
-        netD (str)         -- the architecture's name: basic | n_layers | pixel
-        n_layers_D (int)   -- the number of conv layers in the discriminator; effective when netD=='n_layers'
-        norm (str)         -- the type of normalization layers used in the network.
-        init_type (str)    -- the name of the initialization method.
-        init_gain (float)  -- scaling factor for normal, xavier and orthogonal.
-        gpu_ids (int list) -- which GPUs the network runs on: e.g., 0,1,2
+        input_nc (int)        -- the number of channels in input images
+        ndf (int)             -- the number of filters in the first conv layer
+        netD (str)            -- the architecture's name: basic | n_layers | pixel
+        n_layers_D (int)      -- the number of conv layers in the discriminator; effective when netD=='n_layers'
+        norm (str)            -- the type of normalization layers used in the network.
+        init_type (str)       -- the name of the initialization method.
+        init_gain (float)     -- scaling factor for normal, xavier and orthogonal.
+        gpu_ids (int list)    -- which GPUs the network runs on: e.g., 0,1,2
+        device (torch.device) -- device type: cpu/cuda/xpu
 
     Returns a discriminator
 
@@ -199,7 +204,7 @@ def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal'
         net = PixelDiscriminator(input_nc, ndf, norm_layer=norm_layer)
     else:
         raise NotImplementedError('Discriminator model name [%s] is not recognized' % netD)
-    return init_net(net, init_type, init_gain, gpu_ids)
+    return init_net(net, init_type, init_gain, gpu_ids, device)
 
 
 ##############################################################################
@@ -281,7 +286,7 @@ def cal_gradient_penalty(netD, real_data, fake_data, device, type='mixed', const
         netD (network)              -- discriminator network
         real_data (tensor array)    -- real images
         fake_data (tensor array)    -- generated images from the generator
-        device (str)                -- GPU / CPU: from torch.device('cuda:{}'.format(self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')
+        device (str)                -- GPU / CPU /XPU
         type (str)                  -- if we mix real and fake data or not [real | fake | mixed].
         constant (float)            -- the constant used in formula ( ||gradient||_2 - constant)^2
         lambda_gp (float)           -- weight for this loss

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -104,21 +104,20 @@ def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
         init_type (str)    -- the name of an initialization method: normal | xavier | kaiming | orthogonal
         gain (float)       -- scaling factor for normal, xavier and orthogonal.
         gpu_ids (int list) -- which GPUs the network runs on: e.g., 0,1,2
-        device             -- device type: cpu/cuda/xpu
+        device (str)       -- device type: cpu/cuda/xpu
 
     Return an initialized network.
     """
     if len(gpu_ids) > 0:
-        assert(torch.cuda.is_available())
-        net.to(gpu_ids[0])
+        assert(hasattr(torch, device))
+        assert(getattr(torch, device).is_available())
+        net.to('{}:{}'.format(device, gpu_ids[0]))
         net = torch.nn.DataParallel(net, gpu_ids)  # multi-GPUs
-    else:
-        net.to(device)
     init_weights(net, init_type, init_gain=init_gain)
     return net
 
 
-def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[], device=torch.device('cpu')):
+def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
     """Create a generator
 
     Parameters:
@@ -131,7 +130,7 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
         init_type (str)    -- the name of our initialization method.
         init_gain (float)  -- scaling factor for normal, xavier and orthogonal.
         gpu_ids (int list) -- which GPUs the network runs on: e.g., 0,1,2
-        device (torch.device) -- device type: cpu/cuda/xpu
+        device (str)       -- device type: cpu/cuda/xpu
 
     Returns a generator
 
@@ -162,7 +161,7 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
     return init_net(net, init_type, init_gain, gpu_ids, device)
 
 
-def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[], device=torch.device('cpu')):
+def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
     """Create a discriminator
 
     Parameters:
@@ -174,7 +173,7 @@ def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal'
         init_type (str)       -- the name of the initialization method.
         init_gain (float)     -- scaling factor for normal, xavier and orthogonal.
         gpu_ids (int list)    -- which GPUs the network runs on: e.g., 0,1,2
-        device (torch.device) -- device type: cpu/cuda/xpu
+        device (str)          -- device type: cpu/cuda/xpu
 
     Returns a discriminator
 
@@ -286,7 +285,7 @@ def cal_gradient_penalty(netD, real_data, fake_data, device, type='mixed', const
         netD (network)              -- discriminator network
         real_data (tensor array)    -- real images
         fake_data (tensor array)    -- generated images from the generator
-        device (str)                -- GPU / CPU /XPU
+        device (str)                -- cpu / cuda / xpu
         type (str)                  -- if we mix real and fake data or not [real | fake | mixed].
         constant (float)            -- the constant used in formula ( ||gradient||_2 - constant)^2
         lambda_gp (float)           -- weight for this loss

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -109,6 +109,7 @@ def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
     Return an initialized network.
     """
     if len(gpu_ids) > 0:
+        assert(device != 'cpu')
         assert(hasattr(torch, device))
         assert(getattr(torch, device).is_available())
         net.to('{}:{}'.format(device, gpu_ids[0]))

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/networks.py
@@ -97,7 +97,7 @@ def init_weights(net, init_type='normal', init_gain=0.02):
     net.apply(init_func)  # apply the initialization function <init_func>
 
 
-def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
+def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cuda'):
     """Initialize a network: 1. register CPU/GPU device (with multi-GPU support); 2. initialize the network weights
     Parameters:
         net (network)      -- the network to be initialized
@@ -118,7 +118,7 @@ def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
     return net
 
 
-def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
+def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, init_type='normal', init_gain=0.02, gpu_ids=[], device='cuda'):
     """Create a generator
 
     Parameters:
@@ -162,7 +162,7 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, in
     return init_net(net, init_type, init_gain, gpu_ids, device)
 
 
-def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[], device='cpu'):
+def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal', init_gain=0.02, gpu_ids=[], device='cuda'):
     """Create a discriminator
 
     Parameters:

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
@@ -54,11 +54,11 @@ class Pix2PixModel(BaseModel):
             self.model_names = ['G']
         # define networks (both generator and discriminator)
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
+                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
             self.netD = networks.define_D(opt.input_nc + opt.output_nc, opt.ndf, opt.netD,
-                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:
             # define loss functions

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
@@ -54,7 +54,7 @@ class Pix2PixModel(BaseModel):
             self.model_names = ['G']
         # define networks (both generator and discriminator)
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
+                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
 
         if self.isTrain:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
             self.netD = networks.define_D(opt.input_nc + opt.output_nc, opt.ndf, opt.netD,

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
@@ -54,7 +54,7 @@ class Pix2PixModel(BaseModel):
             self.model_names = ['G']
         # define networks (both generator and discriminator)
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
 
         if self.isTrain:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
             self.netD = networks.define_D(opt.input_nc + opt.output_nc, opt.ndf, opt.netD,

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
@@ -57,7 +57,7 @@ class TemplateModel(BaseModel):
         # you can use opt.isTrain to specify different behaviors for training and test. For example, some networks will not be used during test, and you don't need to load them.
         self.model_names = ['G']
         # define networks; you can use opt.isTrain to specify different behaviors for training and test.
-        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids)
+        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device)
         if self.isTrain:  # only defined during training time
             # define your loss functions. You can use losses provided by torch.nn such as torch.nn.L1Loss.
             # We also provide a GANLoss class "networks.GANLoss". self.criterionGAN = networks.GANLoss().to(self.device)

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
@@ -57,7 +57,7 @@ class TemplateModel(BaseModel):
         # you can use opt.isTrain to specify different behaviors for training and test. For example, some networks will not be used during test, and you don't need to load them.
         self.model_names = ['G']
         # define networks; you can use opt.isTrain to specify different behaviors for training and test.
-        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device)
+        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device_str)
         if self.isTrain:  # only defined during training time
             # define your loss functions. You can use losses provided by torch.nn such as torch.nn.L1Loss.
             # We also provide a GANLoss class "networks.GANLoss". self.criterionGAN = networks.GANLoss().to(self.device)

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
@@ -57,7 +57,7 @@ class TemplateModel(BaseModel):
         # you can use opt.isTrain to specify different behaviors for training and test. For example, some networks will not be used during test, and you don't need to load them.
         self.model_names = ['G']
         # define networks; you can use opt.isTrain to specify different behaviors for training and test.
-        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device_str)
+        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device_type)
         if self.isTrain:  # only defined during training time
             # define your loss functions. You can use losses provided by torch.nn such as torch.nn.L1Loss.
             # We also provide a GANLoss class "networks.GANLoss". self.criterionGAN = networks.GANLoss().to(self.device)

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
@@ -43,7 +43,7 @@ class TestModel(BaseModel):
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>
         self.model_names = ['G' + opt.model_suffix]  # only generator is needed.
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG,
-                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
+                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
 
         # assigns the model to self.netG_[suffix] so that it can be loaded
         # please see <BaseModel.load_networks>

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
@@ -43,7 +43,7 @@ class TestModel(BaseModel):
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>
         self.model_names = ['G' + opt.model_suffix]  # only generator is needed.
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG,
-                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
 
         # assigns the model to self.netG_[suffix] so that it can be loaded
         # please see <BaseModel.load_networks>

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
@@ -43,7 +43,7 @@ class TestModel(BaseModel):
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>
         self.model_names = ['G' + opt.model_suffix]  # only generator is needed.
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG,
-                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_str)
+                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         # assigns the model to self.netG_[suffix] so that it can be loaded
         # please see <BaseModel.load_networks>

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -22,7 +22,7 @@ class BaseOptions():
         # basic parameters
         parser.add_argument('--dataroot', required=True, help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
         parser.add_argument('--name', type=str, default='experiment_name', help='name of the experiment. It decides where to store samples and models')
-        parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
+        parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU, use -2 for XPU')
         parser.add_argument('--checkpoints_dir', type=str, default='./checkpoints', help='models are saved here')
         # model parameters
         parser.add_argument('--model', type=str, default='cycle_gan', help='chooses which model to use. [cycle_gan | pix2pix | test | colorization]')
@@ -123,11 +123,14 @@ class BaseOptions():
         # set gpu ids
         str_ids = opt.gpu_ids.split(',')
         opt.gpu_ids = []
+        opt.use_xpu = False
         for str_id in str_ids:
             id = int(str_id)
             if id >= 0:
                 opt.gpu_ids.append(id)
-        if len(opt.gpu_ids) > 0:
+            if id == -2:
+                opt.use_xpu = True
+        if len(opt.gpu_ids) > 0 and torch.cuda.avaliable():
             torch.cuda.set_device(opt.gpu_ids[0])
 
         self.opt = opt

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -23,7 +23,7 @@ class BaseOptions():
         parser.add_argument('--dataroot', required=True, help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
         parser.add_argument('--name', type=str, default='experiment_name', help='name of the experiment. It decides where to store samples and models')
         parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
-        parser.add_argument('--device', type=str, default='cpu', help='device type: e.g. cpu, cuda, xpu')
+        parser.add_argument('--device_type', type=str, default='cpu', help='device type: e.g. cpu, cuda, xpu')
         parser.add_argument('--checkpoints_dir', type=str, default='./checkpoints', help='models are saved here')
         # model parameters
         parser.add_argument('--model', type=str, default='cycle_gan', help='chooses which model to use. [cycle_gan | pix2pix | test | colorization]')
@@ -129,9 +129,9 @@ class BaseOptions():
             if id >= 0:
                 opt.gpu_ids.append(id)
         if len(opt.gpu_ids) > 0:
-            assert(hasattr(torch, opt.device))
-            assert(hasattr(getattr(torch, opt.device), 'set_device'))
-            getattr(torch, opt.device).set_device(opt.gpu_ids[0])
+            assert(hasattr(torch, opt.device_type))
+            assert(hasattr(getattr(torch, opt.device_type), 'set_device'))
+            getattr(torch, opt.device_type).set_device(opt.gpu_ids[0])
 
         self.opt = opt
         return self.opt

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -22,7 +22,8 @@ class BaseOptions():
         # basic parameters
         parser.add_argument('--dataroot', required=True, help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
         parser.add_argument('--name', type=str, default='experiment_name', help='name of the experiment. It decides where to store samples and models')
-        parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU, use -2 for XPU')
+        parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
+        parser.add_argument('--device', type=str, default='cpu', help='device type: e.g. cpu, cuda, xpu')
         parser.add_argument('--checkpoints_dir', type=str, default='./checkpoints', help='models are saved here')
         # model parameters
         parser.add_argument('--model', type=str, default='cycle_gan', help='chooses which model to use. [cycle_gan | pix2pix | test | colorization]')
@@ -123,15 +124,15 @@ class BaseOptions():
         # set gpu ids
         str_ids = opt.gpu_ids.split(',')
         opt.gpu_ids = []
-        opt.use_xpu = False
         for str_id in str_ids:
             id = int(str_id)
             if id >= 0:
                 opt.gpu_ids.append(id)
-            if id == -2:
-                opt.use_xpu = True
-        if len(opt.gpu_ids) > 0 and torch.cuda.avaliable():
-            torch.cuda.set_device(opt.gpu_ids[0])
+        if len(opt.gpu_ids) > 0:
+            assert(hasattr(torch, opt.device))
+            print("device:", opt.device)
+            assert(hasattr(getattr(torch, opt.device), 'set_device'))
+            getattr(torch, opt.device).set_device(opt.gpu_ids[0])
 
         self.opt = opt
         return self.opt

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -130,7 +130,6 @@ class BaseOptions():
                 opt.gpu_ids.append(id)
         if len(opt.gpu_ids) > 0:
             assert(hasattr(torch, opt.device))
-            print("device:", opt.device)
             assert(hasattr(getattr(torch, opt.device), 'set_device'))
             getattr(torch, opt.device).set_device(opt.gpu_ids[0])
 


### PR DESCRIPTION
Works for Roadmap https://github.com/pytorch/benchmark/issues/1293 to increase benchmark coverage.

For this model, when running on the custom devices except for CPU and CUDA(e.g. XPU), it will raise the error "torchbench.py: error: unrecognized arguments" as it will not generate any gpu_ids for the custom devices.
In this PR, we accept the device args as a param within the training process and inference process which will cover the model initializing and data transposition for these custom devices. 