### PR TITLE
Added installation requirements for three models

### DIFF
--- a/torchbenchmark/models/drq/requirements.txt
+++ b/torchbenchmark/models/drq/requirements.txt
@@ -1,2 +1,3 @@
 kornia
 scikit-image
+gym

--- a/torchbenchmark/models/soft_actor_critic/requirements.txt
+++ b/torchbenchmark/models/soft_actor_critic/requirements.txt
@@ -1,2 +1,3 @@
 gym
 pygame
+tensorboardX

--- a/torchbenchmark/models/vision_maskrcnn/requirements.txt
+++ b/torchbenchmark/models/vision_maskrcnn/requirements.txt
@@ -1,0 +1,1 @@
+pycocotools


### PR DESCRIPTION
The following three models were missing python package installations that cause them to fail:

- vision_maskrcnn (pycocotools package)
- soft_actor_critic (tensorboardX package)
- drq (gym package)