### PR TITLE
Tacotron2, yolov3*: benchmark coverage for custom devices.

### DIFF
--- a/torchbenchmark/models/LearningToPaint/baseline/utils/util.py
+++ b/torchbenchmark/models/LearningToPaint/baseline/utils/util.py
@@ -37,7 +37,7 @@ def prBlack(prt):
 
 
 def to_numpy(var):
-    return var.cpu().data.numpy() if USE_CUDA else var.data.numpy()
+    return var.cpu().data.numpy()
 
 
 def to_tensor(ndarray, device):

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -94,7 +94,7 @@ def processArgState(args) :
       quit()
   
   args.use_cuda = torch.cuda.is_available() # global flag
-  args.use_xpu = args.device == 'xpu'
+  args.use_xpu = torch.xpu.is_available()
   if not args.silent:
     if args.use_cuda or args.use_xpu:
       print('GPU is available.') 

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -101,10 +101,8 @@ def processArgState(args) :
     else: 
       print('GPU is not available.')
   
-  if args.use_cuda and args.forcecpu:
+  if args.forcecpu:
       args.use_cuda = False
-  
-  if args.use_xpu and args.forcecpu:
       args.use_xpu = False
 
   if not args.silent:

--- a/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
+++ b/torchbenchmark/models/nvidia_deeprecommender/nvinfer.py
@@ -57,7 +57,7 @@ def getCommandLineArgs() :
 
   return args
 
-def getBenchmarkArgs(forceCuda):
+def getBenchmarkArgs(forceCuda, device='cuda'):
 
   class Args:
     pass
@@ -76,10 +76,11 @@ def getBenchmarkArgs(forceCuda):
   args.batch_size         = 1
   args.jit                = False
   args.forcecuda          = forceCuda
-  args.forcecpu           = not forceCuda
+  args.forcecpu           = False if forceCuda else device == 'cpu'
   args.nooutput           = True
   args.silent             = True
   args.profile            = False
+  args.device             = device
 
   return args
 
@@ -93,8 +94,9 @@ def processArgState(args) :
       quit()
   
   args.use_cuda = torch.cuda.is_available() # global flag
+  args.use_xpu = args.device == 'xpu'
   if not args.silent:
-    if args.use_cuda:
+    if args.use_cuda or args.use_xpu:
       print('GPU is available.') 
     else: 
       print('GPU is not available.')
@@ -102,11 +104,14 @@ def processArgState(args) :
   if args.use_cuda and args.forcecpu:
       args.use_cuda = False
   
+  if args.use_xpu and args.forcecpu:
+      args.use_xpu = False
+
   if not args.silent:
-    if args.use_cuda:
+    if args.use_cuda or args.use_xpu:
       print('Running On GPU')
     else:
-      print('Running On CUDA')
+      print('Running On CPU')
   
     if args.profile:
       print('Profiler Enabled')
@@ -134,11 +139,13 @@ class DeepRecommenderInferenceBenchmark:
         forcecuda = False
       elif device == "cuda":
         forcecuda = True
+      elif device == "xpu":
+        forcecuda = False
       else:
         # unknown device string, quit init
         return
 
-      self.args = getBenchmarkArgs(forcecuda)
+      self.args = getBenchmarkArgs(forcecuda, device)
 
     args = processArgState(self.args)
 
@@ -199,6 +206,7 @@ class DeepRecommenderInferenceBenchmark:
 
   
     if self.args.use_cuda: self.rencoder = self.rencoder.cuda()
+    elif self.args.use_xpu: self.rencoder = self.rencoder.xpu()
 
     if self.toytest == False:
       self.inv_userIdMap = {v: k for k, v in self.data_layer.userIdMap.items()}
@@ -214,7 +222,7 @@ class DeepRecommenderInferenceBenchmark:
         continue
 
       for i, ((out, src), majorInd) in enumerate(self.eval_data_layer.iterate_one_epoch_eval(for_inf=True)):
-        inputs = Variable(src.cuda().to_dense() if self.args.use_cuda else src.to_dense())
+        inputs = Variable(src.to(device).to_dense())
         targets_np = out.to_dense().numpy()[0, :]
   
         out = self.rencoder(inputs)
