### PR TITLE
Fix BERT_pytorch model on bf16.

### DIFF
--- a/.github/workflows/pr-gha-runner.yml
+++ b/.github/workflows/pr-gha-runner.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
+          sudo ldconfig
           nvidia-smi
       - name: Clone and setup Conda env
         run: |

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -208,7 +208,7 @@ class Model(BenchmarkModel):
         return self.model.model, self.example_inputs
 
     def set_module(self, new_model):
-        self.model.bert = new_model
+        self.model.model = new_model
 
     def eval(self) -> typing.Tuple[torch.Tensor]:
         model = self.model

--- a/torchbenchmark/models/BERT_pytorch/__init__.py
+++ b/torchbenchmark/models/BERT_pytorch/__init__.py
@@ -205,7 +205,7 @@ class Model(BenchmarkModel):
         self.model = trainer
 
     def get_module(self):
-        return self.model.bert, self.example_inputs
+        return self.model.model, self.example_inputs
 
     def set_module(self, new_model):
         self.model.bert = new_model

--- a/torchbenchmark/models/BERT_pytorch/bert_pytorch/trainer/pretrain.py
+++ b/torchbenchmark/models/BERT_pytorch/bert_pytorch/trainer/pretrain.py
@@ -42,9 +42,11 @@ class BERTTrainer:
         # Initialize the BERT Language Model, with BERT model
         self.model = BERTLM(bert, vocab_size).to(self.device)
 
+        # torchbench: by default, we assume the model runs on single GPU
+        # and we handle data parallel in the framework level
         # Distributed GPU training if CUDA can detect more than 1 GPU
-        if self.device.type == "cuda" and torch.cuda.device_count() > 1:
-            self.model = nn.DataParallel(self.model, device_ids=device_ids)
+        # if self.device.type == "cuda" and torch.cuda.device_count() > 1:
+        #     self.model = nn.DataParallel(self.model, device_ids=device_ids)
 
         # Setting the train and test data loader
         self.train_data = train_dataloader


### PR DESCRIPTION
The `get_module()` impl of BERT_pytorch is buggy because it only returns partial computation involved in `train()` and `eval()`. As a result, when running in `bf16` precision, only part of the model are converted to `bf16` and it does not work well with the rest of the model running in `eval()`.

This fix will return the entire model in `get_module()` and fix the bug when running with bf16 precision for both eager and pt2 mode.

Test Plan:

```
$ python run.py BERT_pytorch -d cuda --precision bf16 --torchdynamo inductor
Running eval method from BERT_pytorch on cuda in dynamo inductor mode with input batch size 32 and precision bf16.
GPU Time per batch:   14.625 milliseconds
CPU Wall Time per batch:  14.663 milliseconds
CPU Wall Time:        14.663 milliseconds
Time to first batch:         3477.1816 ms
GPU 0 Peak Memory:              3.8965 GB
CPU Peak Memory:                0.7637 GB
PT2 Compilation time:      33.701 seconds
```