### PR TITLE
move detectron2 pin to the most recent tip

### DIFF
--- a/torchbenchmark/util/framework/detectron2/requirements.txt
+++ b/torchbenchmark/util/framework/detectron2/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/facebookresearch/detectron2.git@1a4df4d
+git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8
 omegaconf==2.3.0
 numpy


### PR DESCRIPTION
With the existing pin, cpp extension compilation on ROCm fails.

# Testing
`$ pip install --user --verbose -r torchbenchmark/util/framework/detectron2/requirements.txt`

(ensure the extension is successfully built)