### PR TITLE
yolov3: benchmark coverage for xpu devices

### DIFF
--- a/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
@@ -37,7 +37,7 @@ def select_device(device='', apex=False, batch_size=None):
 
     if xpu_request:
         print('Using XPU')
-        return torch.device('xpu')
+        return torch.device(f"xpu:{torch.xpu.current_device()}")
 
     print('Using CPU')
     return torch.device('cpu')

--- a/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
@@ -24,15 +24,20 @@ def init_seeds(seed=0):
 
 
 def select_device(device='', apex=False, batch_size=None):
-    # device = 'cpu' or '0' or '0,1,2,3'
+    # device = 'cpu', 'xpu' or '0' or '0,1,2,3'
     cpu_request = device.lower() == 'cpu'
-    if device and not cpu_request:  # if device requested other than 'cpu'
+    xpu_request = device.lower() == 'xpu'
+    if device and not cpu_request and not xpu_request:  # if device requested other than 'cpu'and 'xpu'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
         assert torch.cuda.is_available(), 'CUDA unavailable, invalid device %s requested' % device  # check availablity
 
-    cuda = False if cpu_request else torch.cuda.is_available()
+    cuda = False if cpu_request or xpu_request else torch.cuda.is_available()
     if cuda:
         return torch.device(f"cuda:{torch.cuda.current_device()}")
+
+    if xpu_request:
+        print('Using XPU')
+        return torch.device('xpu')
 
     print('Using CPU')
     return torch.device('cpu')


### PR DESCRIPTION
Works for Roadmap https://github.com/pytorch/benchmark/issues/1293 to increase benchmark coverage.

For this model, running on custom devices except for CPU and CUDA(e.g. XPU) will raise the error as it's hardcoded with the CPU backend and CUDA backends.
In this PR, we add support for 'xpu' devices to enable benchmarking this model on xpu devices.