@@ -237,7 +245,7 @@ class DeepRecommenderInferenceBenchmark:
       e_start_time = time.time()
   
       if self.args.profile:
-        with profiler.profile(record_shapes=True, use_cuda=True) as prof:
+        with profiler.profile(record_shapes=True, use_cuda=self.args.use_cuda, use_xpu=self.args.use_xpu) as prof:
           with profiler.record_function("Inference"):
             self.eval()
       else:

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -35,16 +35,18 @@ class Model(BenchmarkModel):
         results_arg = f"--results_dir {results_dir}"
         data_root = os.path.join(DATA_PATH, "pytorch_CycleGAN_and_pix2pix_inputs")
         device_arg = ""
+        device_type_arg = f"--device_type {self.device}"
         if self.device == "cpu":
             device_arg = "--gpu_ids -1"
-        elif self.device == "cuda":
+        else:
             device_arg = "--gpu_ids 0"
+
         if self.test == "train":
             train_args = f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 " + \
-                         f"--n_epochs_decay 3 {device_arg} {checkpoints_arg}"
+                         f"--n_epochs_decay 3 {device_type_arg} {device_arg} {checkpoints_arg}"
             self.training_loop = prepare_training_loop(train_args.split(' '))
         args = f"--dataroot {data_root}/datasets/horse2zebra/testA --name horse2zebra_pretrained --model test " + \
