### PR TITLE
Add launch_latency to the CI

### DIFF
--- a/userbenchmark/triton/ci.py
+++ b/userbenchmark/triton/ci.py
@@ -10,6 +10,7 @@ from torchbenchmark.util.triton_op import BenchmarkOperatorResult
 
 CI_TESTS = [
     ["--op", "softmax", "--num-inputs", "10"],
+    ["--op", "launch_latency"],
 ]
 
 def ci_result_to_userbenchmark_json(ci_metrics: List[BenchmarkOperatorResult]) -> Any:


### PR DESCRIPTION

Test Plan:
```
$ python run_benchmark.py triton --ci
{
    "name": "triton",
    "environ": {
        "pytorch_git_version": "734a000f16b60b3a4e18404e5047a467e2bc96d4",
        "pytorch_version": "2.4.0.dev20240425+cu121",
        "triton_version": "3.0.0+45fff310c8"
    },
    "metrics": {
        "tritonbench_softmax[x_256-naive_softmax-gbps]": 186.1818167276619,
        "tritonbench_softmax[x_256-naive_softmax-latency]": 0.04505600035190582,
        "tritonbench_softmax[x_256-triton_softmax-gbps]": 546.1333471298221,
        "tritonbench_softmax[x_256-triton_softmax-latency]": 0.015359999611973763,
        "tritonbench_softmax[x_384-naive_softmax-gbps]": 245.76000620841998,
        "tritonbench_softmax[x_384-naive_softmax-latency]": 0.05119999870657921,
        "tritonbench_softmax[x_384-triton_softmax-gbps]": 722.8235167351564,
        "tritonbench_softmax[x_384-triton_softmax-latency]": 0.01740800030529499,
        "tritonbench_softmax[x_512-naive_softmax-gbps]": 282.48275158209714,
        "tritonbench_softmax[x_512-naive_softmax-latency]": 0.05939200147986412,
        "tritonbench_softmax[x_512-triton_softmax-gbps]": 819.2000206947332,
        "tritonbench_softmax[x_512-triton_softmax-latency]": 0.020479999482631683,
        "tritonbench_softmax[x_640-naive_softmax-gbps]": 315.07692221918046,
        "tritonbench_softmax[x_640-naive_softmax-latency]": 0.06656000018119812,
        "tritonbench_softmax[x_640-triton_softmax-gbps]": 890.4347628501507,
        "tritonbench_softmax[x_640-triton_softmax-latency]": 0.023552000522613525,
        "tritonbench_softmax[x_768-naive_softmax-gbps]": 327.6799844360359,
        "tritonbench_softmax[x_768-naive_softmax-latency]": 0.07680000364780426,
        "tritonbench_softmax[x_768-triton_softmax-gbps]": 983.0400248336799,
        "tritonbench_softmax[x_768-triton_softmax-latency]": 0.025599999353289604,
        "tritonbench_softmax[x_896-naive_softmax-gbps]": 333.3953487974944,
        "tritonbench_softmax[x_896-naive_softmax-latency]": 0.08806400001049042,
        "tritonbench_softmax[x_896-triton_softmax-gbps]": 1023.9999859545915,
        "tritonbench_softmax[x_896-triton_softmax-latency]": 0.028672000393271446,
        "tritonbench_softmax[x_1024-naive_softmax-gbps]": 330.9899085677046,
        "tritonbench_softmax[x_1024-naive_softmax-latency]": 0.1013759970664978,
        "tritonbench_softmax[x_1024-triton_softmax-gbps]": 1092.2666942596443,
        "tritonbench_softmax[x_1024-triton_softmax-latency]": 0.030719999223947525,
        "tritonbench_softmax[x_1152-naive_softmax-gbps]": 326.23008308318043,
        "tritonbench_softmax[x_1152-naive_softmax-latency]": 0.1157120019197464,
        "tritonbench_softmax[x_1152-triton_softmax-gbps]": 1053.2571147256976,
        "tritonbench_softmax[x_1152-triton_softmax-latency]": 0.035840000957250595,
        "tritonbench_softmax[x_1280-naive_softmax-gbps]": 317.51939771611177,
        "tritonbench_softmax[x_1280-naive_softmax-latency]": 0.13209599256515503,
        "tritonbench_softmax[x_1280-triton_softmax-gbps]": 1077.894784710746,
        "tritonbench_softmax[x_1280-triton_softmax-latency]": 0.03891199827194214,
        "tritonbench_softmax[x_1408-naive_softmax-gbps]": 306.50340379369584,
        "tritonbench_softmax[x_1408-naive_softmax-latency]": 0.15052799880504608,
        "tritonbench_softmax[x_1408-triton_softmax-gbps]": 1126.4000284552583,
        "tritonbench_softmax[x_1408-triton_softmax-latency]": 0.04095999896526337,
        "tritonbench_launch_latency[x_0-nop_python_function-walltime]": 5.952840145835618e-05,
        "tritonbench_launch_latency[x_0-nop_triton_kernel-walltime]": 0.05847188150065244,
        "tritonbench_launch_latency[x_0-nop_triton_compiled_kernel_run-walltime]": 0.00418019123551221,
        "tritonbench_launch_latency[x_0-nop_inductor_kernel-walltime]": 0.033629700942806116,
        "tritonbench_launch_latency[x_19-nop_python_function-walltime]": 5.954065847667656e-05,
        "tritonbench_launch_latency[x_19-nop_triton_kernel-walltime]": 0.22586542793145084,
        "tritonbench_launch_latency[x_19-nop_triton_compiled_kernel_run-walltime]": 0.006857241936889006,
        "tritonbench_launch_latency[x_19-nop_inductor_kernel-walltime]": 0.04284843048687937
    }
}
```