### PR TITLE
Bump transformers from 4.36.0 to 4.38.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests
 tabulate
 git+https://github.com/huggingface/pytorch-image-models.git@730b907
 # this version of transformers is required as per this page https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1
-transformers==4.36.0
+transformers==4.38.1
 MonkeyType
 psutil
 pyyaml


### PR DESCRIPTION
A previous transformers update to torchbench (https://github.com/pytorch/pytorch/pull/117073) resulted in some failures on the TorchInductor benchmarks (https://github.com/pytorch/pytorch/issues/117280).

A fix was made to transformers (https://github.com/huggingface/transformers/pull/27871), which was released in transformers version 4.38.0, so I would like to bump the version in torchbench so that we can fix the issue with the Inductor benchmarks.

Please let me know if there are any procedures I should go through for this update!