### PR TITLE
Enable `--num-batch` by default

### DIFF
--- a/run.py
+++ b/run.py
@@ -105,22 +105,22 @@ def printResultSummaryTime(
                 sep="",
             )
         )
-        print(
-            "{:<20} {:>20}".format(
-                "CPU Wall Time per batch:",
-                "%.3f milliseconds" % (cpu_walltime / model.num_batch),
-                sep="",
-            )
-        )
     else:
         cpu_walltime = np.median(list(map(lambda x: x[0], result_summary)))
-        print(
-            "{:<20} {:>20}".format(
-                "CPU Wall Time per batch:",
-                "%.3f milliseconds" % (cpu_walltime / model.num_batch),
-                sep="",
-            )
+    print(
+        "{:<20} {:>20}".format(
+            "CPU Wall Time per batch:",
+            "%.3f milliseconds" % (cpu_walltime / model.num_batch),
+            sep="",
         )
+    )
+    print(
+        "{:<20} {:>20}".format(
+            "CPU Wall Time:",
+            "%.3f milliseconds" % (cpu_walltime),
+            sep="",
+        )
+    )
     # if model_flops is not None, output the TFLOPs per sec
     if "flops" in metrics_needed:
         if flops_model_analyzer.metrics_backend_mapping["flops"] == "dcgm":

--- a/torchbenchmark/models/nanogpt/__init__.py
+++ b/torchbenchmark/models/nanogpt/__init__.py
@@ -43,14 +43,23 @@ class Model(BenchmarkModel):
             torch.randint(1, self.gpt_config.vocab_size, (self.batch_size, prompt_size)).to(self.device),
         )
 
+        if self.test == "train":
+            self.model.train()
+        else:
+            self.model.eval()
+
     def get_module(self):
         return self.model, self.example_inputs
 
-    def train(self):
-        self.model.train()
+    def forward(self):
         logits = self.model(*self.example_inputs)
         loss = logits.sum() / logits.numel()
+        return loss
+
+    def backward(self, loss):
         loss.backward()
+
+    def optimizer_step(self):
         self.optimizer.step()
 
     def eval(self):

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -267,9 +267,10 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             raise NotImplementedError("The instance variable 'model' does not exist or is not type 'torch.nn.Module', implement your own `set_module()` function.")
 
     def get_input_iter(self) -> Generator:
-        """Return the dynamic input iterator for the model."""
-        raise NotImplementedError(f"Default dynamic input iterator is not implemented. "
-                                  "Please submit an issue if you need a dynamic shape input iterator implementation for the model {self.name}.")
+        """Return the dynamic input iterator for the model. By default, always return the same batch of input."""
+        model, example_inputs = self.get_module()
+        while True:
+            yield example_inputs
 
     def get_input_descriptor(self) -> ModelInputDescriptor:
         if hasattr(self, 'input_descriptor') and isinstance(self.input_descriptor, ModelInputDescriptor):


### PR DESCRIPTION
Summary: By default, we can enable `--num-batch` option for all models by always returning the same batch of input.

Differential Revision: D53549476


