### PR TITLE
Add Triton kernels with fast variable-length loop to jagged_sum benchmark

### DIFF
--- a/torchbenchmark/operators/jagged_sum/kernels.py
+++ b/torchbenchmark/operators/jagged_sum/kernels.py
@@ -4,9 +4,9 @@ import triton
 import triton.language as tl
 
 
-BLOCK_SIZES = [2**n for n in range(2, 11, 3)]
-NUM_WARPS = [2, 4, 8]
-NUM_STAGES = [2, 4, 8]
+BLOCK_SIZES = [2**n for n in range(3, 7, 3)]
+NUM_WARPS = [4, 8]
+NUM_STAGES = [2, 4]
 
 
 @triton.autotune(
@@ -137,6 +137,148 @@ def triton_jagged_sum_kernel_simple_fused_buffer_then_sum(
         block_start_ragged = (
             ragged_start + block_pos
         )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        buffer += tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+    buffer_sum = tl.sum(buffer, axis=0)
+
+    buffer_view = buffer_sum.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    output_offsets = offsets_m + (
+        pid_ragged * M
+    )  # output is offset by both ragged dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_ragged + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view, mask=output_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES,  # block sizes on non-reduction dimension
+            BLOCK_SIZES,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (1, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging from beginning to end of this program in values tensor
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+        buffer += tl.sum(input, axis=0)
+
+    buffer_view = buffer.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    output_offsets = offsets_m + (
+        pid_b * M
+    )  # output is offset by both B-th dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_b + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view, mask=output_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES,  # block sizes on non-reduction dimension
+            BLOCK_SIZES,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_sum_kernel_variable_length_loop_buffer_then_sum(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_ragged = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_ragged), tl.load(
+        input_ptr_offsets + (pid_ragged + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging from beginning to end of this program in values tensor
         offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
         mask_ragged = offsets_ragged < ragged_end
 

--- a/torchbenchmark/operators/jagged_sum/operator.py
+++ b/torchbenchmark/operators/jagged_sum/operator.py
@@ -18,6 +18,8 @@ from torchbenchmark.util.triton_op import (
 from .kernels import (
     triton_jagged_sum_kernel_simple_fused_buffer_then_sum,
     triton_jagged_sum_kernel_simple_fused_sum_then_buffer,
+    triton_jagged_sum_kernel_variable_length_loop_buffer_then_sum,
+    triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer,
 )
 
 seed = 16
@@ -26,7 +28,9 @@ torch.manual_seed(seed)
 
 GIGABYTES_PER_BYTE = 1e-6
 RANDOM_CHOICE_MARGIN = 0.3
-ABSOLUTE_TOLERANCE = 1e-3
+ABSOLUTE_TOLERANCE = 1e-4
+RELATIVE_TOLERANCE = 1e-3
+TENSOR_BYTES_LIMIT = 8 * 1e9  # allocate tensors no greater than 8GB
 
 
 def parse_op_args(args: List[str]):
@@ -54,8 +58,8 @@ def parse_op_args(args: List[str]):
     parser.add_argument(
         "--sum-then-buffer",
         type=int,  # 1: sum then buffer, 0: buffer then sum
-        default=1,
-        help="[Optional] For Triton kernels, determines whether to sum individual blocks then add to a buffer or add to a buffer then sum; 1: sum then buffer, 0: buffer then sum",
+        default=0,
+        help="[Optional] For Triton kernels, determines whether to sum individual blocks then add to a buffer or add to a buffer then sum; 1: sum then buffer, 0: buffer then sum; default 0",
     )
     return parser.parse_args(args)
 
@@ -85,6 +89,29 @@ def execute_kernel_simple_fused(x, max_seqlen, sum_then_buffer):
     return kernel_output
 
 
+def execute_kernel_variable_length_loop(x, sum_then_buffer):
+    B, M = x.shape[0], x.shape[2]
+    grid = lambda meta: ((len(x.offsets()) - 1) * triton.cdiv(M, meta["BLOCK_SIZE_M"]),)
+    kernel_output = torch.zeros((B, M), device=x.device)
+
+    if sum_then_buffer:
+        triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer[grid](
+            x.values(),
+            x.offsets(),
+            kernel_output,
+            M=M,
+        )
+    else:
+        triton_jagged_sum_kernel_variable_length_loop_buffer_then_sum[grid](
+            x.values(),
+            x.offsets(),
+            kernel_output,
+            M=M,
+        )
+
+    return kernel_output
+
+
 class Operator(BenchmarkOperator):
 
     DEFAULT_METRICS = ["latency", "accuracy"]
@@ -94,15 +121,15 @@ class Operator(BenchmarkOperator):
 
     def __init__(self, mode: str, device: str, extra_args: Optional[List[str]] = None):
         super().__init__(mode=mode, device=device, extra_args=extra_args)
-        self.sizes = list(range(2, 8, 2)) + list(
-            range(8, 12)
+        self.sizes = list(range(2, 12, 4)) + list(
+            range(12, 23, 3)
         )  # bias towards larger sizes, which are more representative of real-world shapes
 
         args = parse_op_args(self.extra_args)
-        self.B = args.B if args.B is not None else None
-        self.M = args.M if args.M is not None else None
-        self.seqlen = args.seqlen if args.seqlen is not None else None
-        self.sparsity = args.sparsity if args.sparsity is not None else None
+        self.B = args.B
+        self.M = args.M
+        self.seqlen = args.seqlen
+        self.sparsity = args.sparsity
         self.sum_then_buffer = args.sum_then_buffer
 
     @register_benchmark(baseline=True)
@@ -131,11 +158,20 @@ class Operator(BenchmarkOperator):
         )  # sum along ragged dimension (dim == 1)
 
     @register_benchmark()
-    def triton_jagged_sum_no_pad(
+    def triton_jagged_sum_no_pad_simple_fused(
         self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
     ):
         def _inner():
             return execute_kernel_simple_fused(x, seqlen, self.sum_then_buffer)
+
+        return _inner
+
+    @register_benchmark()
+    def triton_jagged_sum_no_pad_variable_length_loop(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        def _inner():
+            return execute_kernel_variable_length_loop(x, self.sum_then_buffer)
 
         return _inner
 
@@ -169,8 +205,7 @@ class Operator(BenchmarkOperator):
 
         if self.seqlen is None:
             seqlen_vals.extend(
-                list(range(100, 1000, 100))
-                + list(range(1000, 10000, 1000))
+                list(range(100, 1000, 100)) + list(range(1000, 20000, 1000))
             )
         else:
             seqlen_vals.extend([self.seqlen])
@@ -187,47 +222,57 @@ class Operator(BenchmarkOperator):
         Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
         """
 
+        def get_size_in_bytes(shape) -> int:
+            num_elements = math.prod(shape)
+            element_size = self.dtype.itemsize
+            return math.floor(num_elements * element_size)
+
         B_vals, M_vals, seqlen_vals, sparsity_vals = self.get_x_vals()
         vals = itertools.product(B_vals, M_vals, seqlen_vals, sparsity_vals)
 
-        for B, M, seqlen, sparsity in vals:
-            tensors = []
+        for B, M, max_seqlen, sparsity in vals:
+            if (
+                get_size_in_bytes((B, M, max_seqlen)) < TENSOR_BYTES_LIMIT
+            ):  # ensure that GPU memory is not exceeded
+                tensors = []
 
-            # greater sparsity --> shorter sequence lengths on ragged dimension
-            seqlen_avg = math.floor(
-                seqlen * (1 - sparsity)
-            )  # average sequence length across all tensors in nested tensor
-            seqlen_margin = math.floor(
-                seqlen * RANDOM_CHOICE_MARGIN
-            )  # use margin to constrain sequence lengths to range [seqlen_avg - seqlen_margin, seqlen_avg + seqlen_margin] to approximate an average sequence length, which correlates with sparsity
+                # greater sparsity --> shorter sequence lengths on ragged dimension
+                seqlen_avg = math.floor(
+                    max_seqlen * (1 - sparsity)
+                )  # average sequence length across all tensors in nested tensor
+                seqlen_margin = math.floor(
+                    max_seqlen * RANDOM_CHOICE_MARGIN
+                )  # use margin to constrain sequence lengths to range [seqlen_avg - seqlen_margin, seqlen_avg + seqlen_margin] to approximate an average sequence length, which correlates with sparsity
 
-            for _ in range(B):
-                seqlen_randint = random.randint(
-                    max(
-                        seqlen_avg - seqlen_margin, 1
-                    ),  # seqlen_randint must be at least 1
-                    min(
-                        seqlen_avg + seqlen_margin, seqlen
-                    ),  # seqlen_randint must not exceed self.seqlen
+                for _ in range(B):
+                    seqlen_randint = random.randint(
+                        max(
+                            seqlen_avg - seqlen_margin, 1
+                        ),  # seqlen_randint must be at least 1
+                        min(
+                            seqlen_avg + seqlen_margin, max_seqlen
+                        ),  # seqlen_randint must not exceed self.seqlen
+                    )
+                    tensor_2d = torch.randn(
+                        (seqlen_randint, M), device=self.device, dtype=self.dtype
+                    )
+                    tensors.append(tensor_2d)
+
+                nt = torch.nested.nested_tensor(
+                    tensors,
+                    layout=torch.jagged,
+                    device=self.device,
+                    dtype=self.dtype,
                 )
-                tensor_2d = torch.randn(
-                    (seqlen_randint, M), device=self.device, dtype=self.dtype
-                )
-                tensors.append(tensor_2d)
 
-            nt = torch.nested.nested_tensor(
-                tensors,
-                layout=torch.jagged,
-                device=self.device,
-                dtype=self.dtype,
-            )
-
-            yield (nt, B, M, seqlen, sparsity)
+                yield (nt, B, M, max_seqlen, sparsity)
 
     def _get_accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:
         output = fn()
         baseline_output = baseline_fn()
-        return torch.allclose(output, baseline_output, atol=ABSOLUTE_TOLERANCE)
+        return torch.allclose(
+            output, baseline_output, atol=ABSOLUTE_TOLERANCE, rtol=RELATIVE_TOLERANCE
+        )
 
     @register_metric()
     def gbps(self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics):
@@ -238,7 +283,7 @@ class Operator(BenchmarkOperator):
             * GIGABYTES_PER_BYTE
         )
 
-    @register_metric(x_only=True)  # TODO modify!!!!
+    @register_metric(x_only=True)
     def input_shape(
         self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics
     ):
@@ -254,10 +299,20 @@ class Operator(BenchmarkOperator):
     def best_config(
         self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics
     ) -> str:
+        fn_name_str = str(fn_name).split(".")[1]
+
         if self.sum_then_buffer:
+            if "simple_fused" in fn_name_str:
+                return dump_autotuner_best_config(
+                    triton_jagged_sum_kernel_simple_fused_sum_then_buffer
+                )
             return dump_autotuner_best_config(
-                triton_jagged_sum_kernel_simple_fused_sum_then_buffer
+                triton_jagged_sum_kernel_variable_length_loop_sum_then_buffer
+            )
+        if "simple_fused" in fn_name_str:
+            return dump_autotuner_best_config(
+                triton_jagged_sum_kernel_simple_fused_buffer_then_sum
             )
         return dump_autotuner_best_config(
-            triton_jagged_sum_kernel_simple_fused_buffer_then_sum
+            triton_jagged_sum_kernel_variable_length_loop_buffer_then_sum
         )


### PR DESCRIPTION
Summary:
Add a set of Triton kernels which implements a fast, variable-length loop upon the simple fused Triton kernels created in D58549297. This diff enables looping from the beginning to the end of the specific variable-length subsection of the input nested tensor, which eliminates the extra work done by the simple fused kernel in looping over the entire range of the maximum sequence length. Specifically, this diff eliminates the need to loop over extraneous data beyond the nested tensor's jagged length, terminating the loop before it starts reading, reducing, and writing extra zeros. This diff also contains implementations for `sum_then_buffer` and `buffer_then_sum`, as seen in the simple fused implementation from D58549297.

This diff draws from a similar binary search implementation found [here](https://www.internalfb.com/code/fbsource/[d33668c8c8fe3cc7d75beb58b4b0dc51dc6e96a1][diffs]/fbcode/caffe2/torch/_inductor/runtime/triton_helpers.py?lines=195).

Default the `sum_then_buffer` parameter to 0; as shown in the Test Plan, the `buffer_to_sum` implementation outperforms the `sum_to_buffer` implementation.

Note that the benchmark selects nested tensor inputs whose padded versions do not exceed an 8 GB size limitation, as the PyTorch benchmarks are limited by the size of the padded, rather than the unpadded, nested tensors.

Reviewed By: davidberard98

Differential Revision: D59026460
