### PR TITLE
Prioritize user-defined `train()` function over the staged `forward()`

### DIFF
--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -125,10 +125,6 @@ class HuggingFaceModel(BenchmarkModel):
                 self.example_inputs['decoder_input_ids'] = eval_context
             self.model.eval()
         self.amp_context = nullcontext
-        if test == "train" and hasattr(self, "train"):
-           # users might implement a placeholder train function that throws NotImplementedError
-           # in this case, try invoking this function to skip the run.
-           self.train()
 
     def get_module(self, wrap_model=True):
         if not self.is_generate and class_models[self.unqual_name][3] == 'AutoModelForSeq2SeqLM':

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -125,6 +125,10 @@ class HuggingFaceModel(BenchmarkModel):
                 self.example_inputs['decoder_input_ids'] = eval_context
             self.model.eval()
         self.amp_context = nullcontext
+        if test == "train" and hasattr(self, "train"):
+           # users might implement a placeholder train function that throws NotImplementedError
+           # in this case, try invoking this function to skip the run.
+           self.train()
 
     def get_module(self, wrap_model=True):
         if not self.is_generate and class_models[self.unqual_name][3] == 'AutoModelForSeq2SeqLM':

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -306,7 +306,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
         return None
 
     def invoke(self) -> Optional[Tuple[torch.Tensor]]:
-        if self.test == "train" and is_staged_train_test(self):
+        if self.test == "train" and is_staged_train_test(self) and (getattr(self, "train", None) == None):
             return self._invoke_staged_train_test(num_batch=self.num_batch)
         assert self.num_batch == 1, "Only staged_train_test supports multiple-batch testing at this time."
         out = None


### PR DESCRIPTION
It gives more user-friendly error messages upon unimplemented train tests.

Fixes https://github.com/pytorch/benchmark/issues/2166

Test Plan:
```
$ python -u run.py -d cuda -t train --bs 4 --metrics None hf_Whisper
/home/runner/miniconda3/envs/torchbench/lib/python3.11/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
/home/runner/miniconda3/envs/torchbench/lib/python3.11/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
/home/runner/miniconda3/envs/torchbench/lib/python3.11/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
Running train method from hf_Whisper on cuda in eager mode with input batch size 4 and precision fp32.
Traceback (most recent call last):
  File "/workspace/benchmark/run.py", line 623, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/workspace/benchmark/run.py", line 593, in main
    run_one_step(
  File "/workspace/benchmark/run.py", line 173, in run_one_step
    func()
  File "/workspace/benchmark/torchbenchmark/util/model.py", line 315, in invoke
    self.train()
  File "/workspace/benchmark/torchbenchmark/models/hf_Whisper/__init__.py", line 20, in train
    raise NotImplementedError("Training is not implemented.")
NotImplementedError: Training is not implemented.
```