### PR TITLE
Fix a bug in the torch._export.aot_load API

### DIFF
--- a/userbenchmark/dynamo/dynamobench/common.py
+++ b/userbenchmark/dynamo/dynamobench/common.py
@@ -1149,7 +1149,7 @@ def export_aot_inductor(model, example_inputs, device):
 
     def opt_aot_inductor(_, example_inputs, collect_outputs=False):
         example_args, example_kwargs = _normalize_bench_inputs(example_inputs)
-        return optimized(example_args, example_kwargs)
+        return optimized(*example_args, **example_kwargs)
 
     return opt_aot_inductor
 


### PR DESCRIPTION
Summary:
tree_flatten_spec should use args instead of *args

clone of https://github.com/pytorch/pytorch/pull/117948 but with some fbcode specific changes

Differential Revision: D52982401


