### PR TITLE
Added missing batch.pt file for functorch_maml_omniglot

### DIFF
--- a/torchbenchmark/models/functorch_maml_omniglot/install.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/install.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from utils import s3_utils
 
 
 def pip_install_requirements():
@@ -7,3 +8,4 @@ def pip_install_requirements():
 
 if __name__ == '__main__':
     pip_install_requirements()
+    s3_utils.checkout_s3_data("MODEL_PKLS", "maml_omniglot/batch.pt", decompress=False)


### PR DESCRIPTION
`functorch_maml_omniglot` [tries to load some inputs ](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/functorch_maml_omniglot/__init__.py#L73) from a file that it has not downloaded in its `install.py`. This should be done similarly to [how it's done for maml_omniglot](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/maml_omniglot/install.py).

Testing before:


```
FileNotFoundError: [Errno 2] No such file or directory: 'benchmark/torchbenchmark/models/maml_omniglot/batch.pt'

(...)

benchmark/components/_impl/workers/subprocess_rpc.py:458: FileNotFoundError
========================================================================= short test summary info ==========================================================================
FAILED benchmark/test.py::TestBenchmark::test_functorch_maml_omniglot_check_device_cpu - FileNotFoundError: [Errno 2] No such file or directory
FAILED benchmark/test.py::TestBenchmark::test_functorch_maml_omniglot_eval_cpu - FileNotFoundError: [Errno 2] No such file or directory
FAILED benchmark/test.py::TestBenchmark::test_functorch_maml_omniglot_example_cpu - FileNotFoundError: [Errno 2] No such file or directory
FAILED benchmark/test.py::TestBenchmark::test_functorch_maml_omniglot_train_cpu - FileNotFoundError: [Errno 2] No such file or directory
```

and afterwards:

```
==================================================================== 4 passed, 384 deselected in 12.55s ====================================================================
```