### PR TITLE
Re-enable detectron2 model accuracy checks.

### DIFF
--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_c4/metadata.yaml
@@ -6,5 +6,3 @@ eval_deterministic: false
 eval_nograd: true
 train_benchmark: false
 train_deterministic: false
-not_implemented:
-  - test: example

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_dc5/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_101_fpn/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_c4/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_dc5/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_fasterrcnn_r_50_fpn/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -58,6 +58,7 @@ class Model(BenchmarkModel):
     model_file = os.path.join(MODEL_DIR, ".data", f"{MODEL_NAME}.pkl")
     DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
+    DISABLE_DETERMINISM = True
 
     def __init__(self, test, device, batch_size=None, extra_args=[]):
         super().__init__(

--- a/torchbenchmark/models/detectron2_maskrcnn/__init__.py
+++ b/torchbenchmark/models/detectron2_maskrcnn/__init__.py
@@ -58,9 +58,6 @@ class Model(BenchmarkModel):
     model_file = os.path.join(MODEL_DIR, ".data", f"{MODEL_NAME}.pkl")
     DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
-    # Skip correctness check, because the output tensor can't be verified using
-    # cosine similarity or torch.close()
-    SKIP_CORRECTNESS_CHECK = True
 
     def __init__(self, test, device, batch_size=None, extra_args=[]):
         super().__init__(

--- a/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_c4/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_101_fpn/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_c4/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
+++ b/torchbenchmark/models/detectron2_maskrcnn_r_50_fpn/metadata.yaml
@@ -6,6 +6,5 @@ eval_deterministic: false
 eval_nograd: true
 not_implemented:
 - device: cpu
-- test: example
 train_benchmark: false
 train_deterministic: false

--- a/torchbenchmark/models/maml/__init__.py
+++ b/torchbenchmark/models/maml/__init__.py
@@ -16,9 +16,6 @@ class Model(BenchmarkModel):
     DEFAULT_EVAL_BSIZE = 1
     ALLOW_CUSTOMIZE_BSIZE = False
     CANNOT_SET_CUSTOM_OPTIMIZER = True
-    # Skip correctness check, because maml runs backward and optimizer in eval()
-    # Which will return non-deterministic results
-    SKIP_CORRECTNESS_CHECK = True
 
     def __init__(self, test, device, batch_size=None, extra_args=[]):
         super().__init__(

--- a/torchbenchmark/util/framework/detectron2/model_factory.py
+++ b/torchbenchmark/util/framework/detectron2/model_factory.py
@@ -90,9 +90,7 @@ class Detectron2Model(BenchmarkModel):
     # Default batch sizes
     DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
-    # Skip correctness check, because the output tensor can't be verified using
-    # cosine similarity or torch.close()
-    SKIP_CORRECTNESS_CHECK = True
+    DISABLE_DETERMINISM = True
 
     def __init__(self, variant, test, device, batch_size=None, extra_args=[]):
         super().__init__(


### PR DESCRIPTION
Detectron2 models can pass the accuracy check when the deterministic mode is disabled.

Revert https://github.com/pytorch/benchmark/commit/abed1e7d6033ea9b75e4fc821d6c74d900fe9cc5.
Fixes https://github.com/pytorch/benchmark/issues/2290