### PR TITLE
Add sys.executable to ncu command

### DIFF
--- a/torchbenchmark/util/triton_op.py
+++ b/torchbenchmark/util/triton_op.py
@@ -817,7 +817,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         import subprocess
         from pathlib import Path
 
-        op_task_args = copy.deepcopy(sys.argv)
+        op_task_args = [sys.executable] + copy.deepcopy(sys.argv)
         for override_option in ["--only", "--input-id", "--num-inputs", "--metrics"]:
             op_task_args = _remove_params(
                 op_task_args, _find_param_loc(op_task_args, override_option)


### PR DESCRIPTION
Previously, the ncu option would exit with code 255 for me:
```
python run_benchmark.py triton --op int4_gemm --metrics ncu_trace
```

For me, adding the python executable path into the command fixed this.