### PR TITLE
Add variable seqlen and sparsity parameters to jagged_sum benchmark

### DIFF
--- a/torchbenchmark/operators/jagged_sum/kernels.py
+++ b/torchbenchmark/operators/jagged_sum/kernels.py
@@ -59,7 +59,9 @@ def triton_jagged_sum_kernel_simple_fused_sum_then_buffer(
     for block_pos in range(
         0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
     ):  # loop over ragged dimension, ranging until maximum seqlen
-        block_start_ragged = ragged_start + block_pos  # offset block position by start of current program
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
         offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
         mask_ragged = offsets_ragged < ragged_end
 
@@ -132,7 +134,9 @@ def triton_jagged_sum_kernel_simple_fused_buffer_then_sum(
     for block_pos in range(
         0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
     ):  # loop over ragged dimension, ranging until maximum seqlen
-        block_start_ragged = ragged_start + block_pos  # offset block position by start of current program
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
         offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
         mask_ragged = offsets_ragged < ragged_end
 


### PR DESCRIPTION
Summary:
Modify existing `jagged_sum` operator benchmark to optionally accept any of the following parameters: `B` (dimension 0 of nested tensor), `M` (dimension 2 of nested tensor), `seqlen` (maximum sequence length on ragged dimension), or `sparsity` (average sparsity on ragged dimension). This diff fixes the provided command line parameters and varies all other parameters above, enabling testing of all combinations of multiple parameters in parallel.

The following errors persist with sufficiently large inputs:
- `RuntimeError: numel needs to be smaller than int32_t max; otherwise, please use packed_accessor64` (when running command `buck2 run @mode/{opt,inplace} //pytorch/benchmark:triton -- --op jagged_sum --B 1024 --M 1024 --sparsity 0.3`)
- `torch.OutOfMemoryError: CUDA out of memory.`

Reviewed By: davidberard98

Differential Revision: D58772201
