### PR TITLE
Schedule the base docker build monthly

### DIFF
--- a/.github/workflows/build-gcp-docker.yml
+++ b/.github/workflows/build-gcp-docker.yml
@@ -1,5 +1,8 @@
 name: TorchBench Nightly GCP Base Docker Build
 on:
+  schedule:
+    # Build the base Docker monthly
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We need to periodically update the base docker build because the underlying runner container will update.