### PR TITLE
Unet: disable deterministic on training

### DIFF
--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -6,7 +6,6 @@ import torch.nn.functional as F
 from torch import optim
 from typing import Tuple
 
-torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 
 from .pytorch_unet.unet import UNet
@@ -89,6 +88,7 @@ class Model(BenchmarkModel):
             self.model = torch.jit.script(self.model)
 
     def eval(self) -> Tuple[torch.Tensor]:
+        torch.backends.cudnn.deterministic = True
         self.model.eval()
         with torch.no_grad():
             with torch.cuda.amp.autocast(enabled=self.args.amp):

--- a/torchbenchmark/models/pytorch_unet/metadata.yaml
+++ b/torchbenchmark/models/pytorch_unet/metadata.yaml
@@ -5,4 +5,4 @@ eval_benchmark: false
 eval_deterministic: true
 eval_nograd: true
 train_benchmark: false
-train_deterministic: true
+train_deterministic: false


### PR DESCRIPTION
It seems that the backward of some upsample cuda kernels is not deterministic:
https://github.com/pytorch/pytorch/pull/121324#issuecomment-2011091426

/cc @ezyang 

