### PR TITLE
Compile FBGEMM on H100

### DIFF
--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -11,7 +11,7 @@ def install_fbgemm():
     cmd = ["pip", "install", "-r", "requirements.txt"]
     subprocess.check_call(cmd, cwd=str(FBGEMM_PATH.resolve()))
     # Build target A100(8.0) or H100(9.0)
-    cmd = [sys.executable, "setup.py", "bdist_wheel", "--package_variant=genai", "-DTORCH_CUDA_ARCH_LIST=8.0;9.0"]
+    cmd = [sys.executable, "setup.py", "bdist_wheel", "--package_variant=genai", "-DTORCH_CUDA_ARCH_LIST=8.0;9.0;9.0a"]
     subprocess.check_call(cmd, cwd=str(FBGEMM_PATH.resolve()))
 
 def test_fbgemm():

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -10,7 +10,7 @@ FBGEMM_PATH = REPO_PATH.joinpath("submodules", "FBGEMM", "fbgemm_gpu")
 def install_fbgemm():
     cmd = ["pip", "install", "-r", "requirements.txt"]
     subprocess.check_call(cmd, cwd=str(FBGEMM_PATH.resolve()))
-    # Build target A100(8.0) or H100(9.0)
+    # Build target A100(8.0) or H100(9.0, 9.0a)
     cmd = [sys.executable, "setup.py", "bdist_wheel", "--package_variant=genai", "-DTORCH_CUDA_ARCH_LIST=8.0;9.0;9.0a"]
     subprocess.check_call(cmd, cwd=str(FBGEMM_PATH.resolve()))
 


### PR DESCRIPTION
H100 requires a special `9.0a` arch list to gain full kernel compilation.

Test plan:
https://github.com/pytorch/benchmark/actions/runs/9489468560