### PR TITLE
Add workflow to cleanup Docker images

### DIFF
--- a/.github/workflows/build-gcp-docker.yml
+++ b/.github/workflows/build-gcp-docker.yml
@@ -1,6 +1,9 @@
 name: TorchBench Nightly GCP Base Docker Build
 on:
   workflow_dispatch:
+  schedule:
+    # Build the base Docker monthly
+    - cron: '0 0 1 * *'
 
 env:
   WITH_PUSH: "true"

--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -1,4 +1,4 @@
-name: TorchBench nightly docker build
+name: TorchBench Nightly Docker Build
 on:
   schedule:
     # Push the nightly docker daily at 3 PM UTC

--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -1,0 +1,26 @@
+name: TorchBench Nightly Docker Cleanup
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-push-docker:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    runs-on: [self-hosted, linux.4xlarge]
+    environment: docker-s3-upload
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: torchbench
+          package-type: container
+          delete-only-untagged-versions: true
+          token: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: torchbench
+          package-type: container
+          min-versions-to-keep: 200
+          token: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true


### PR DESCRIPTION
Update the workflow to:
1. Update the GCP base docker every month
2. Add a cleanup workflow to only keep the most recent 200 docker images.

Each docker images is ~28GB, so 200 images will take around 5.6 TB storage in total.