### PR TITLE
Set maximum number of runners to 9

### DIFF
--- a/docker/infra/values.yaml
+++ b/docker/infra/values.yaml
@@ -241,8 +241,10 @@ template:
         - name: dshm
           mountPath: /dev/shm
       resources:
-        limits:
+        requests:
           nvidia.com/gpu: 1 # requesting 1 GPU
+        limits:
+          nvidia.com/gpu: 1 # limiting 1 GPU
     volumes:
     - name: nvidia-lib
       hostPath:

--- a/docker/infra/values.yaml
+++ b/docker/infra/values.yaml
@@ -240,6 +240,9 @@ template:
           mountPath: /dev/nvidiactl
         - name: dshm
           mountPath: /dev/shm
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # requesting 1 GPU
     volumes:
     - name: nvidia-lib
       hostPath:
@@ -264,9 +267,6 @@ template:
     - name: dshm
       emptyDir:
         medium: Memory
-    resources:
-      limits:
-        nvidia.com/gpu: 1 # requesting 1 GPU
 ## Optional controller service account that needs to have required Role and RoleBinding
 ## to operate this gha-runner-scale-set installation.
 ## The helm chart will try to find the controller deployment and its service account at installation time.

--- a/docker/infra/values.yaml
+++ b/docker/infra/values.yaml
@@ -37,7 +37,7 @@ githubConfigSecret: arc-secret
 #     - example.org
 
 ## maxRunners is the max number of runners the autoscaling runner set will scale up to.
-maxRunners: 6
+maxRunners: 9
 
 ## minRunners is the min number of idle runners. The target number of runners created will be
 ## calculated as a sum of minRunners and the number of jobs assigned to the scale set.


### PR DESCRIPTION
Add the following 2 improvements to the TorchBench Infra:
1. Set the resource requirements of 1 GPU to the runner
2. Increase the number of maximum runners to 9