### PR TITLE
Further delay the jobs by 1 hour

### DIFF
--- a/.github/workflows/userbenchmark-a100.yml
+++ b/.github/workflows/userbenchmark-a100.yml
@@ -1,7 +1,7 @@
 name: TorchBench Userbenchmark on A100
 on:
   schedule:
-    - cron: '00 17 * * *' # run at 5:00 PM UTC
+    - cron: '00 18 * * *' # run at 6:00 PM UTC, K8s containers will roll out at 12PM EST
   workflow_dispatch:
     inputs:
       userbenchmark_name:

--- a/.github/workflows/v3-nightly.yml
+++ b/.github/workflows/v3-nightly.yml
@@ -2,7 +2,7 @@ name: TorchBench V3 nightly (A100)
 on:
   workflow_dispatch:
   schedule:
-    - cron: '00 17 * * *' # run at 5:00 PM UTC
+    - cron: '00 18 * * *' # run at 6:00 PM UTC, K8s containers will roll out at 12PM EST
 
 jobs:
   run-benchmark:


### PR DESCRIPTION
We have found that the K8s cluster will renew all container images at 12PM EST, and at 1PM EST all runners will have the latest container image. It is not clear how to change this behavior.

To run the latest container image in our nightly jobs, we have to further delay our nightly job to start at 1PM EST