### PR TITLE
[tritonbench] Report tflops by default for gemm; fix exception handling

### DIFF
--- a/torchbenchmark/operators/gemm/operator.py
+++ b/torchbenchmark/operators/gemm/operator.py
@@ -89,7 +89,7 @@ SPLIT_K_SHAPES = [
 
 
 class Operator(BenchmarkOperator):
-    DEFAULT_METRICS = ["latency", "speedup", "accuracy"]
+    DEFAULT_METRICS = ["latency", "speedup", "accuracy", "tflops"]
     DEFAULT_PRECISION = "fp16"
 
     def __init__(self, mode: str, device: str, extra_args: Optional[List[str]] = None):
@@ -202,13 +202,7 @@ class Operator(BenchmarkOperator):
     def _get_accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:
         output = fn()
         baseline_output = baseline_fn()
-        accuracy = True
-        try:
-            torch.testing.assert_close(output, baseline_output)
-        except Exception:
-            accuracy = False
-        finally:
-            return accuracy
+        return torch.allclose(output, baseline_output)
 
     def plot(self):
         @triton.testing.perf_report(

--- a/torchbenchmark/util/triton_op.py
+++ b/torchbenchmark/util/triton_op.py
@@ -752,8 +752,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     metrics.extra_metrics[metric_name] = func(fn, self.example_inputs, metrics)
         except torch.cuda.OutOfMemoryError:
             metrics.error_msg = "CUDA OOM"
-        except RuntimeError as e:
-            metrics.error_msg = str(e)
         return metrics
 
     def get_peak_mem(


### PR DESCRIPTION
Summary: TFLOPS is the core metric for gemm.  Along the way I hit some bugs and weirdness:

- You couldn't Ctrl-C out of tritonbench, because the `finally` clause contained a return, which [suppresses the exception](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions)
- In generally I don't think the framework should catch RuntimeErrors, it makes it really hard to debug stuff because the desired result just ends up missing
- In fact we had a typo (`metric` instead of `metrics` in the framework code that was never caught because it was caught and suppressed

Test Plan:
```
python run_benchmark.py triton --op gemm --splitk
```