### PR TITLE
Torchbench enable on Windows

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -62,14 +62,16 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
     ]
     run_env = os.environ.copy()
     run_env["PYTHONPATH"] = this_dir.parent
+    for key, item in run_env.items():
+        run_env[key] = str(run_env[key])
     run_kwargs = {
         "cwd": model_path,
-        "check": True,
+        "check": 'True',
         "env": run_env,
     }
 
     output_buffer = None
-    _, stdout_fpath = tempfile.mkstemp()
+    fd, stdout_fpath = tempfile.mkstemp()
 
     try:
         output_buffer = io.FileIO(stdout_fpath, mode="w")
@@ -91,7 +93,9 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
     except Exception as e:
         return (False, e, io.FileIO(stdout_fpath, mode="r").read().decode())
     finally:
+        output_buffer.close()
         del output_buffer
+        os.close(fd)
         os.remove(stdout_fpath)
 
     return (True, None, None)


### PR DESCRIPTION
Torchbench enable on windows.
--------------------------------------------------------
Failed to run install.py on Windows platform. Two errors raised: 

**The first one:**
'''
environment can only contain strings 
'''
Here is some reference on official document for this special request on windows:
subprocess.run(): it doesn't explicitly state that the variables mush be string on windows, it's mentioned that the environment variables are stored as strings and typically pass string to subprocesses. 
https://docs.python.org/3.9/library/subprocess.html#module-subprocess

And this patch will force to convert all env configs to string. 

**Second Error:**
'''
    os.remove(stdout_fpath)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\tmpnrc60z2c'
'''
On torchbenchmark install phase, a temp file is created and it's supposed to be deleted with cmd: os.remove() after installation. However, file descriptor is not closed, then this patch will run descriptor close before os.remove. 