### PR TITLE
Add support for reducing across the middle dimension for 3D matrices using the sum Triton kernel

### DIFF
--- a/torchbenchmark/operators/sum/kernels.py
+++ b/torchbenchmark/operators/sum/kernels.py
@@ -46,9 +46,9 @@ def triton_sum_kernel_scalar_result(
         triton.Config(
             {"BLOCK_SIZE_NON_REDUCE_DIM": b},
             num_warps=w,
-        ) for b, w in itertools.product(
-            [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],  # block sizes
-            [2, 4, 8, 16]  # number of warps
+        )
+        for b, w in itertools.product(
+            [2, 4, 8, 16], [2, 4, 8]  # block sizes  # number of warps
         )
     ],
     key=["M", "N"],
@@ -109,3 +109,70 @@ def triton_sum_kernel_1D_result(
         tl.store(output_ptr + offsets_n, output, mask=mask_n)
     elif dim == 1:  # store output along M-th dimension
         tl.store(output_ptr + offsets_m, output, mask=mask_m)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_SIZE_K": b},
+            num_warps=w,
+        )
+        for b, w in itertools.product(
+            [2, 4, 16, 32, 128, 256], [2, 4, 8]  # block sizes  # number of warps
+        )
+    ],
+    key=["N"],
+)
+@triton.jit
+def triton_sum_kernel_2D_result_dim_1(
+    input_ptr,  # pointer to input matrix
+    output_ptr,  # pointer to output matrix
+    # matrix dimensions (input)
+    M: tl.constexpr,  # number of elements in M-th dimension
+    N: tl.constexpr,  # number of elements in N-th dimension
+    K: tl.constexpr,  # number of elements in K-th dimension
+    # block sizes (input)
+    BLOCK_SIZE_N: tl.constexpr,  # number of elements in block on N-th dimension
+    BLOCK_SIZE_K: tl.constexpr,  # number of elements in block on K-th dimension
+):
+    # input block shape: (1, N, BLOCK_SIZE_K)
+
+    pid = tl.program_id(axis=0)  # i-th block of input
+
+    pid_m = pid // tl.cdiv(K, BLOCK_SIZE_K)
+    pid_k = pid % tl.cdiv(K, BLOCK_SIZE_K)
+
+    block_start_n = (
+        0  # assuming that the entire reduction dimension fits within one thread block
+    )
+    block_start_k = pid_k * BLOCK_SIZE_K
+
+    offsets_n = block_start_n + tl.arange(0, BLOCK_SIZE_N)
+    offsets_k = block_start_k + tl.arange(0, BLOCK_SIZE_K)
+
+    mask_n = offsets_n < N
+    mask_k = offsets_k < K
+
+    # idxs has shape (N, BLOCK_SIZE_K)
+    idxs_base = (offsets_n[:, None] * K) + offsets_k
+    idxs = idxs_base + (
+        pid_m * N * K
+    )  # increment idxs by the number of elements in all previous blocks
+
+    # mask has shape (N, BLOCK_SIZE_K)
+    mask = mask_n[:, None] & mask_k
+
+    # loaded pointers have shape (N, K)
+    input = tl.load(
+        input_ptr + idxs, mask=mask, other=0
+    )  # zero out masked values from input
+
+    # output has shape (1, BLOCK_SIZE_K)
+    output = tl.sum(input, axis=0)
+
+    output_offsets = (pid_m * K) + offsets_k
+
+    # stored pointers have shape (1, BLOCK_SIZE_K)
+    tl.store(
+        output_ptr + output_offsets, output, mask=mask_k
+    )  # store a 1D vector into a specific row of 2D output


### PR DESCRIPTION
Summary: Support reducing 3-dimensional matrices across the middle dimension (`dim == 1`) such that the result is of dimensions `(M, K)`. This kernel assumes that `BLOCK_SIZE_M == 1`, as Triton is currently unable to perform reductions on a middle dimension, and that that the entire reduction dimension of the tensor fits in a thread block (`BLOCK_SIZE_N >= N`).

Reviewed By: davidberard98

Differential Revision: D58307854
