### PR TITLE
Hardcode the numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ psutil
 pyyaml
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
-numpy==1.21.2
+numpy==1.21.2; python_version < '3.11'
+numpy==2.0.0; python_version >= '3.11'
 opencv-python
 submitit
 pynvml

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,9 @@ transformers==4.38.1
 MonkeyType
 psutil
 pyyaml
-numpy
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2
 opencv-python
 submitit
 pynvml

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
-numpy==2.0.0; python_version >= '3.11'
+numpy==1.26.0; python_version >= '3.11'
 opencv-python
 submitit
 pynvml

--- a/torchbenchmark/models/Background_Matting/requirements.txt
+++ b/torchbenchmark/models/Background_Matting/requirements.txt
@@ -1,4 +1,7 @@
-numpy==1.21.2
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2; python_version < '3.11'
+numpy==2.0.0; python_version >= '3.11'
 opencv-python
 pandas
 Pillow

--- a/torchbenchmark/models/Background_Matting/requirements.txt
+++ b/torchbenchmark/models/Background_Matting/requirements.txt
@@ -1,7 +1,7 @@
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
-numpy==2.0.0; python_version >= '3.11'
+numpy==1.26.0; python_version >= '3.11'
 opencv-python
 pandas
 Pillow

--- a/torchbenchmark/models/Background_Matting/requirements.txt
+++ b/torchbenchmark/models/Background_Matting/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.21.2
 opencv-python
 pandas
 Pillow

--- a/torchbenchmark/models/hf_Whisper/requirements.txt
+++ b/torchbenchmark/models/hf_Whisper/requirements.txt
@@ -2,4 +2,4 @@ numba
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
-numpy==2.0.0; python_version >= '3.11'
+numpy==1.26.0; python_version >= '3.11'

--- a/torchbenchmark/models/hf_Whisper/requirements.txt
+++ b/torchbenchmark/models/hf_Whisper/requirements.txt
@@ -1,1 +1,2 @@
 numba
+numpy==1.21.2

--- a/torchbenchmark/models/hf_Whisper/requirements.txt
+++ b/torchbenchmark/models/hf_Whisper/requirements.txt
@@ -1,2 +1,5 @@
 numba
-numpy==1.21.2
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2; python_version < '3.11'
+numpy==2.0.0; python_version >= '3.11'

--- a/torchbenchmark/models/tacotron2/requirements.txt
+++ b/torchbenchmark/models/tacotron2/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy==1.21.2
 inflect
 scipy
 Unidecode

--- a/torchbenchmark/models/tacotron2/requirements.txt
+++ b/torchbenchmark/models/tacotron2/requirements.txt
@@ -1,4 +1,7 @@
-numpy==1.21.2
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2; python_version < '3.11'
+numpy==2.0.0; python_version >= '3.11'
 inflect
 scipy
 Unidecode

--- a/torchbenchmark/models/tacotron2/requirements.txt
+++ b/torchbenchmark/models/tacotron2/requirements.txt
@@ -1,7 +1,7 @@
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
-numpy==2.0.0; python_version >= '3.11'
+numpy==1.26.0; python_version >= '3.11'
 inflect
 scipy
 Unidecode

--- a/torchbenchmark/util/framework/detectron2/requirements.txt
+++ b/torchbenchmark/util/framework/detectron2/requirements.txt
@@ -3,4 +3,4 @@ omegaconf==2.3.0
 # We need to pin numpy version to the same as the torch testing environment
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
-numpy==2.0.0; python_version >= '3.11'
+numpy==1.26.0; python_version >= '3.11'

--- a/torchbenchmark/util/framework/detectron2/requirements.txt
+++ b/torchbenchmark/util/framework/detectron2/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8
 omegaconf==2.3.0
-numpy
+numpy==1.21.2

--- a/torchbenchmark/util/framework/detectron2/requirements.txt
+++ b/torchbenchmark/util/framework/detectron2/requirements.txt
@@ -1,3 +1,6 @@
 git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8
 omegaconf==2.3.0
-numpy==1.21.2
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2; python_version < '3.11'
+numpy==2.0.0; python_version >= '3.11'

