### PR TITLE
Update and fix gnn model factory and models

### DIFF
--- a/torchbenchmark/canary_models/gat/install.py
+++ b/torchbenchmark/canary_models/gat/install.py
@@ -1,11 +1,13 @@
 
 import subprocess
 import sys
+from utils import s3_utils
 
 
 def pip_install_requirements():
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.0.0+cpu.html'])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.1.0+cpu.html'])
 
 
 if __name__ == '__main__':
+    s3_utils.checkout_s3_data("INPUT_TARBALLS", "Reddit_minimal.tar.gz", decompress=True)
     pip_install_requirements()

--- a/torchbenchmark/canary_models/gat/requirements.txt
+++ b/torchbenchmark/canary_models/gat/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/gat/requirements.txt
+++ b/torchbenchmark/canary_models/gat/requirements.txt
@@ -1,4 +1,4 @@
-# pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/gcn/install.py
+++ b/torchbenchmark/canary_models/gcn/install.py
@@ -1,11 +1,13 @@
 
 import subprocess
 import sys
+from utils import s3_utils
 
 
 def pip_install_requirements():
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.0.0+cpu.html'])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.1.0+cpu.html'])
 
 
 if __name__ == '__main__':
+    s3_utils.checkout_s3_data("INPUT_TARBALLS", "Reddit_minimal.tar.gz", decompress=True)
     pip_install_requirements()

--- a/torchbenchmark/canary_models/gcn/requirements.txt
+++ b/torchbenchmark/canary_models/gcn/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/gcn/requirements.txt
+++ b/torchbenchmark/canary_models/gcn/requirements.txt
@@ -1,4 +1,4 @@
-# pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/sage/install.py
+++ b/torchbenchmark/canary_models/sage/install.py
@@ -1,11 +1,13 @@
 
 import subprocess
 import sys
+from utils import s3_utils
 
 
 def pip_install_requirements():
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.0.0+cpu.html'])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt', '-f', 'https://data.pyg.org/whl/torch-2.1.0+cpu.html'])
 
 
 if __name__ == '__main__':
+    s3_utils.checkout_s3_data("INPUT_TARBALLS", "Reddit_minimal.tar.gz", decompress=True)
     pip_install_requirements()

--- a/torchbenchmark/canary_models/sage/requirements.txt
+++ b/torchbenchmark/canary_models/sage/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/sage/requirements.txt
+++ b/torchbenchmark/canary_models/sage/requirements.txt
@@ -1,4 +1,4 @@
-# pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
+pyg_lib # pyg-lib has no build wheel to download, will support this when ready.
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/util/framework/gnn/model_factory.py
+++ b/torchbenchmark/util/framework/gnn/model_factory.py
@@ -110,7 +110,7 @@ class GNNModel(BenchmarkModel):
             for example_output in self.example_outputs:
                 yield example_output
 
-    
+
     def forward(self):
         pred = self.model(**self.example_inputs)
         outputs = next(self.output_generator)

--- a/torchbenchmark/util/framework/gnn/model_factory.py
+++ b/torchbenchmark/util/framework/gnn/model_factory.py
@@ -2,6 +2,7 @@ import torch
 import sys
 import typing
 from contextlib import nullcontext
+import copy
 from torchbenchmark.util.model import BenchmarkModel
 
 import torch_geometric
@@ -42,7 +43,6 @@ class GNNModel(BenchmarkModel):
             data = torch.load(f'{root}/data/.data/Reddit_minimal/sub_reddit_sparse.pt')
         else:
             data = torch.load(f'{root}/data/.data/Reddit_minimal/sub_reddit.pt')
