### PR TITLE
Fix tagging the nightly docker

### DIFF
--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -44,7 +44,7 @@ jobs:
               -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch/torchbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')
-          export DOCKER_TAG=$(sed -n 's/.*\(dev[0-9]\+\).*/\1/p' <<< "${PYTORCH_VERSION}")
+          export DOCKER_TAG=$(awk '{match($0, /dev[0-9]+/, arr); print arr[0]}' <<< "${PYTORCH_VERSION}")
           docker tag ghcr.io/pytorch/torchbench:latest ghcr.io/pytorch/torchbench:${DOCKER_TAG}
       - name: Push docker to remote
         if: ${{ env.WITH_PUSH == 'true' }}

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -44,7 +44,7 @@ jobs:
               -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch/torchbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')
-          export DOCKER_TAG=$(sed -n 's/.*\(dev[0-9]\+\).*/\1/p' <<< "${PYTORCH_VERSION}"")
+          export DOCKER_TAG=$(sed -n 's/.*\(dev[0-9]\+\).*/\1/p' <<< "${PYTORCH_VERSION}")
           docker tag ghcr.io/pytorch/torchbench:latest ghcr.io/pytorch/torchbench:${DOCKER_TAG}
       - name: Push docker to remote
         if: ${{ env.WITH_PUSH == 'true' }}

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -35,19 +35,16 @@ jobs:
       - name: Build TorchBench nightly docker
         run: |
           export NIGHTLY_DATE="${{ github.event.inputs.nightly_date }}"
-          if [ -z "${NIGHTLY_DATE}" ]; then
-            export TODAY=$(date +'%Y%m%d')
-            export DOCKER_TAG=dev${TODAY}
-          else
-            export DOCKER_TAG=dev${NIGHTLY_DATE}
-          fi
           cd benchmark/docker
           full_ref="${{ github.ref }}"
           prefix="refs/heads/"
           branch_name=${full_ref#$prefix}
           docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
-              -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:${DOCKER_TAG}
-          docker tag ghcr.io/pytorch/torchbench:${DOCKER_TAG} ghcr.io/pytorch/torchbench:latest
+              -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:latest
+          # Extract pytorch version from the docker
+          PYTORCH_VERSION=$(docker run ghcr.io/pytorch/torchbench:latest bash -c '. /workspace/setup_instance.sh; python -c "import torch; print(torch.__version__)"')
+          export DOCKER_TAG=$(sed -n 's/.*\(dev[0-9]\+\).*/\1/p' <<< "${PYTORCH_VERSION}"")
+          docker tag ghcr.io/pytorch/torchbench:latest ghcr.io/pytorch/torchbench:${DOCKER_TAG}
       - name: Push docker to remote
         if: ${{ env.WITH_PUSH == 'true' }}
         run: |

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           export TODAY=$(date +'%Y%m%d')
           export DOCKER_TAG=dev${TODAY}
-          docker push ghcr.io/pytorch/torchbench:${DOCKER_TAG}
-          docker push ghcr.io/pytorch/torchbench:latest
+          # docker push ghcr.io/pytorch/torchbench:${DOCKER_TAG}
+          # docker push ghcr.io/pytorch/torchbench:latest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           export TODAY=$(date +'%Y%m%d')
           export DOCKER_TAG=dev${TODAY}
-          # docker push ghcr.io/pytorch/torchbench:${DOCKER_TAG}
-          # docker push ghcr.io/pytorch/torchbench:latest
+          docker push ghcr.io/pytorch/torchbench:${DOCKER_TAG}
+          docker push ghcr.io/pytorch/torchbench:latest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -42,7 +42,7 @@ jobs:
           docker build . --build-arg TORCHBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f torchbench-nightly.dockerfile -t ghcr.io/pytorch/torchbench:latest
           # Extract pytorch version from the docker
-          PYTORCH_VERSION=$(docker run ghcr.io/pytorch/torchbench:latest bash -c '. /workspace/setup_instance.sh; python -c "import torch; print(torch.__version__)"')
+          PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch/torchbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')
           export DOCKER_TAG=$(sed -n 's/.*\(dev[0-9]\+\).*/\1/p' <<< "${PYTORCH_VERSION}"")
           docker tag ghcr.io/pytorch/torchbench:latest ghcr.io/pytorch/torchbench:${DOCKER_TAG}
       - name: Push docker to remote

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -34,6 +34,7 @@ jobs:
           password: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
       - name: Build TorchBench nightly docker
         run: |
+          set -x
           export NIGHTLY_DATE="${{ github.event.inputs.nightly_date }}"
           cd benchmark/docker
           full_ref="${{ github.ref }}"

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -57,7 +57,6 @@ RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 && \
     sudo apt-get purge -y libnvidia-compute-550
 
 # Install Torchbench
-# Debug - remove this before commit
-# RUN cd /workspace/benchmark && \
-#     . ${SETUP_SCRIPT} && \
-#     python install.py
+RUN cd /workspace/benchmark && \
+    . ${SETUP_SCRIPT} && \
+    python install.py

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -57,6 +57,7 @@ RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 && \
     sudo apt-get purge -y libnvidia-compute-550
 
 # Install Torchbench
-RUN cd /workspace/benchmark && \
-    . ${SETUP_SCRIPT} && \
-    python install.py
+# Debug - remove this before commit
+# RUN cd /workspace/benchmark && \
+#     . ${SETUP_SCRIPT} && \
+#     python install.py


### PR DESCRIPTION
We should tag the nightly docker with the pytorch nightly version installed to make sure the docker tag and pytorch version are consistent.

Test workflow:
https://github.com/pytorch/benchmark/actions/runs/9771261183