-               f"--no_dropout {device_arg} {checkpoints_arg} {results_arg}"
+               f"--no_dropout {device_type_arg} {device_arg} {checkpoints_arg} {results_arg}"
         self.model, self.input = get_model(args, self.device)
 
     def get_module(self):

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/base_model.py
@@ -31,8 +31,9 @@ class BaseModel(ABC):
         """
         self.opt = opt
         self.gpu_ids = opt.gpu_ids
+        self.device_type = opt.device_type
         self.isTrain = opt.isTrain
-        self.device = torch.device('cuda:{}'.format(self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
+        self.device = torch.device('{}:{}'.format(self.device_type, self.gpu_ids[0])) if self.gpu_ids else torch.device('cpu')  # get device name: CPU or GPU
         self.save_dir = os.path.join(opt.checkpoints_dir, opt.name)  # save all the checkpoints to save_dir
         if opt.preprocess != 'scale_width':  # with [scale_width], input images might have different sizes, which hurts the performance of cudnn.benchmark.
             torch.backends.cudnn.benchmark = True

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/cycle_gan_model.py
@@ -71,15 +71,15 @@ class CycleGANModel(BaseModel):
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
         self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,
-                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
             self.netD_B = networks.define_D(opt.input_nc, opt.ndf, opt.netD,
-                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                            opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:
             if opt.lambda_identity > 0.0:  # only works when input and output images have the same number of channels

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/pix2pix_model.py
@@ -54,11 +54,11 @@ class Pix2PixModel(BaseModel):
             self.model_names = ['G']
         # define networks (both generator and discriminator)
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
             self.netD = networks.define_D(opt.input_nc + opt.output_nc, opt.ndf, opt.netD,
-                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         if self.isTrain:
             # define loss functions

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/template_model.py
@@ -57,7 +57,7 @@ class TemplateModel(BaseModel):
         # you can use opt.isTrain to specify different behaviors for training and test. For example, some networks will not be used during test, and you don't need to load them.
         self.model_names = ['G']
         # define networks; you can use opt.isTrain to specify different behaviors for training and test.
-        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids)
+        self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, gpu_ids=self.gpu_ids, device=self.device_type)
         if self.isTrain:  # only defined during training time
             # define your loss functions. You can use losses provided by torch.nn such as torch.nn.L1Loss.
             # We also provide a GANLoss class "networks.GANLoss". self.criterionGAN = networks.GANLoss().to(self.device)

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/models/test_model.py
@@ -43,7 +43,7 @@ class TestModel(BaseModel):
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>
         self.model_names = ['G' + opt.model_suffix]  # only generator is needed.
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG,
-                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                      opt.norm, not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device_type)
 
         # assigns the model to self.netG_[suffix] so that it can be loaded
         # please see <BaseModel.load_networks>

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/base_options.py
@@ -23,6 +23,7 @@ class BaseOptions():
         parser.add_argument('--dataroot', required=True, help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
         parser.add_argument('--name', type=str, default='experiment_name', help='name of the experiment. It decides where to store samples and models')
         parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
+        parser.add_argument('--device_type', type=str, default='cpu', help='device type: e.g. cpu, cuda, xpu')
         parser.add_argument('--checkpoints_dir', type=str, default='./checkpoints', help='models are saved here')
         # model parameters
         parser.add_argument('--model', type=str, default='cycle_gan', help='chooses which model to use. [cycle_gan | pix2pix | test | colorization]')
@@ -128,7 +129,9 @@ class BaseOptions():
             if id >= 0:
                 opt.gpu_ids.append(id)
         if len(opt.gpu_ids) > 0:
-            torch.cuda.set_device(opt.gpu_ids[0])
+            assert(hasattr(torch, opt.device_type))
+            assert(hasattr(getattr(torch, opt.device_type), 'set_device'))
+            getattr(torch, opt.device_type).set_device(opt.gpu_ids[0])
 
         self.opt = opt
         return self.opt

--- a/torchbenchmark/models/tacotron2/__init__.py
+++ b/torchbenchmark/models/tacotron2/__init__.py
@@ -28,7 +28,7 @@ class Model(BenchmarkModel):
             raise NotImplementedError("Tacotron2 doesn't support CPU because load_model assumes CUDA.")
 
         self.hparams = self.create_hparams(batch_size=self.batch_size)
-        self.model = load_model(self.hparams).to(device=device)
+        self.model = load_model(self.hparams, device)
         self.optimizer = torch.optim.Adam(self.model.parameters(),
                                           lr=self.hparams.learning_rate,
                                           weight_decay=self.hparams.weight_decay)

--- a/torchbenchmark/models/tacotron2/train_tacotron2.py
+++ b/torchbenchmark/models/tacotron2/train_tacotron2.py
@@ -70,8 +70,8 @@ def prepare_directories_and_logger(output_directory, log_directory, rank):
     return logger
 
 
-def load_model(hparams):
-    model = Tacotron2(hparams).cuda()
+def load_model(hparams, device='cuda'):
+    model = Tacotron2(hparams).to(device)
     if hparams.fp16_run:
         model.decoder.attention_layer.score_mask_value = finfo('float16').min
 

--- a/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
@@ -37,7 +37,7 @@ def select_device(device='', apex=False, batch_size=None):
 
     if xpu_request:
         print('Using XPU')
-        return torch.device('xpu')
+        return torch.device(f"xpu:{torch.xpu.current_device()}")
 
     print('Using CPU')
     return torch.device('cpu')

--- a/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
+++ b/torchbenchmark/models/yolov3/yolo_utils/torch_utils.py
@@ -24,15 +24,20 @@ def init_seeds(seed=0):
 
 
 def select_device(device='', apex=False, batch_size=None):
-    # device = 'cpu' or '0' or '0,1,2,3'
+    # device = 'cpu', 'xpu' or '0' or '0,1,2,3'
     cpu_request = device.lower() == 'cpu'
-    if device and not cpu_request:  # if device requested other than 'cpu'
+    xpu_request = device.lower() == 'xpu'
+    if device and not cpu_request and not xpu_request:  # if device requested other than 'cpu'and 'xpu'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
         assert torch.cuda.is_available(), 'CUDA unavailable, invalid device %s requested' % device  # check availablity
 
-    cuda = False if cpu_request else torch.cuda.is_available()
+    cuda = False if cpu_request or xpu_request else torch.cuda.is_available()
     if cuda:
         return torch.device(f"cuda:{torch.cuda.current_device()}")
+
+    if xpu_request:
+        print('Using XPU')
+        return torch.device('xpu')
 
     print('Using CPU')
     return torch.device('cpu')


### PR DESCRIPTION
Works for Roadmap https://github.com/pytorch/benchmark/issues/1293 to increase benchmark coverage.

For these 5 models:tacotron2, yolov3, nvidia_deeprecommender, LearningToPoint and pytorch_CycleGAN_and_pix2pix, 
when running on custom devices except for CPU and CUDA(e.g. XPU), it will raise the error as it's hard-coded with CPU/CUDA backends.
In this PR, we accept the device args as a param within the training process and inference process which will cover the model initializing and data transposition for these custom devices.