### PR TITLE
Prune cuda installation for docker image

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -29,8 +29,8 @@ RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 
 # Use the CUDA installation scripts from pytorch/builder
 RUN cd /workspace; git clone https://github.com/pytorch/builder.git
-RUN sudo bash -c 'source /workspace/builder/common/install_cuda.sh; install_118'
-RUN sudo bash -c 'source /workspace/builder/common/install_cuda.sh; install_121'
+RUN sudo bash -c 'source /workspace/builder/common/install_cuda.sh; install_118; prune_118'
+RUN sudo bash -c 'source /workspace/builder/common/install_cuda.sh; install_121; prune_121'
 
 # Install miniconda
 RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /workspace/Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
The [`install_cuda.sh`](https://github.com/pytorch/builder/blob/main/common/install_cuda.sh#L126) in pytorch/builder provides functions `prune_121` and `prune_118` to remove unnecessary parts in the installed CUDA. 

In my local testing, the image size generated by this docker file is reduced from 23.5GB to 19.7GB.