### PR TITLE
add condition in enable_amp to fix eval not work under amp

### DIFF
--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -188,9 +188,10 @@ def apply_decoration_args(
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
         elif model.test == "train":
             # the model must implement staged train test
-            assert is_staged_train_test(
-                model
-            ), f"Expected model implements staged train test (forward, backward, optimizer)."
+            warnings.warn(
+                    "Usually models do not want to enable amp only in forward path, so expected "
+                    "model to have staged train support."
+                    )
             import torch
 
             model.add_context(

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -189,7 +189,7 @@ def apply_decoration_args(
         elif model.test == "train":
             # the model must implement staged train test
             warnings.warn(
-                    "Usually models do not want to enable amp only in forward path, so expected "
+                    "Usually models only want to enable AMP in forward path, so expected "
                     "model to have staged train support."
                     )
             import torch

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -187,17 +187,21 @@ def apply_decoration_args(
 
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
         elif model.test == "train":
-            # the model must implement staged train test
-            warnings.warn(
-                    "Usually models only want to enable AMP in forward path, so expected "
-                    "model to have staged train support."
-                    )
-            import torch
+            if is_staged_train_test(model):
+                import torch
 
-            model.add_context(
+                model.add_context(
                 lambda: torch.cuda.amp.autocast(dtype=torch.float16),
                 stage=TEST_STAGE.FORWARD,
             )
+            else:
+                warnings.warn(
+                        "Usually models only want to enable AMP in forward path, so expected "
+                        "model to have staged train support. As the model do not support staged "
+                        "training, try to add context to TEST_STAGE.ALL."
+                        )
+                model.enable_amp()
+
     elif dargs.precision == "amp_bf16":
         assert model.device == "cpu", "amp_bf16 is only supported on cpu device."
         if model.test == "eval":

--- a/torchbenchmark/util/extra_args.py
+++ b/torchbenchmark/util/extra_args.py
@@ -187,20 +187,23 @@ def apply_decoration_args(
 
             model.add_context(lambda: torch.cuda.amp.autocast(dtype=torch.float16))
         elif model.test == "train":
-            if is_staged_train_test(model):
-                import torch
+            import torch
 
+            if is_staged_train_test(model):
                 model.add_context(
                 lambda: torch.cuda.amp.autocast(dtype=torch.float16),
                 stage=TEST_STAGE.FORWARD,
-            )
+                )
             else:
                 warnings.warn(
                         "Usually models only want to enable AMP in forward path, so expected "
                         "model to have staged train support. As the model do not support staged "
                         "training, try to add context to TEST_STAGE.ALL."
                         )
-                model.enable_amp()
+                model.add_context(
+                lambda: torch.cuda.amp.autocast(dtype=torch.float16),
+                stage=TEST_STAGE.ALL,
+                )
 
     elif dargs.precision == "amp_bf16":
         assert model.device == "cpu", "amp_bf16 is only supported on cpu device."

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -490,7 +490,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
                 self.add_context(self.amp_context, TEST_STAGE.FORWARD)
             else:
                 warnings.warn(
-                        "Usually models do not want to enable amp only in forward path, so expected "
+                        "Usually models only want to enable AMP in forward path, so expected "
                         "model to have staged train support."
                         )
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -483,7 +483,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.amp_context = lambda: torch.cpu.amp.autocast()
         elif self.device == "cuda":
             self.amp_context = lambda: torch.cuda.amp.autocast()
-        if is_staged_train_test(self):
+        if self.test == "train" and is_staged_train_test(self):
             self.forward_contexts.append(self.amp_context)
 
     @property

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -483,8 +483,18 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.amp_context = lambda: torch.cpu.amp.autocast()
         elif self.device == "cuda":
             self.amp_context = lambda: torch.cuda.amp.autocast()
-        if self.test == "train" and is_staged_train_test(self):
-            self.forward_contexts.append(self.amp_context)
+        if self.test == "eval":
+            self.add_context(self.amp_context)
+        elif self.test == "train":
+            if is_staged_train_test(self):
+                self.add_context(self.amp_context, TEST_STAGE.FORWARD)
+            else:
+                warnings.warn(
+                        "Usually models do not want to enable amp only in forward path, so expected "
+                        "model to have staged train support."
+                        )
+
+
 
     @property
     def pt2_compilation_time(self) -> Optional[float]:

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -491,8 +491,10 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             else:
                 warnings.warn(
                         "Usually models only want to enable AMP in forward path, so expected "
-                        "model to have staged train support."
+                        "model to have staged train support. As the model do not support staged "
+                        "training, try to add context to TEST_STAGE.ALL."
                         )
+                self.add_context(self.amp_context)
 
 
 


### PR DESCRIPTION
when we running alexnet eval with amp, it will failed due to AttributeError: 'Model' object has no attribute 'forward_contexts'
when i check the code, i found that it will go into the is_staged_train_test and even i just want to run eval. 
so i modify the condition and it will pass then.
