### PR TITLE
Remove the date constraint in the scheduled runs

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -32,13 +32,6 @@ jobs:
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
-      - name: Check PyTorch nightly if scheduled
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
-          pushd benchmark
-          TODAY_STR=$(date +'%Y%m%d')
-          python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
       - name: Clone and setup conda env
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -7,23 +7,18 @@ on:
 jobs:
   run-benchmark:
     environment: docker-s3-upload
+    env:
+      BASE_CONDA_ENV: "torchbench"
+      CONDA_ENV:  "torchbench-v3-nightly"
+      PLATFORM_NAME: "gcp_a100"
+      SETUP_SCRIPT: "/workspace/setup_instance.sh"
+      TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      IS_GHA: 1
+      BUILD_ENVIRONMENT: benchmark-nightly
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [a100-runner]
-    env:
-      DOCKER_HOST:        "unix:///run/docker/docker.sock"
-    container:
-      image: ghcr.io/pytorch/torchbench:latest
-      env:
-        BASE_CONDA_ENV:    "torchbench"
-        CONDA_ENV:         "torchbench-v3-nightly"
-        PLATFORM_NAME:     "gcp_a100"
-        SETUP_SCRIPT: "/workspace/setup_instance.sh"
-        TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        IS_GHA: 1
-        BUILD_ENVIRONMENT: benchmark-nightly
-      options: --gpus all
     steps:
       - name: Checkout TorchBench v3.0 branch
         uses: actions/checkout@v3
@@ -35,13 +30,6 @@ jobs:
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
-      - name: Check PyTorch nightly if scheduled
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
-          pushd benchmark
-          TODAY_STR=$(date +'%Y%m%d')
-          python utils/cuda_utils.py --check-torch-nightly-version --force-date ${TODAY_STR}
       - name: Clone and setup conda env
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -7,18 +7,21 @@ on:
 jobs:
   run-benchmark:
     environment: docker-s3-upload
-    env:
-      BASE_CONDA_ENV: "torchbench"
-      CONDA_ENV:  "torchbench-v3-nightly"
-      PLATFORM_NAME: "gcp_a100"
-      SETUP_SCRIPT: "/workspace/setup_instance.sh"
-      TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      IS_GHA: 1
-      BUILD_ENVIRONMENT: benchmark-nightly
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [a100-runner]
+    container:
+      image: ghcr.io/pytorch/torchbench:latest
+      env:
+        BASE_CONDA_ENV:    "torchbench"
+        CONDA_ENV:         "torchbench-v3-nightly"
+        PLATFORM_NAME:     "gcp_a100"
+        SETUP_SCRIPT: "/workspace/setup_instance.sh"
+        TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TORCHBENCH_USERBENCHMARK_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        IS_GHA: 1
+        BUILD_ENVIRONMENT: benchmark-nightly
+      options: --gpus all
     steps:
       - name: Checkout TorchBench v3.0 branch
         uses: actions/checkout@v3

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -9,6 +9,8 @@ jobs:
     environment: docker-s3-upload
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [a100-runner]
+    env:
+      DOCKER_HOST:        "unix:///run/docker/docker.sock"
     container:
       image: ghcr.io/pytorch/torchbench:latest
       env:

--- a/docker/infra/values.yaml
+++ b/docker/infra/values.yaml
@@ -224,6 +224,7 @@ template:
     - name: runner
       # image: ghcr.io/actions/actions-runner:latest
       image: ghcr.io/pytorch/torchbench:latest
+      imagePullPolicy: Always
       command: ["sh", "-c", "sudo cp -r /usr/bin/nvidia/* /usr/bin; sudo cp -r /usr/lib/x86_64-linux-gnu/nvidia/* /usr/lib/x86_64-linux-gnu; bash /home/runner/run.sh"]
       securityContext:
         privileged: true


### PR DESCRIPTION
We met an issue where the K8s cluster does not update the image for the runners.
Reported to upstream: https://github.com/actions/actions-runner-controller/discussions/3292

Before we find a workaround, we have to remove the constraint on the running date.

Test Plan:
https://github.com/pytorch/benchmark/actions/runs/7911493482