--- a/utils/build_requirements.txt
+++ b/utils/build_requirements.txt
@@ -1,0 +1,6 @@
+# We need to pin numpy version to the same as the torch testing environment
+# which still supports python 3.8
+numpy==1.21.2; python_version < '3.11'
+numpy==1.26.0; python_version >= '3.11'
+psutil
+pyyaml

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -20,18 +20,7 @@ CUDA_VERSION_MAP = {
 PIN_CMAKE_VERSION = "3.22.*"
 
 TORCHBENCH_TORCH_NIGHTLY_PACKAGES = ["torch", "torchvision", "torchaudio"]
-
-def _get_pin_numpy_version() -> str:
-    requirements_file = REPO_ROOT.joinpath("requirements.txt")
-    numpy_reg = "numpy==(.*)"
-    with open(requirements_file, "r") as fp:
-        numpy_requirement = list(filter(lambda x: "numpy==" in x, fp.readlines()))
-    assert numpy_requirement, f"Expected numpy version hardcoded in {str(requirements_file.resolve())}."
-    numpy_version = re.match(numpy_reg, numpy_requirement[0]).groups()[0]
-    print(f"Pinned NUMPY version: {numpy_version}")
-    return numpy_version
-
-PIN_NUMPY_VERSION = _get_pin_numpy_version()
+BUILD_REQUIREMENTS_FILE = REPO_ROOT.joinpath("utils", "build_requirements.txt")
 
 def _nvcc_output_match(nvcc_output, target_cuda_version):
     regex = "release (.*),"
@@ -163,9 +152,8 @@ def install_torch_build_deps(cuda_version: str):
     build_deps = ["ffmpeg"]
     cmd = ["conda", "install", "-y"] + build_deps
     subprocess.check_call(cmd)
-    # pip deps
-    pip_deps = [f"numpy=={PIN_NUMPY_VERSION}"]
-    cmd = ["pip", "install"] + pip_deps
+    # pip build deps
+    cmd = ["pip", "install", "-r"] + str(BUILD_REQUIREMENTS_FILE.resolve())
     subprocess.check_call(cmd)
     # conda forge deps
     # ubuntu 22.04 comes with libstdcxx6 12.3.0

--- a/utils/cuda_utils.py
+++ b/utils/cuda_utils.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from .python_utils import DEFAULT_PYTHON_VERSION
+
 from typing import Optional
 
 # defines the default CUDA version to compile against
@@ -17,11 +19,18 @@ CUDA_VERSION_MAP = {
     },
 }
 PIN_CMAKE_VERSION = "3.22.*"
-# the numpy version needs to be consistent with
-# https://github.com/pytorch/builder/blob/e66e48f9b1968213c6a7ce3ca8df6621435f0a9c/wheel/build_wheel.sh#L146
-PIN_NUMPY_VERSION = "1.23.5"
+
 TORCHBENCH_TORCH_NIGHTLY_PACKAGES = ["torch", "torchvision", "torchaudio"]
 
+def _get_pin_numpy_version() -> str:
+    # the numpy version needs to be consistent with
+    # https://github.com/pytorch/builder/blob/main/wheel/build_wheel.sh#L146
+    RAW_GITHUB_BUILDER_SCRIPT = "https://raw.githubusercontent.com/pytorch/builder/main/wheel/build_wheel.sh"
+    numpy_version = "2.0.0rc1"
+    print(f"Pinned NUMPY version: {numpy_version}")
+    return numpy_version
+
+PIN_CMAKE_VERSION = _get_pin_numpy_version()
 
 def _nvcc_output_match(nvcc_output, target_cuda_version):
     regex = "release (.*),"


### PR DESCRIPTION
When there is a big numpy version bump (1.21.2 -> 2.0.0), `pip install` will somehow automatically upgrade numpy version to 2.0.0 even when the old version (1.21.2) has been installed.

Therefore, we have to hardcode numpy version both globally and for the models whose install will cause numpy to unexpectedly upgrade. Since downstream CI supports Python 3.8 as the lowest supported Python version, we have to pin numpy version to the lowest version used in the downstream CI.