### PR TITLE
Add padded, torch.sum benchmark for jagged_mean operator

### DIFF
--- a/torchbenchmark/operators/jagged_mean/__init__.py
+++ b/torchbenchmark/operators/jagged_mean/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/jagged_mean/operator.py
+++ b/torchbenchmark/operators/jagged_mean/operator.py
@@ -1,0 +1,171 @@
+import argparse
+import itertools
+import math
+import os
+import random
+from typing import Callable, Generator, List, Optional, Tuple
+
+import torch
+import triton
+from torchbenchmark.util.jagged_utils import (
+    generate_input_vals,
+    generate_random_nested_tensors,
+    get_parse_op_args,
+)
+
+from torchbenchmark.util.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    register_benchmark,
+    register_metric,
+)
+
+
+seed = 16
+random.seed(seed)
+
+GIGABYTES_PER_BYTE = 1e-6
+RANDOM_CHOICE_MARGIN = 0.3
+ABSOLUTE_TOLERANCE = 1e-4
+RELATIVE_TOLERANCE = 1e-3
+TENSOR_BYTES_LIMIT = 8 * 1e9  # allocate tensors no greater than 8GB
+
+
+def parse_op_args(args: List[str]):
+    parser = get_parse_op_args("B", "M", "seqlen", "sparsity")
+    return parser.parse_args(args)
+
+
+class Operator(BenchmarkOperator):
+
+    DEFAULT_METRICS = ["latency", "accuracy"]
+    use_cuda_graphs = (
+        False  # enables GPU/CPU sync (for methods like NestedTensor unbind)
+    )
+
+    def __init__(self, mode: str, device: str, extra_args: Optional[List[str]] = None):
+        super().__init__(mode=mode, device=device, extra_args=extra_args)
+        self.sizes = list(range(2, 12, 4)) + list(
+            range(12, 23, 3)
+        )  # bias towards larger sizes, which are more representative of real-world shapes
+
+        args = parse_op_args(self.extra_args)
+        self.B = args.B
+        self.M = args.M
+        self.seqlen = args.seqlen
+        self.sparsity = args.sparsity
+
+    @register_benchmark(baseline=True)
+    def torch_jagged_mean_unbind_torch_mean(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        return lambda: torch.cat(
+            [torch.mean(t, dim=0).unsqueeze(0) for t in x.unbind()]
+        )  # in 3D tensor (B, *, M), takes the mean of B 2D tensors (*, M)
+
+    def get_x_val(self, example_inputs):
+        if self.B is None:
+            return example_inputs[1]
+        if self.M is None:
+            return example_inputs[2]
+        if self.seqlen is None:
+            return example_inputs[3]
+        return example_inputs[4]
+
+    def get_x_vals(self) -> Tuple[List[int], List[int], List[int], List[float]]:
+        return generate_input_vals(
+            self.B, self.M, self.seqlen, self.sparsity, self.sizes
+        )
+
+    def get_input_iter(self) -> Generator:
+        """
+        Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+        """
+
+        B_vals, M_vals, seqlen_vals, sparsity_vals = self.get_x_vals()
+
+        for nt, B, M, max_seqlen, sparsity in generate_random_nested_tensors(
+            B_vals,
+            M_vals,
+            seqlen_vals,
+            sparsity_vals,
+            device=self.device,
+            dtype=self.dtype,
+            TENSOR_BYTES_LIMIT=TENSOR_BYTES_LIMIT,
+            RANDOM_CHOICE_MARGIN=RANDOM_CHOICE_MARGIN,
+        ):
+            yield (nt, B, M, max_seqlen, sparsity)
+
+    @register_metric()
+    def gbps(self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics):
+        return (
+            example_inputs[0].element_size()
+            * example_inputs[0].numel()
+            / metrics.latency
+            * GIGABYTES_PER_BYTE
+        )
+
+    @register_metric(x_only=True)
+    def input_shape(
+        self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics
+    ):
+        return (
+            f"B: {example_inputs[1]}",  # B
+            "*",
+            f"M: {example_inputs[2]}",  # M
+            f"max seqlen: {example_inputs[3]}",  # seqlen
+            f"sparsity: {example_inputs[4]}",  # sparsity
+        )  # return (B, '*', M, max seqlen, sparsity) for each example input
+
+    def plot(self):
+        str_B, str_M, str_seqlen, str_sparsity = (
+            f"-B-{self.B}",
+            f"-M-{self.M}",
+            f"-seqlen-{self.seqlen}",
+            f"-sparsity-{self.sparsity}",
+        )
+        if self.B is None:
+            x_axis = "B"
+            params = str_M + str_seqlen + str_sparsity
+        elif self.M is None:
+            x_axis = "M"
+            params = str_B + str_seqlen + str_sparsity
+        elif self.seqlen is None:
+            x_axis = "seqlen"
+            params = str_B + str_M + str_sparsity
+        else:
+            x_axis = "sparsity"
+            params = str_B + str_M + str_seqlen
+
+        line_vals = ["torch_jagged_mean_unbind_torch_mean"]
+        line_names = ["PyTorch jagged mean, torch.mean"]
+        styles = [("blue", "-")]
+
+        plot_name = f"jagged-mean-perf-var-{x_axis}" + params
+
+        @triton.testing.perf_report(
+            triton.testing.Benchmark(
+                x_names=["x_axis"],
+                x_vals=self.output.x_vals,
+                line_arg="provider",
+                line_vals=line_vals,
+                line_names=line_names,
+                styles=styles,
+                xlabel=x_axis,
+                ylabel="latency",
+                plot_name=plot_name,
+                args={},
+            )
+        )
+        def _plot(x_axis, provider):
+            return self.output.get_y_vals(x_axis, provider, "latency")
+
+        save_path = (
+            os.getcwd()
+            + f"/pytorch/benchmark/torchbenchmark/operators/jagged_mean/jagged_mean_performance/{plot_name}"
+        )
+
+        if not os.path.exists(save_path):
+            os.mkdir(save_path)
+
+        _plot.run(show_plots=True, print_data=True, save_path=save_path)

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -1,0 +1,148 @@
+"""
+Utils for nested (jagged) tensor operators
+e.g. jagged_sum, jagged_mean
+"""
+
+import argparse
+import itertools
+import math
+import random
+from typing import List, Tuple
+
+import torch
+
+
+parser_args = {
+    "B": ("--B", int, "[Optional] Size of dimension 0 in shape (B, *, M) (integer)"),
+    "M": ("--M", int, "[Optional] Size of dimension 2 in shape (B, *, M) (integer)"),
+    "seqlen": (
+        "--seqlen",
+        int,
+        "[Optional] Maximum sequence length on ragged dimension (integer)",
+    ),
+    "sparsity": (
+        "--sparsity",
+        float,
+        "[Optional] Average sparsity for nested tensor (float, (0.0-1.0))",
+    ),
+}
+
+
+def get_parse_op_args(*args):
+    parser = argparse.ArgumentParser()
+    for arg in args:
+        if arg not in parser_args:
+            raise ValueError(f"jagged_utils: {arg} not in parser_args")
+        parser.add_argument(
+            parser_args[arg][0],
+            type=parser_args[arg][1],
+            help=parser_args[arg][2],
+        )
+    return parser
+
+
+def get_dim_vals(sizes):
+    vals = []
+    vals.extend([2**n for n in sizes])
+    vals.extend(
+        [
+            (n - 1) * (n + 1)
+            for n in sizes
+            if n - 1 > 0 and (n - 1) * (n + 1) not in vals
+        ]
+    )
+    return vals
+
+
+def generate_input_vals(B, M, max_seqlen, sparsity, sizes):
+    """
+    Generate values for input parameters B, M, max_seqlen, sparsity for
+    nested tensor of logical shape (B, *, M) with maximum sequence length
+    `max_seqlen` along the ragged dimension `*` and average sparsity `sparsity
+    """
+
+    B_vals, M_vals, seqlen_vals, sparsity_vals = [], [], [], []
+
+    if B is None:
+        B_vals.extend(get_dim_vals(sizes))
+    else:
+        B_vals.extend([B])
+
+    if M is None:
+        M_vals.extend(get_dim_vals(sizes))
+    else:
+        M_vals.extend([M])
+
+    if max_seqlen is None:
+        seqlen_vals.extend(list(range(100, 1000, 100)) + list(range(1000, 20000, 1000)))
+    else:
+        seqlen_vals.extend([max_seqlen])
+
+    if sparsity is None:
+        sparsity_vals.extend([n / 10 for n in range(1, 10)])
+    else:
+        sparsity_vals.extend([sparsity])
+
+    return B_vals, M_vals, seqlen_vals, sparsity_vals
+
+
+def get_size_in_bytes(shape, dtype) -> int:
+    num_elements = math.prod(shape)
+    element_size = dtype.itemsize
+    return math.floor(num_elements * element_size)
+
+
+def generate_random_nested_tensors(
+    B_vals,
+    M_vals,
+    seqlen_vals,
+    sparsity_vals,
+    device,
+    dtype,
+    TENSOR_BYTES_LIMIT=8 * 1e9,
+    RANDOM_CHOICE_MARGIN=0.3,
+):
+    """
+    Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+    with maximum sequence length `max_seqlen` and average sparsity `sparsity`
+    """
+
+    nested_tensors = []
+    vals = itertools.product(B_vals, M_vals, seqlen_vals, sparsity_vals)
+
+    for B, M, max_seqlen, sparsity in vals:
+        if (
+            get_size_in_bytes((B, M, max_seqlen), dtype) < TENSOR_BYTES_LIMIT
+        ):  # ensure that GPU memory is not exceeded
+            tensors = []
+
+            # greater sparsity --> shorter sequence lengths on ragged dimension
+            seqlen_avg = math.floor(
+                max_seqlen * (1 - sparsity)
+            )  # average sequence length across all tensors in nested tensor
+            seqlen_margin = math.floor(
+                max_seqlen * RANDOM_CHOICE_MARGIN
+            )  # use margin to constrain sequence lengths to range [seqlen_avg - seqlen_margin, seqlen_avg + seqlen_margin] to approximate an average sequence length, which correlates with sparsity
+
+            for _ in range(B):
+                seqlen_randint = random.randint(
+                    max(
+                        seqlen_avg - seqlen_margin, 1
+                    ),  # seqlen_randint must be at least 1
+                    min(
+                        seqlen_avg + seqlen_margin, max_seqlen
+                    ),  # seqlen_randint must not exceed self.seqlen
+                )
+                tensor_2d = torch.randn((seqlen_randint, M), device=device, dtype=dtype)
+                tensors.append(tensor_2d)
+
+            nt = torch.nested.nested_tensor(
+                tensors,
+                layout=torch.jagged,
+                device=device,
+                dtype=dtype,
+            )
+
+            nested_tensors.append((nt, B, M, max_seqlen, sparsity))
+
+    return nested_tensors


### PR DESCRIPTION
Summary:
Add to TritonBench a `jagged_mean` reduction operator benchmark for nested tensors using the PyTorch `torch.sum` function and [`torch.ops.aten._jagged_to_padded_dense_forward`](https://www.internalfb.com/code/fbsource/[92c2a067ab04e3eebc999254fed4ae2fbea6def3]/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/inductor_lowerings/elementwise_ops.py?lines=26).

This diff implements a benchmark for reducing along the ragged dimension of 3-dimensional jagged tensors. For a 3-dimensional tensor of shape `(B, *, M)`, where `*` is the ragged dimension, this benchmark pads each 2-dimensional tensor with zeros. Next, it divides the `sum` of the padded 3-dimensional tensor by the number of elements along each ragged dimension `*`, calculated using `x.offsets().diff()`.

This benchmark avoids a GPU/CPU sync and is thus faster than the previous two PyTorch benchmarks, where D59144906 incurs a GPU/CPU sync and D59146024 uses the unoptimized `torch.nanmean` function.

Reviewed By: davidberard98

Differential Revision: D59245842
