### PR TITLE
nvidia_deeprecommender: benchmark coverage for custom devices

### DIFF
--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -94,7 +94,7 @@ def processArgState(args) :
       quit()
   
   args.use_cuda = torch.cuda.is_available() # global flag
-  args.use_xpu = args.device == 'xpu'
+  args.use_xpu = torch.xpu.is_available()
   if not args.silent:
     if args.use_cuda or args.use_xpu:
       print('GPU is available.') 

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -101,10 +101,8 @@ def processArgState(args) :
     else: 
       print('GPU is not available.')
   
-  if args.use_cuda and args.forcecpu:
+  if args.forcecpu:
       args.use_cuda = False
-  
-  if args.use_xpu and args.forcecpu:
       args.use_xpu = False
 
   if not args.silent:

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -57,7 +57,7 @@ def getCommandLineArgs() :
 
   return args
 
-def getBenchmarkArgs(forceCuda):
+def getBenchmarkArgs(forceCuda, device='cuda'):
 
   class Args:
     pass
@@ -76,10 +76,11 @@ def getBenchmarkArgs(forceCuda):
   args.batch_size         = 1
   args.jit                = False
   args.forcecuda          = forceCuda
-  args.forcecpu           = not forceCuda
+  args.forcecpu           = False if forceCuda else device == 'cpu'
   args.nooutput           = True
   args.silent             = True
   args.profile            = False
+  args.device             = device
 
   return args
 
@@ -93,8 +94,9 @@ def processArgState(args) :
       quit()
   
   args.use_cuda = torch.cuda.is_available() # global flag
+  args.use_xpu = args.device == 'xpu'
   if not args.silent:
-    if args.use_cuda:
+    if args.use_cuda or args.use_xpu:
       print('GPU is available.') 
     else: 
       print('GPU is not available.')
@@ -102,11 +104,14 @@ def processArgState(args) :
   if args.use_cuda and args.forcecpu:
       args.use_cuda = False
   
+  if args.use_xpu and args.forcecpu:
+      args.use_xpu = False
+
   if not args.silent:
-    if args.use_cuda:
+    if args.use_cuda or args.use_xpu:
       print('Running On GPU')
     else:
-      print('Running On CUDA')
+      print('Running On CPU')
   
     if args.profile:
       print('Profiler Enabled')
@@ -134,11 +139,13 @@ class DeepRecommenderInferenceBenchmark:
         forcecuda = False
       elif device == "cuda":
         forcecuda = True
+      elif device == "xpu":
+        forcecuda = False
       else:
         # unknown device string, quit init
         return
 
-      self.args = getBenchmarkArgs(forcecuda)
+      self.args = getBenchmarkArgs(forcecuda, device)
 
     args = processArgState(self.args)
 
@@ -199,6 +206,7 @@ class DeepRecommenderInferenceBenchmark:
 
   
     if self.args.use_cuda: self.rencoder = self.rencoder.cuda()
+    elif self.args.use_xpu: self.rencoder = self.rencoder.xpu()
 
     if self.toytest == False:
       self.inv_userIdMap = {v: k for k, v in self.data_layer.userIdMap.items()}
@@ -214,7 +222,7 @@ class DeepRecommenderInferenceBenchmark:
         continue
 
       for i, ((out, src), majorInd) in enumerate(self.eval_data_layer.iterate_one_epoch_eval(for_inf=True)):
-        inputs = Variable(src.cuda().to_dense() if self.args.use_cuda else src.to_dense())
+        inputs = Variable(src.to(device).to_dense())
         targets_np = out.to_dense().numpy()[0, :]
   
         out = self.rencoder(inputs)
@@ -237,7 +245,7 @@ class DeepRecommenderInferenceBenchmark:
       e_start_time = time.time()
   
       if self.args.profile:
-        with profiler.profile(record_shapes=True, use_cuda=True) as prof:
+        with profiler.profile(record_shapes=True, use_cuda=self.args.use_cuda, use_xpu=self.args.use_xpu) as prof:
           with profiler.record_function("Inference"):
             self.eval()
       else:


### PR DESCRIPTION
Works for Roadmap https://github.com/pytorch/benchmark/issues/1293 to increase benchmark coverage.

For this model, when running on the custom devices except for CPU and CUDA(e.g. XPU), it will raise the error "'DeepRecommenderTrainBenchmark' object has no attribute 'rencoder'" as it will not initialize the rencoder for the custom devices.
In this PR, we accept the device args as a param within the training process and inference process which will cover the model initializing and data transposition for these custom devices.