### PR TITLE
tacotron2: benchmark coverage for custom devices

### DIFF
--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -28,7 +28,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Tacotron2 doesn't support CPU because load_model assumes CUDA.")
 
         self.hparams = self.create_hparams(batch_size=self.batch_size)
-        self.model = load_model(self.hparams).to(device=device)
+        self.model = load_model(self.hparams, device)
         self.optimizer = torch.optim.Adam(self.model.parameters(),
                                           lr=self.hparams.learning_rate,
                                           weight_decay=self.hparams.weight_decay)

--- a/torchbenchmark/models/tacotron2/train_tacotron2.py
+++ b/torchbenchmark/models/tacotron2/train_tacotron2.py
@@ -70,8 +70,8 @@ def prepare_directories_and_logger(output_directory, log_directory, rank):
     return logger
 
 
-def load_model(hparams):
-    model = Tacotron2(hparams).cuda()
+def load_model(hparams, device='cuda'):
+    model = Tacotron2(hparams).to(device)
     if hparams.fp16_run:
         model.decoder.attention_layer.score_mask_value = finfo('float16').min
 


### PR DESCRIPTION
Works for Roadmap https://github.com/pytorch/benchmark/issues/1293 to increase benchmark coverage.

For this model, running on custom devices except for CPU and CUDA(e.g. XPU) will raise the error as it's hardcoded with the CUDA backends.
In this PR, we add support for custom devices to enable benchmarking this model on custom devices as the device information is sent by the args 'device'.  