-        print(data)
         mask = None
         sampler = None
         kwargs = {
@@ -82,9 +82,12 @@ class GNNModel(BenchmarkModel):
             tmp_example_outputs.append(batch.y.to(device))
         self.example_inputs = tmp_example_inputs
         self.example_outputs = tmp_example_outputs
+        self.starter_inputs = copy.copy(self.example_inputs) # important to rerun the input generator
 
         if test == "train":
+            self.output_generator = self._gen_target()
             self.optimizer = torch.optim.Adam(self.model.parameters(), lr=0.001)
+            self.loss_fn = torch.nn.CrossEntropyLoss()
             self.model.train()
         elif test == "eval":
             self.model.eval()
@@ -93,13 +96,34 @@ class GNNModel(BenchmarkModel):
     def get_module(self):
         return self.model, self.example_inputs[0]
 
-    def train(self):
-        for batch_id in range(self.num_batch):
-            self.optimizer.zero_grad()
-            out = self.model(**self.example_inputs[batch_id])
-            loss = F.cross_entropy(out, self.example_outputs[batch_id])
-            loss.backward()
-            self.optimizer.step()
+    def get_input_iter(self):
+        """Yield batch of inputs."""
+
+        while True:
+            for example_input in self.starter_inputs:
+                yield example_input
+
+    def _gen_target(self):
+        """Yield batch of targets"""
+
+        while True:
+            for example_output in self.example_outputs:
+                yield example_output
+
+    
+    def forward(self):
+        pred = self.model(**self.example_inputs)
+        outputs = next(self.output_generator)
+
+        return self.loss_fn(pred, outputs)
+
+
+    def backward(self, loss):
+        loss.backward()
+
+
+    def optimizer_step(self):
+        self.optimizer.step()
 
 
     def eval(self) -> typing.Tuple[torch.Tensor]:


### PR DESCRIPTION
This PR deals with a variety of issues around gnn canary models. Currently the models:
- sage
- gcn
- gat

are failing directly from the installation step as they are missing the required data file, `sub_reddit.pt`. 

The PR checks out the data file `Reddit_minimal.tar.gz` from S3 for all these models. It also updates the requirements and installation files, for example importing `pyg_lib`, since running the models without it causes `NeighborSampler` to throw a deprecation warning.

Lastly, this PR focuses on the updating of the gnn model factory to be more in line with both `model.py` and [_invoke_staged_train_test()](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/util/model.py#L289) as it is a multi batch model. This means that it needed a `forward()`, `backward()`, `optimizer_step()` and `get_input_iter()` function. This would also make it more in line with other model factories such as the vision one. 

These changes allow the models to be trained with `run.py`:

```
python benchmark/run.py sage -d cpu -t train --metrics model_flops,cpu_peak_mem,ttfb
Warning: The model sage cannot be found at core set.
Running train method from sage on cpu in eager mode with input batch size 64 and precision fp32.
3054644320
Module              FLOP    % Total
-------------  ---------  ---------
Global         3054.644M    100.00%
 - aten.addmm   763.661M     25.00%
 - aten.mm     2290.983M     75.00%
CPU Wall Time per batch:   1.654 milliseconds
CPU Wall Time:       201.804 milliseconds
Time to first batch:          321.6082 ms
Model Flops:         0.0151 TFLOPs per second
CPU Peak Memory:                0.3770 GB
```
```
python benchmark/run.py gat -d cpu -t train --metrics cpu_peak_mem,ttfb
Warning: The model gat cannot be found at core set.
Running train method from gat on cpu in eager mode with input batch size 64 and precision fp32.
CPU Wall Time per batch:   2.721 milliseconds
CPU Wall Time:       331.996 milliseconds
Time to first batch:          174.6178 ms
CPU Peak Memory:                0.3594 GB
```
```
python benchmark/run.py gcn -d cpu -t train --metrics cpu_peak_mem,ttfb
Warning: The model gcn cannot be found at core set.
Running train method from gcn on cpu in eager mode with input batch size 64 and precision fp32.
CPU Wall Time per batch:   1.795 milliseconds
CPU Wall Time:       219.015 milliseconds
Time to first batch:          220.0093 ms
CPU Peak Memory:                0.3350 GB
```

NOTE: Gat and Gcn cannot collect model_flops metrics because there is a bug when running these models with the FlopCounterMode context manager ([here](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/util/experiment/metrics.py#L106)). 

NOTE 2: eval is not supported yet as there is no `_invoke_staged_eval_test`() function yet, but this would be a good idea to implement for completion. 
