### PR TITLE
Fix bisection with start/end versions.

### DIFF
--- a/bisection.py
+++ b/bisection.py
@@ -185,8 +185,12 @@ class BisectionTargetRepo:
     commits: List[Commit]
     # Map from commit SHA to its index in commits
     commit_dict: Dict[str, int]
-    def __init__(self, repo: TorchRepo, start: str, end: str,
-                 start_version: str, end_version: str,
+    def __init__(self,
+                 repo: TorchRepo,
+                 start: str,
+                 end: str,
+                 start_version: str,
+                 end_version: str,
                  non_target_repos: List[TorchRepo]):
         self.repo = repo
         self.start = start
@@ -414,6 +418,8 @@ class TorchBenchBisection:
         target_repo: TorchRepo,
         start: str,
         end: str,
+        start_version: str,
+        end_version: str,
         bisect_config: TorchBenchABTestResult,
         output_json: str,
         debug: bool = False,
@@ -428,7 +434,12 @@ class TorchBenchBisection:
         )
         torchbench_repo_key = "torchbench" if not IS_FBCODE else "fbcode"
         self.target_repo = BisectionTargetRepo(
-            repo=target_repo, start=start, end=end, non_target_repos=non_target_repos
+            repo=target_repo,
+            start=start,
+            end=end,
+            start_version=start_version,
+            end_version=end_version,
+            non_target_repos=non_target_repos,
         )
         self.torchbench = TorchBenchRepo(
             repo=torch_repos[torchbench_repo_key],

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -119,7 +119,7 @@ def install_torchbench_deps():
     # ubuntu 22.04 does not need this hack
     # conda_deps = ["glib"]
     # cmd = ["conda", "install", "-y"] + conda_deps
-    subprocess.check_call(cmd)
+    # subprocess.check_call(cmd)
     cmd = ["pip", "install", "unittest-xml-reporting", "boto3"]
     subprocess.check_call(cmd)
 

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -113,13 +113,14 @@ def install_torch_build_deps(cuda_version: str):
     pip_deps = [ f"numpy=={PIN_NUMPY_VERSION}" ]
     cmd = ["pip", "install"] + pip_deps
     subprocess.check_call(cmd)
+    # conda forge deps
+    # ubuntu 22.04 comes with libstdcxx6 12.3.0
+    # we need to install the same library version in conda
+    conda_deps = ["libstdcxx-ng=12.3.0"]
+    cmd = ["conda", "install", "-y", "-c", "conda-forge"] + conda_deps
+    subprocess.check_call(cmd)
 
 def install_torchbench_deps():
-    # weasyprint requires ffi7, which requires glib > 2.69 on ubuntu 20.04
-    # ubuntu 22.04 does not need this hack
-    # conda_deps = ["glib"]
-    # cmd = ["conda", "install", "-y"] + conda_deps
-    # subprocess.check_call(cmd)
     cmd = ["pip", "install", "unittest-xml-reporting", "boto3"]
     subprocess.check_call(cmd)
 

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -116,8 +116,9 @@ def install_torch_build_deps(cuda_version: str):
 
 def install_torchbench_deps():
     # weasyprint requires ffi7, which requires glib > 2.69 on ubuntu 20.04
-    conda_deps = ["glib"]
-    cmd = ["conda", "install", "-y"] + conda_deps
+    # ubuntu 22.04 does not need this hack
+    # conda_deps = ["glib"]
+    # cmd = ["conda", "install", "-y"] + conda_deps
     subprocess.check_call(cmd)
     cmd = ["pip", "install", "unittest-xml-reporting", "boto3"]
     subprocess.check_call(cmd)


### PR DESCRIPTION
At the compile time, pytorch compilation will link with the system libstdcxx. At runtime, it will use the version provided by conda.

After the upgrade, Ubuntu 22.04 ships with libstdcxx 12.3.0, but the default conda version of libstdcxx-ng is 11.2.0.
Install libstdcxx-ng 12.3.0 to provide the ABI symbol GLIBCXX_3.4.30 at runtime.

Ubuntu 22.04 ships with glib 2.78.3, so it does not need the glib 2.69 trick anymore.

Test Plan:
https://github.com/pytorch/benchmark/actions/runs/7663583650

