### PR TITLE
Let random seed setting work on xpu device

### DIFF
--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -172,9 +172,12 @@ def set_random_seed():
 
         seed = MAIN_RANDOM_SEED
         import torch.cuda
-
         if not torch.cuda._is_in_bad_fork():
             torch.cuda.manual_seed_all(seed)
+
+        import torch.xpu
+        if not torch.xpu._is_in_bad_fork():
+            torch.xpu.manual_seed_all(seed)
         return default_generator.manual_seed(seed)
 
     torch.manual_seed(MAIN_RANDOM_SEED)


### PR DESCRIPTION
This Pull Request relates to [Roadmap Issue #1293](https://github.com/pytorch/benchmark/issues/1293) by enhancing our benchmark coverage.

Currently, Torchbench utilizes a custom random seed function that is incompatible with the XPU device backend. 
This incompatibility affects models that include random data augmentation operations, leading to accuracy check failures due to variations in input data across two separate runs.

In this PR, we introduce support for setting a random seed for the XPU backend.