### PR TITLE
Change the llama max_batch_size larger than default eval batch size

### DIFF
--- a/torchbenchmark/models/llama/model.py
+++ b/torchbenchmark/models/llama/model.py
@@ -19,7 +19,7 @@ class ModelArgs:
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
     norm_eps: float = 1e-5
 
-    max_batch_size: int = 32 # From the paper they use a batch size of 4M for training
+    max_batch_size: int = 64 # From the paper they use a batch size of 4M for training
     max_seq_len: int = 1024
 
     device: Optional[str] = None


### PR DESCRIPTION
Fix the PyTorch issue: https://github.com/pytorch/pytorch/issues/106110 for llama dynamic batch test case.
The root-cause and discussion is as described in https://github.com/pytorch/pytorch/issues/106110#issuecomment-1950964863.