### PR TITLE
Support loading data files from manifold and run in Meta internal environment.

### DIFF
--- a/torchbenchmark/models/Background_Matting/__init__.py
+++ b/torchbenchmark/models/Background_Matting/__init__.py
@@ -56,7 +56,19 @@ class Model(BenchmarkModel):
             }
         )
 
-        datadir = os.path.join(DATA_PATH, "Background_Matting_inputs")
+        input_data_dir_name = "Background_Matting_inputs"
+        datadir = os.path.join(DATA_PATH, input_data_dir_name)
+        if not os.path.exists(datadir):
+            try:
+                from torchbenchmark.util.framework.fb.installer import install_data
+                import shutil
+                datadir = install_data(input_data_dir_name)
+                # Input data files are decompressed into the folder one level deeper.
+                datadir = os.path.join(datadir, input_data_dir_name)
+            except Exception as e:
+                msg = f"Failed to download data from manifold: {e}"
+                raise RuntimeError(msg) from e
+
         csv_file_path = _create_data_dir().joinpath("Video_data_train_processed.csv")
         with open(f"{datadir}/Video_data_train.csv", "r") as r:
             with open(csv_file_path, "w") as w:

--- a/torchbenchmark/models/Super_SloMo/dataloader.py
+++ b/torchbenchmark/models/Super_SloMo/dataloader.py
@@ -168,6 +168,15 @@ class SuperSloMo(data.Dataset):
 
         # Populate the list with image paths for all the
         # frame in `root`.
+        if not os.path.exists(root):
+            try:
+                from torchbenchmark.util.framework.fb.installer import install_data
+                data_dir = install_data("Super_SloMo_inputs")
+                root = os.path.join(data_dir, "Super_SloMo_inputs/dataset/train")
+            except Exception as e:
+                msg = f"Failed to download data from manifold: {e}"
+                raise RuntimeError(msg) from e
+
         framesPath = _make_dataset(root)
         # Raise error if no images found in root.
         if len(framesPath) == 0:

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/data/image_folder.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/data/image_folder.py
@@ -23,7 +23,18 @@ def is_image_file(filename):
 
 def make_dataset(dir, max_dataset_size=float("inf")):
     images = []
-    assert os.path.isdir(dir), '%s is not a valid directory' % dir
+    # The script is probably run at Meta internally. Attempt to
+    # download the dataset from Manifold.
+    if not os.path.isdir(dir):
+        try:
+            from torchbenchmark.util.framework.fb.installer import install_data
+
+            data_dir = install_data("pytorch_CycleGAN_and_pix2pix_inputs")
+            # Process the path to use the data just downloaded.
+            dir = os.path.join(data_dir, dir.split("/.data/", 1)[1])
+        except Exception as e:
+            msg = f"Failed to download data from manifold: {e}"
+            raise RuntimeError(msg) from e
 
     for root, _, fnames in sorted(os.walk(dir)):
         for fname in fnames:

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
@@ -49,6 +49,15 @@ def get_model(args, device):
     else:
         model = model.netG
     root = str(Path(__file__).parent)
+    # The script is probably run at Meta internally. Attempt to download the dataset from Manifold.
+    if not os.path.exists(f'{root}/example_input.pt'):
+        try:
+            from torchbenchmark.util.framework.fb.installer import install_data
+            data_name = "pytorch_CycleGAN_and_pix2pix_example_inputs"
+            root = install_data(data_name)
+        except Exception as e:
+            msg = f"Failed to download data from manifold: {e}"
+            raise RuntimeError(msg) from e
     data = torch.load(f'{root}/example_input.pt')
     input = data['A'].to(device)
 

--- a/torchbenchmark/models/tacotron2/data_utils.py
+++ b/torchbenchmark/models/tacotron2/data_utils.py
@@ -1,5 +1,6 @@
 import random
 import numpy as np
+import os
 import torch
 import torch.utils.data
 
@@ -30,6 +31,10 @@ class TextMelLoader(torch.utils.data.Dataset):
         # separate filename and text
         audiopath, text = audiopath_and_text[0], audiopath_and_text[1]
         text = self.get_text(text)
+        # do some file path processing when input data is not linked as
+        # data dependency.
+        if not os.path.exists(audiopath):
+            audiopath = audiopath.replace("../../data/.data", "", 1)
         mel = self.get_mel(audiopath)
         return (text, mel)
 

--- a/torchbenchmark/models/tacotron2/tacotron2_utils.py
+++ b/torchbenchmark/models/tacotron2/tacotron2_utils.py
@@ -1,7 +1,9 @@
-import numpy as np
-from scipy.io.wavfile import read
-import torch
+import os
 from pathlib import Path
+
+import numpy as np
+import torch
+from scipy.io.wavfile import read
 
 
 def get_mask_from_lengths(lengths):
@@ -18,11 +20,25 @@ def load_wav_to_torch(full_path):
 
 def load_filepaths_and_text(filename, split="|"):
     root = str(Path(__file__).parent)
-    with open(filename, encoding='utf-8') as f:
+    # The script is probably run at Meta internally. Attempt to download the dataset from Manifold.
+    if not os.path.exists(filename):
+        try:
+            from torchbenchmark.util.framework.fb.installer import install_data
+
+            root = install_data("tacotron2-minimal")
+            filename = os.path.join(
+                root,
+                "tacotron2-minimal/filelists/ljs_audio_text_train_filelist.txt",
+            )
+        except Exception as e:
+            msg = f"Failed to download data from manifold: {e}"
+            raise RuntimeError(msg) from e
+
+    with open(filename, encoding="utf-8") as f:
         filepaths_and_text = []
         for line in f:
             filename, *text = line.strip().split(split)
-            filename = f'{root}/{filename}'
+            filename = f"{root}/{filename}"
             filepaths_and_text.append((filename, *text))
     return filepaths_and_text
 


### PR DESCRIPTION
Summary: Update several torchbenchmark models so that when being run in Meta internal dev environment using `buck` command, they downloads data from pre-uploaded manifold path.

Differential Revision: D59014352
