### PR TITLE
Enable Huggingface and Timm models for interal buck runner

### DIFF
--- a/torchbenchmark/util/framework/huggingface/extended_configs.py
+++ b/torchbenchmark/util/framework/huggingface/extended_configs.py
@@ -5,8 +5,9 @@ import os
 from typing import List
 
 import torch
-from userbenchmark.dynamo.run import DYNAMOBENCH_PATH
+from torchbenchmark import REPO_PATH
 
+DYNAMOBENCH_PATH = REPO_PATH.joinpath("userbenchmark", "dynamo", "dynamobench")
 # These models contain the models present in huggingface_models_list. It is a
 # combination of models supported by HF Fx parser and some manually supplied
 # models. For these models, we already know the largest batch size that can fit

--- a/torchbenchmark/util/framework/timm/extended_configs.py
+++ b/torchbenchmark/util/framework/timm/extended_configs.py
@@ -3,8 +3,9 @@ import os
 from typing import List
 
 import torch
-from userbenchmark.dynamo.run import DYNAMOBENCH_PATH
+from torchbenchmark import REPO_PATH
 
+DYNAMOBENCH_PATH = REPO_PATH.joinpath("userbenchmark", "dynamo", "dynamobench")
 TIMM_MODELS = dict()
 # Only load the extended models in OSS
 if hasattr(torch.version, "git_version"):

--- a/userbenchmark/dynamo/run.py
+++ b/userbenchmark/dynamo/run.py
@@ -3,25 +3,85 @@ import warnings
 import sys
 
 from torchbenchmark import add_path, REPO_PATH
+from torchbenchmark.util.framework.huggingface.extended_configs import (
+    list_extended_huggingface_models,
+)
+from torchbenchmark.util.framework.timm.extended_configs import (
+    list_extended_timm_models,
+)
 
 DYNAMOBENCH_PATH = REPO_PATH.joinpath("userbenchmark", "dynamo", "dynamobench")
 
-try:
-    # OSS Import
-    with add_path(str(DYNAMOBENCH_PATH)):
-        from torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
-        from common import main
-except ImportError:
-    # Meta Internal Import
-    from caffe2.benchmarks.dynamo.torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
-    from caffe2.benchmarks.dynamo.common import main
-
 from typing import List, Optional
+
+def _get_model_set_by_model_name(args: List[str]) -> str:
+    if "--huggingface" in args:
+        args.remove("--huggingface")
+        return "huggingface"
+    if "--timm" in args:
+        args.remove("--timm")
+        return "timm"
+    if "--torchbench" in args:
+        args.remove("--torchbench")
+        return "torchbench"
+    if "--only" in args:
+        only_index = args.index("--only")
+        model_name = args[only_index + 1]
+        if model_name in list_extended_huggingface_models():
+            return "huggingface"
+        if model_name in list_extended_timm_models():
+            return "timm"
+    return "torchbench"
+
+def _run_huggingface(args: List[str]) -> None:
+    try:
+        # OSS Import
+        with add_path(str(DYNAMOBENCH_PATH)):
+            from huggingface import HuggingfaceRunner
+            from common import main
+    except ImportError:
+        # Meta Internal Import
+        from caffe2.benchmarks.dynamo.huggingface import HuggingfaceRunner
+        from caffe2.benchmarks.dynamo.common import main
+    main(runner=HuggingfaceRunner(), args=args)
+
+
+def _run_timm(args: List[str]) -> None:
+    try:
+        # OSS Import
+        with add_path(str(DYNAMOBENCH_PATH)):
+            from timm_models import TimmRunner
+            from common import main
+    except ImportError:
+        # Meta Internal Import
+        from caffe2.benchmarks.dynamo.timm_models import TimmRunner
+        from caffe2.benchmarks.dynamo.common import main
+    main(runner=TimmRunner(), args=args)
+
+
+def _run_torchbench(args: List[str]) -> None:
+    try:
+        # OSS Import
+        with add_path(str(DYNAMOBENCH_PATH)):
+            from torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
+            from common import main
+    except ImportError:
+        # Meta Internal Import
+        from caffe2.benchmarks.dynamo.torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
+        from caffe2.benchmarks.dynamo.common import main
+    original_dir = setup_torchbench_cwd()
+    main(TorchBenchmarkRunner(), original_dir, args)
+
 
 def run(args: Optional[List[str]]=None):
     if args is None:
         args = sys.argv[1:]
-    original_dir = setup_torchbench_cwd()
+    model_set = _get_model_set_by_model_name(args)
     logging.basicConfig(level=logging.WARNING)
     warnings.filterwarnings("ignore")
-    main(TorchBenchmarkRunner(), original_dir, args)
+    if model_set == "huggingface":
+        _run_huggingface(args)
+    elif model_set == "timm":
+        _run_timm(args)
+    else:
+        _run_torchbench(args)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/127460

Add huggingface and timm model runs to the  internal pt2 benchmark runner.

Reviewed By: HDCharles, huydhn

Differential Revision: D57930582


