### PR TITLE
Fix the tritonbench nightly ci

### DIFF
--- a/.github/workflows/tritonbench-nightly.yml
+++ b/.github/workflows/tritonbench-nightly.yml
@@ -55,7 +55,7 @@ jobs:
           # Upload the result json to Amazon S3
           python ./scripts/userbenchmark/upload_s3.py --upload-file "${LATEST_RESULT}" --userbenchmark_platform "${PLATFORM_NAME}"
       - name: Upload result to GH Actions Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: TribonBench result
           path: benchmark-output/

--- a/.github/workflows/tritonbench-nightly.yml
+++ b/.github/workflows/tritonbench-nightly.yml
@@ -29,6 +29,8 @@ jobs:
           sudo nvidia-smi -pm 1
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
+          sudo ldconfig
+          sudo ldconfig
       - name: Clone and setup conda env
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"

--- a/.github/workflows/tritonbench-nightly.yml
+++ b/.github/workflows/tritonbench-nightly.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TribonBench result
+          name: TritonBench result
           path: benchmark-output/
       - name: Clean up Conda env
         if: always()

--- a/.github/workflows/tritonbench-nightly.yml
+++ b/.github/workflows/tritonbench-nightly.yml
@@ -30,7 +30,6 @@ jobs:
           sudo nvidia-smi -ac 1215,1410
           nvidia-smi
           sudo ldconfig
-          sudo ldconfig
       - name: Clone and setup conda env
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"


### PR DESCRIPTION
Currently it is reusing the generic userbenchmark dashboard, we may want to develop a dedicated tritonbench dashboard later.

Test workflow:

https://github.com/pytorch/benchmark/actions/runs/8842193730

<img width="1843" alt="image" src="https://github.com/pytorch/benchmark/assets/502017/6d82aed2-23c3-4f62-8ea4-04e3460e0656">
