### PR TITLE
Fix installation for diffuser_instruct_pix2pix

### DIFF
--- a/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
+++ b/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
@@ -11,10 +11,10 @@ def load_model_checkpoint():
     StableDiffusionInstructPix2PixPipeline.from_pretrained(MODEL_NAME, torch_dtype=torch.float16, safety_checker=None)
 
 if __name__ == '__main__':
+    install_diffusers()
     if not "HUGGING_FACE_HUB_TOKEN" in os.environ:
         warnings.warn(
             "Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights"
         )
     else:
-        install_diffusers()
         load_model_checkpoint()

--- a/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
+++ b/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
@@ -6,8 +6,8 @@ import warnings
 MODEL_NAME = "timbrooks/instruct-pix2pix"
 
 def load_model_checkpoint():
-
     from diffusers import StableDiffusionInstructPix2PixPipeline
+
     StableDiffusionInstructPix2PixPipeline.from_pretrained(MODEL_NAME, torch_dtype=torch.float16, safety_checker=None)
 
 if __name__ == '__main__':

--- a/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
+++ b/torchbenchmark/canary_models/diffuser_instruct_pix2pix/install.py
@@ -1,11 +1,20 @@
 from torchbenchmark.util.framework.diffusers import install_diffusers
-from diffusers import StableDiffusionInstructPix2PixPipeline
 import torch
+import os
+import warnings
 
 MODEL_NAME = "timbrooks/instruct-pix2pix"
 
 def load_model_checkpoint():
+
+    from diffusers import StableDiffusionInstructPix2PixPipeline
     StableDiffusionInstructPix2PixPipeline.from_pretrained(MODEL_NAME, torch_dtype=torch.float16, safety_checker=None)
 
 if __name__ == '__main__':
-    install_diffusers()
+    if not "HUGGING_FACE_HUB_TOKEN" in os.environ:
+        warnings.warn(
+            "Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights"
+        )
+    else:
+        install_diffusers()
+        load_model_checkpoint()


### PR DESCRIPTION
Currently `diffuser_instruct_pix2pix/install.py` tries to import `diffusers` before installing the requirements throwing an error:

```
from diffusers import StableDiffusionInstructPix2PixPipeline
ModuleNotFoundError: No module named 'diffusers'
```
These changes fix the installation making this file similar to other diffuser installation scripts. 

