### PR TITLE
Molly/enable unet1d

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -62,14 +62,16 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
     ]
     run_env = os.environ.copy()
     run_env["PYTHONPATH"] = this_dir.parent
+    for key, item in run_env.items():
+        run_env[key] = str(run_env[key])
     run_kwargs = {
         "cwd": model_path,
-        "check": True,
+        "check": 'True',
         "env": run_env,
     }
 
     output_buffer = None
-    _, stdout_fpath = tempfile.mkstemp()
+    fd, stdout_fpath = tempfile.mkstemp()
 
     try:
         output_buffer = io.FileIO(stdout_fpath, mode="w")
@@ -91,7 +93,9 @@ def _install_deps(model_path: str, verbose: bool = True) -> Tuple[bool, Any]:
     except Exception as e:
         return (False, e, io.FileIO(stdout_fpath, mode="r").read().decode())
     finally:
+        output_buffer.close()
         del output_buffer
+        os.close(fd)
         os.remove(stdout_fpath)
 
     return (True, None, None)

--- a/torchbenchmark/models/unet1d/__init__.py
+++ b/torchbenchmark/models/unet1d/__init__.py
@@ -4,13 +4,13 @@ import torch
 from diffusers import UNet1DModel
 
 class Model(BenchmarkModel):
-    DEFAULT_EVAL_BSIZE = 64
+    DEFAULT_EVAL_BSIZE = 32
     def __init__(self, test, device, batch_size=None, extra_args=[]):
         super().__init__( test=test, device=device,
                 batch_size=batch_size, extra_args=extra_args)
 
         self.in_channels = 32
-        self.seq_len = 256
+        self.seq_len = 2016
         self.num_features = 16
         self.block_out_channels = (self.seq_len, 64, 64)
         print(self.batch_size)

--- a/torchbenchmark/models/unet1d/__init__.py
+++ b/torchbenchmark/models/unet1d/__init__.py
@@ -10,7 +10,7 @@ class Model(BenchmarkModel):
                 batch_size=batch_size, extra_args=extra_args)
 
         self.in_channels = 32
-        self.seq_len = 2016
+        self.seq_len = 256
         self.num_features = 16
         self.block_out_channels = (self.seq_len, 64, 64)
         print(self.batch_size)

--- a/torchbenchmark/models/unet1d/__init__.py
+++ b/torchbenchmark/models/unet1d/__init__.py
@@ -1,0 +1,27 @@
+from ...util.model import BenchmarkModel
+
+import torch
+from diffusers import UNet1DModel
+
+class Model(BenchmarkModel):
+    DEFAULT_EVAL_BSIZE = 64
+    def __init__(self, test, device, batch_size=None, extra_args=[]):
+        super().__init__( test=test, device=device,
+                batch_size=batch_size, extra_args=extra_args)
+
+        self.in_channels = 32
+        self.seq_len = 256
+        self.num_features = 16
+        self.block_out_channels = (self.seq_len, 64, 64)
+        print(self.batch_size)
+        self.example_inputs =  torch.randn(1, self.num_features, self.seq_len)
+        self.timesteps = torch.tensor([1])
+        self.model = UNet1DModel(in_channels=self.in_channels, block_out_channels=self.block_out_channels)
+
+    def get_module(self):
+        return self.model, self.example_inputs
+
+    def eval(self):
+        self.model.eval()
+        with torch.no_grad():
+            out=self.model(self.example_inputs, self.timesteps)

--- a/torchbenchmark/models/unet1d/install.py
+++ b/torchbenchmark/models/unet1d/install.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+import os
+
+def pip_install_requirements():
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', 'requirements.txt'])
+
+if __name__ == '__main__':
+    pip_install_requirements()

--- a/torchbenchmark/models/unet1d/metadata.yml
+++ b/torchbenchmark/models/unet1d/metadata.yml
@@ -1,0 +1,8 @@
+devices:
+  NVIDIA A100-SXM4-40GB:
+    eval_batch_size: 64
+eval_benchmark: true
+eval_deterministic: false
+eval_nograd: true
+train_benchmark: true
+train_deterministic: false

--- a/torchbenchmark/models/unet1d/requirements.txt
+++ b/torchbenchmark/models/unet1d/requirements.txt
@@ -1,0 +1,1 @@
+diffusers


### PR DESCRIPTION
-------------------------------------------
Enabling Unet1d to track OP performance:conv_transpose1d.
-------------------------------------------

This PR is to enable Huggingface/Diffusers/UNET1D which includes conv_transpose1d on upsampling and downsampling phase.
(In #120982, a remarkable performance regression happens to conv_transpose1d. )

Note: Torch.profiling Detail suggests: conv_transposed accounts for 5% of the total time consumption in UNET1D.  

Verified on Torch2.2 and Torch 1.13.1 with the following cmd
numactl -C 0 python run.py unet1d

Torch 2.2:  
CPU Wall Time per batch:  10.803 milliseconds
CPU Wall Time:        10.803 milliseconds
Time to first batch:           25.9873 ms
CPU Peak Memory:                0.5264 GB

CPU Wall Time per batch:  10.365 milliseconds
CPU Wall Time:        10.365 milliseconds
Time to first batch:           24.0618 ms
CPU Peak Memory:                0.4609 GB

