### PR TITLE
Use pick_grad to choose grad in the framework

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -544,21 +544,6 @@ class ModelTask(base_task.TaskBase):
     # =========================================================================
 
     @contextlib.contextmanager
-    def no_grad(self, disable_nograd: bool) -> None:
-        # TODO: deduplicate with `torchbenchmark.util.model.no_grad`
-
-        initial_value = self.worker.load_stmt("torch.is_grad_enabled()")
-        eval_in_nograd = not disable_nograd and self.worker.load_stmt(
-            "model.eval_in_nograd()"
-        )
-
-        try:
-            self.worker.run(f"torch.set_grad_enabled({not eval_in_nograd})")
-            yield
-        finally:
-            self.worker.run(f"torch.set_grad_enabled({initial_value})")
-
-    @contextlib.contextmanager
     def watch_cuda_memory(
         self,
         skip: bool,

--- a/torchbenchmark/models/DALLE2_pytorch/__init__.py
+++ b/torchbenchmark/models/DALLE2_pytorch/__init__.py
@@ -84,8 +84,7 @@ class Model(BenchmarkModel):
 
     def eval(self):
         model, inputs = self.get_module()
-        with torch.no_grad():
-            images = model(*inputs)
+        images = model(*inputs)
         return (images,)
 
     def train(self):

--- a/torchbenchmark/models/cm3leon_generate/__init__.py
+++ b/torchbenchmark/models/cm3leon_generate/__init__.py
@@ -47,6 +47,5 @@ class Model(BenchmarkModel):
         return loss.item()
 
     def eval(self):
-        with torch.no_grad():
-            out = self.model(*self.example_inputs)
+        out = self.model(*self.example_inputs)
         return (out,)

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -102,8 +102,7 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         self.model.eval()
         idx = 0
-        with torch.no_grad():
-            out = self.model(self.example_inputs[idx])
+        out = self.model(self.example_inputs[idx])
         # retrieve output tensors
         outputs = []
         for item in out:

--- a/torchbenchmark/models/doctr_det_predictor/__init__.py
+++ b/torchbenchmark/models/doctr_det_predictor/__init__.py
@@ -37,6 +37,5 @@ class Model(BenchmarkModel):
         return self.model, (self.example_inputs,)
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with torch.inference_mode():
-            out = self.model(self.example_inputs, return_model_output=True)
+        out = self.model(self.example_inputs, return_model_output=True)
         return (out["out_map"],)

--- a/torchbenchmark/models/doctr_reco_predictor/__init__.py
+++ b/torchbenchmark/models/doctr_reco_predictor/__init__.py
@@ -35,6 +35,5 @@ class Model(BenchmarkModel):
         return self.model, (self.example_inputs,)
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with torch.inference_mode():
-            out = self.model(self.example_inputs, return_model_output=True)
+        out = self.model(self.example_inputs, return_model_output=True)
         return (out["out_map"],)

--- a/torchbenchmark/models/fastNLP_Bert/__init__.py
+++ b/torchbenchmark/models/fastNLP_Bert/__init__.py
@@ -117,9 +117,8 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         self._mode(self.model, is_test=True)
         self._predict_func = self.model.forward
-        with torch.no_grad():
-            for batch_x, _batch_y in self.example_inputs:
-                pred_dict = self._data_forward(self._predict_func, batch_x)
+        for batch_x, _batch_y in self.example_inputs:
+            pred_dict = self._data_forward(self._predict_func, batch_x)
         # return a tuple of Tensors
         return (pred_dict["pred_start"], pred_dict["pred_end"])
 

--- a/torchbenchmark/models/functorch_dp_cifar10/__init__.py
+++ b/torchbenchmark/models/functorch_dp_cifar10/__init__.py
@@ -99,6 +99,5 @@ class Model(BenchmarkModel):
         (images, ) = self.example_inputs
         model.eval()
         targets = self.example_target
-        with torch.no_grad():
-            out = model(images)
+        out = model(images)
         return (out, )

--- a/torchbenchmark/models/functorch_maml_omniglot/__init__.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/__init__.py
@@ -104,6 +104,5 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         model, (example_input,) = self.get_module()
         model.eval()
-        with torch.no_grad():
-            out = model(example_input)
+        out = model(example_input)
         return (out, )

--- a/torchbenchmark/models/hf_Whisper/__init__.py
+++ b/torchbenchmark/models/hf_Whisper/__init__.py
@@ -24,8 +24,7 @@ class Model(HuggingFaceModel):
 
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            self.model(self.example_inputs["input_ids"])
+        self.model(self.example_inputs["input_ids"])
     
     def enable_fp16(self):
         self.model.half()

--- a/torchbenchmark/models/hf_distil_whisper/__init__.py
+++ b/torchbenchmark/models/hf_distil_whisper/__init__.py
@@ -25,8 +25,7 @@ class Model(HuggingFaceModel):
 
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            self.model(self.example_inputs["input_ids"])
+        self.model(self.example_inputs["input_ids"])
     
     def enable_fp16(self):
         self.model.half()

--- a/torchbenchmark/models/lennard_jones/__init__.py
+++ b/torchbenchmark/models/lennard_jones/__init__.py
@@ -100,6 +100,5 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         model = self.model
         model.eval()
-        with torch.no_grad():
-            out = make_prediction(model, self.drs)
+        out = make_prediction(model, self.drs)
         return out

--- a/torchbenchmark/models/llama/__init__.py
+++ b/torchbenchmark/models/llama/__init__.py
@@ -36,6 +36,5 @@ class Model(BenchmarkModel):
 
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            out=self.model(*self.example_inputs)
+        out=self.model(*self.example_inputs)
         return (out,)

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -105,6 +105,3 @@ class Model(BenchmarkModel):
 
     def train(self):
         raise NotImplementedError("MAML model doesn't support train.")
-
-    def eval_in_nograd(self):
-        return False

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -114,6 +114,5 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         model, (example_input,) = self.get_module()
         model.eval()
-        with torch.no_grad():
-            out = model(example_input)
+        out = model(example_input)
         return (out, )

--- a/torchbenchmark/models/microbench_unbacked_tolist_sum/__init__.py
+++ b/torchbenchmark/models/microbench_unbacked_tolist_sum/__init__.py
@@ -36,8 +36,7 @@ class Model(BenchmarkModel):
         return self.model, self.example_inputs
 
     def eval(self):
-        with torch.no_grad():
-            out = self.model(*self.example_inputs)
+        out = self.model(*self.example_inputs)
         return (out,)
 
     def train(self):

--- a/torchbenchmark/models/nanogpt/__init__.py
+++ b/torchbenchmark/models/nanogpt/__init__.py
@@ -64,6 +64,5 @@ class Model(BenchmarkModel):
 
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            out = self.model.generate(*self.example_inputs, self.generate_config.max_new_tokens, self.generate_config.temperature, self.generate_config.top_k)
+        out = self.model.generate(*self.example_inputs, self.generate_config.max_new_tokens, self.generate_config.temperature, self.generate_config.top_k)
         return (out,)

--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -85,6 +85,5 @@ class Model(BenchmarkModel):
         (images, ) = self.example_inputs
         model.eval()
         targets = self.example_target
-        with torch.no_grad():
-            out = model(images)
+        out = model(images)
         return (out, )

--- a/torchbenchmark/models/phlippe_densenet/__init__.py
+++ b/torchbenchmark/models/phlippe_densenet/__init__.py
@@ -192,6 +192,5 @@ class Model(BenchmarkModel):
         model = self.model
         (images, ) = self.example_inputs
         model.eval()
-        with torch.no_grad():
-            out = model(images)
+        out = model(images)
         return (out,)

--- a/torchbenchmark/models/phlippe_resnet/__init__.py
+++ b/torchbenchmark/models/phlippe_resnet/__init__.py
@@ -155,6 +155,5 @@ class Model(BenchmarkModel):
     
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            out=self.model(self.images)
+        out=self.model(self.images)
         return (out,)

--- a/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
+++ b/torchbenchmark/models/pyhpc_equation_of_state/__init__.py
@@ -53,6 +53,5 @@ class Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
-        with torch.no_grad():
-            out = model(*example_inputs)
+        out = model(*example_inputs)
         return (out, )

--- a/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
+++ b/torchbenchmark/models/pyhpc_isoneutral_mixing/__init__.py
@@ -146,6 +146,5 @@ class Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
-        with torch.no_grad():
-            out = model(*example_inputs)
+        out = model(*example_inputs)
         return out

--- a/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
+++ b/torchbenchmark/models/pyhpc_turbulent_kinetic_energy/__init__.py
@@ -145,6 +145,5 @@ class Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         model, example_inputs = self.get_module()
-        with torch.no_grad():
-            out = model(*example_inputs)
+        out = model(*example_inputs)
         return out

--- a/torchbenchmark/models/pytorch_unet/__init__.py
+++ b/torchbenchmark/models/pytorch_unet/__init__.py
@@ -90,18 +90,17 @@ class Model(BenchmarkModel):
     def eval(self) -> Tuple[torch.Tensor]:
         torch.backends.cudnn.deterministic = True
         self.model.eval()
-        with torch.no_grad():
-            with torch.cuda.amp.autocast(enabled=self.args.amp):
-                mask_pred = self.model(self.example_inputs)
+        with torch.cuda.amp.autocast(enabled=self.args.amp):
+            mask_pred = self.model(self.example_inputs)
 
-                if self.model.n_classes == 1:
-                    mask_pred = (F.sigmoid(mask_pred) > 0.5).float()
-                else:
-                    mask_pred = (
-                        F.one_hot(mask_pred.argmax(dim=1), self.model.n_classes)
-                        .permute(0, 3, 1, 2)
-                        .float()
-                    )
+            if self.model.n_classes == 1:
+                mask_pred = (F.sigmoid(mask_pred) > 0.5).float()
+            else:
+                mask_pred = (
+                    F.one_hot(mask_pred.argmax(dim=1), self.model.n_classes)
+                    .permute(0, 3, 1, 2)
+                    .float()
+                )
         return (mask_pred,)
 
     def _get_args(self):

--- a/torchbenchmark/models/soft_actor_critic/__init__.py
+++ b/torchbenchmark/models/soft_actor_critic/__init__.py
@@ -258,21 +258,20 @@ class Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         niter = 1
-        with torch.no_grad():
-            discount = 1.0
-            episode_return_history = []
-            for episode in range(niter):
-                episode_return = 0.0
-                state, _info = self.test_env.reset()
-                done, info = False, {}
-                for step_num in range(self.args.max_episode_steps):
-                    if done:
-                        break
-                    action = self.agent.forward(state)
-                    state, reward, done, info, _unused = self.test_env.step(action)
-                    episode_return += reward * (discount**step_num)
-                episode_return_history.append(episode_return)
-            retval = torch.tensor(episode_return_history)
+        discount = 1.0
+        episode_return_history = []
+        for episode in range(niter):
+            episode_return = 0.0
+            state, _info = self.test_env.reset()
+            done, info = False, {}
+            for step_num in range(self.args.max_episode_steps):
+                if done:
+                    break
+                action = self.agent.forward(state)
+                state, reward, done, info, _unused = self.test_env.step(action)
+                episode_return += reward * (discount**step_num)
+            episode_return_history.append(episode_return)
+        retval = torch.tensor(episode_return_history)
         return (torch.tensor(action),)
 
     def get_optimizer(self):

--- a/torchbenchmark/models/speech_transformer/config.py
+++ b/torchbenchmark/models/speech_transformer/config.py
@@ -251,9 +251,8 @@ class SpeechTransformerEvalConfig:
                 break
 
     def eval(self):
-        with torch.no_grad():
-            for input, input_length in self.example_inputs:
-                nbest_hyps = self.model.recognize(
-                    input, input_length, self.char_list, self
-                )
+        for input, input_length in self.example_inputs:
+            nbest_hyps = self.model.recognize(
+                input, input_length, self.char_list, self
+            )
         return nbest_hyps

--- a/torchbenchmark/models/timm_efficientdet/__init__.py
+++ b/torchbenchmark/models/timm_efficientdet/__init__.py
@@ -181,9 +181,8 @@ class Model(BenchmarkModel):
                 # self.lr_scheduler.step(epoch + 1, eval_metrics[eval_metric])
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with torch.no_grad():
-            for input, target in self.loader:
-                with self.amp_autocast():
-                    output = self.model(input, img_info=target)
-                self.evaluator.add_predictions(output, target)
+        for input, target in self.loader:
+            with self.amp_autocast():
+                output = self.model(input, img_info=target)
+            self.evaluator.add_predictions(output, target)
         return (output, )

--- a/torchbenchmark/models/torch_multimodal_clip/__init__.py
+++ b/torchbenchmark/models/torch_multimodal_clip/__init__.py
@@ -77,11 +77,9 @@ class Model(BenchmarkModel):
 
     def eval(self):
         self.model.eval()
-
-        with torch.no_grad():
-            image_embedding, text_embedding = self.model(
-                self.image_tensor, self.text_tensor
-            )
-            score = image_embedding @ text_embedding.t()
+        image_embedding, text_embedding = self.model(
+            self.image_tensor, self.text_tensor
+        )
+        score = image_embedding @ text_embedding.t()
 
         return self.text[torch.argmax(score)]

--- a/torchbenchmark/models/vision_maskrcnn/__init__.py
+++ b/torchbenchmark/models/vision_maskrcnn/__init__.py
@@ -117,10 +117,9 @@ class Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         self.model.eval()
-        with torch.no_grad():
-            for _batch_id, (images, _targets) in zip(
-                range(self.NUM_OF_BATCHES), self.data_loader
-            ):
-                out = self.model(images)
+        for _batch_id, (images, _targets) in zip(
+            range(self.NUM_OF_BATCHES), self.data_loader
+        ):
+            out = self.model(images)
         out = list(map(lambda x: x.values(), out))
         return tuple(itertools.chain(*out))

--- a/torchbenchmark/util/framework/detectron2/model_factory.py
+++ b/torchbenchmark/util/framework/detectron2/model_factory.py
@@ -211,8 +211,7 @@ class Detectron2Model(BenchmarkModel):
 
     def eval(self) -> Tuple[torch.Tensor]:
         batch_id = 0
-        with torch.no_grad():
-            out = self.model(self.example_inputs[batch_id])
+        out = self.model(self.example_inputs[batch_id])
         # retrieve output tensors
         outputs = []
         for item in out:

--- a/torchbenchmark/util/framework/diffusers/model_factory.py
+++ b/torchbenchmark/util/framework/diffusers/model_factory.py
@@ -53,6 +53,5 @@ class DiffuserModel(BenchmarkModel):
         raise NotImplementedError(f"Train is not implemented for model {self.name}")
 
     def eval(self):
-        with torch.no_grad():
-            images = self.pipe(*self.example_inputs).images
+        images = self.pipe(*self.example_inputs).images
         return images

--- a/torchbenchmark/util/framework/gnn/model_factory.py
+++ b/torchbenchmark/util/framework/gnn/model_factory.py
@@ -179,8 +179,7 @@ class BasicGNNModel(BenchmarkModel):
 
     def eval(self):
         self.model.eval()
-        with torch.no_grad():
-            return (self.model(*self.example_inputs),)
+        return (self.model(*self.example_inputs),)
 
     def train(self):
         # NB: This is a little different than test_basic_gnn.py, as we

--- a/torchbenchmark/util/framework/huggingface/model_factory.py
+++ b/torchbenchmark/util/framework/huggingface/model_factory.py
@@ -118,9 +118,8 @@ class HuggingFaceModel(BenchmarkModel):
         self.optimizer.step()
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with torch.no_grad():
-            with self.amp_context():
-                out = self.model(**self.example_inputs)
+        with self.amp_context():
+            out = self.model(**self.example_inputs)
         # logits: prediction scores of language modeling head
         # https://github.com/huggingface/transformers/blob/v4.16.2/src/transformers/modeling_outputs.py#L455
         # transformations such as fx2trt will cast the original output type to dict
@@ -174,9 +173,8 @@ class HuggingFaceGenerationModel(HuggingFaceModel):
         raise NotImplementedError("_generate variant doesn't train")
 
     def eval(self) -> Tuple[torch.Tensor]:
-        with torch.no_grad():
-            with self.amp_context():
-                out = self.model(*self.example_inputs)
+        with self.amp_context():
+            out = self.model(*self.example_inputs)
         return (out,)
 
 

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -107,9 +107,8 @@ class TimmModel(BenchmarkModel):
         self._step_train()
 
     def eval(self) -> typing.Tuple[torch.Tensor]:
-        with torch.no_grad():
-            with self.amp_context():
-                out = self._step_eval()
+        with self.amp_context():
+            out = self._step_eval()
         return (out,)
 
 

--- a/torchbenchmark/util/framework/vision/model_factory.py
+++ b/torchbenchmark/util/framework/vision/model_factory.py
@@ -115,9 +115,8 @@ class TorchVisionModel(BenchmarkModel):
             self.g.replay()
 
     def eval(self) -> typing.Tuple[torch.Tensor]:
-        with torch.no_grad():
-            with self.amp_context():
-                return self.model(*self.example_inputs)
+        with self.amp_context():
+            return self.model(*self.example_inputs)
 
     def cudagraph_eval(self):
         for data, target in zip(self.real_input, self.real_output):

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -112,7 +112,11 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.backward_contexts = []
             self.optimizer_contexts = []
         self.run_contexts = [
-            enable_profiling_executor,  # force JIT profiling executor to be enabled by default
+            # force JIT profiling executor to be enabled by default
+            enable_profiling_executor,
+            # Due to an Inductor bug https://github.com/pytorch/pytorch/issues/125474
+            # In inference tests, we need to handle the grad context in the framework level
+            # before the model function is called
             lambda: pick_grad(self.name, bool(self.test == "train")),
         ]
 

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -113,7 +113,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.optimizer_contexts = []
         self.run_contexts = [
             enable_profiling_executor,  # force JIT profiling executor to be enabled by default
-            pick_grad(self.name, bool(self.test == "train")),
+            lambda: pick_grad(self.name, bool(self.test == "train")),
         ]
 
         set_random_seed()

--- a/torchbenchmark/util/model.py
+++ b/torchbenchmark/util/model.py
@@ -112,7 +112,7 @@ class BenchmarkModel(metaclass=PostInitProcessor):
             self.backward_contexts = []
             self.optimizer_contexts = []
         self.run_contexts = [
-            enable_profiling_executor  # force JIT profiling executor to be enabled by default,
+            enable_profiling_executor,  # force JIT profiling executor to be enabled by default
             pick_grad(self.name, bool(self.test == "train")),
         ]
 


### PR DESCRIPTION
Related Inductor issue: https://github.com/pytorch/pytorch/issues/125474.

Inductor cannot correctly handle `torch.no_grad()` context when it is inside the model code. To best leverage inductor code on inference, we are removing the `torch.no_grad()` context requirement from the model code. Instead, use the `pick_grad` helper function to manage the grad context from the framework level.

Fixes https://github.com/pytorch/benchmark/issues/2253