### PR TITLE
Do not skip `llama_v2_7b_16h` on NVIDIA A100 40G.

### DIFF
--- a/torchbenchmark/models/llama_v2_7b_16h/metadata.yaml
+++ b/torchbenchmark/models/llama_v2_7b_16h/metadata.yaml
@@ -7,9 +7,5 @@ eval_nograd: true
 not_implemented:
 - device: cpu
 - device: NVIDIA A10G
-# TODO: llama_v2_7b_16h accuracy test will cause "CUBLAS_STATUS_NOT_INITIALIZED" Error
-# https://github.com/pytorch/benchmark/issues/2064
-- device: NVIDIA A100-SXM4-40GB
-  test: eval
 train_benchmark: false
 train_deterministic: false


### PR DESCRIPTION
This PR partially reverts #2095, since #2064 seems not to be an issue anymore.