### PR TITLE
Add variable-length loop Triton kernel benchmark for jagged_mean operator

### DIFF
--- a/torchbenchmark/operators/jagged_mean/__init__.py
+++ b/torchbenchmark/operators/jagged_mean/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/jagged_mean/kernels.py
+++ b/torchbenchmark/operators/jagged_mean/kernels.py
@@ -1,0 +1,170 @@
+import itertools
+
+import triton
+import triton.language as tl
+
+
+BLOCK_SIZES_RAGGED = [2**n for n in range(3, 12, 4)]
+BLOCK_SIZES_M = [2**n for n in range(3, 7, 3)]
+NUM_WARPS = [4, 8]
+NUM_STAGES = [2, 4]
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_mean_kernel_simple_fused_sum_then_buffer(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    MAX_SEQLEN,  # max length of ragged dimension
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (1, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+    ragged_len = ragged_end - ragged_start
+
+    for block_pos in range(
+        0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+        buffer += tl.sum(input, axis=0)
+
+    buffer_view = buffer.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    buffer_view_mean = buffer_view * (
+        1 / ragged_len
+    )  # multiplication is faster than division on a tensor
+
+    output_offsets = offsets_m + (
+        pid_b * M
+    )  # output is offset by both ragged dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_b + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view_mean, mask=output_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_mean_kernel_simple_fused_buffer_then_sum(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    MAX_SEQLEN,  # max length of ragged dimension
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+    ragged_len = ragged_end - ragged_start
+
+    for block_pos in range(
+        0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        buffer += tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+    buffer_sum = tl.sum(buffer, axis=0)
+
+    buffer_view = buffer_sum.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    buffer_view_mean = buffer_view * (
+        1 / ragged_len
+    )  # multiplication is faster than division on a tensor
+
+    output_offsets = offsets_m + (
+        pid_b * M
+    )  # output is offset by both ragged dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_b + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view_mean, mask=output_mask)

--- a/torchbenchmark/operators/jagged_mean/kernels.py
+++ b/torchbenchmark/operators/jagged_mean/kernels.py
@@ -168,3 +168,155 @@ def triton_jagged_mean_kernel_simple_fused_buffer_then_sum(
     output_mask = output_offsets < (M * (pid_b + 1))
 
     tl.store(output_ptr + output_offsets, buffer_view_mean, mask=output_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_mean_kernel_variable_length_loop_sum_then_buffer(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (1, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+    ragged_len = ragged_end - ragged_start
+
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging from beginning to end of this program in values tensor
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+        buffer += tl.sum(input, axis=0)
+
+    buffer_view = buffer.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    buffer_view_mean = buffer_view * (
+        1 / ragged_len
+    )  # multiplication is faster than division on a tensor
+
+    output_offsets = offsets_m + (
+        pid_b * M
+    )  # output is offset by both B-th dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_b + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view_mean, mask=output_mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_mean_kernel_variable_length_loop_buffer_then_sum(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_ragged = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_ragged), tl.load(
+        input_ptr_offsets + (pid_ragged + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+    ragged_len = ragged_end - ragged_start
+
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging from beginning to end of this program in values tensor
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        buffer += tl.load(input_ptr_values + idxs, mask=mask, other=0)
+
+    buffer_sum = tl.sum(buffer, axis=0)
+
+    buffer_view = buffer_sum.reshape(
+        (BLOCK_SIZE_M,),
+    )  # reshape buffer to 1D, as tl.sum may return a 2D tensor
+
+    buffer_view_mean = buffer_view * (
+        1 / ragged_len
+    )  # multiplication is faster than division on a tensor
+
+    output_offsets = offsets_m + (
+        pid_ragged * M
+    )  # output is offset by both ragged dimension and M-th dimension
+    output_mask = output_offsets < (M * (pid_ragged + 1))
+
+    tl.store(output_ptr + output_offsets, buffer_view_mean, mask=output_mask)

--- a/torchbenchmark/operators/jagged_mean/operator.py
+++ b/torchbenchmark/operators/jagged_mean/operator.py
@@ -1,0 +1,171 @@
+import argparse
+import itertools
+import math
+import os
+import random
+from typing import Callable, Generator, List, Optional, Tuple
+
+import torch
+import triton
+from torchbenchmark.util.jagged_utils import (
+    generate_input_vals,
+    generate_random_nested_tensors,
+    get_parse_op_args,
+)
+
+from torchbenchmark.util.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    register_benchmark,
+    register_metric,
+)
+
+
+seed = 16
+random.seed(seed)
+
+GIGABYTES_PER_BYTE = 1e-6
+RANDOM_CHOICE_MARGIN = 0.3
+ABSOLUTE_TOLERANCE = 1e-4
+RELATIVE_TOLERANCE = 1e-3
+TENSOR_BYTES_LIMIT = 8 * 1e9  # allocate tensors no greater than 8GB
+
+
+def parse_op_args(args: List[str]):
+    parser = get_parse_op_args("B", "M", "seqlen", "sparsity")
+    return parser.parse_args(args)
+
+
+class Operator(BenchmarkOperator):
+
+    DEFAULT_METRICS = ["latency", "accuracy"]
+    use_cuda_graphs = (
+        False  # enables GPU/CPU sync (for methods like NestedTensor unbind)
+    )
+
+    def __init__(self, mode: str, device: str, extra_args: Optional[List[str]] = None):
+        super().__init__(mode=mode, device=device, extra_args=extra_args)
+        self.sizes = list(range(2, 12, 4)) + list(
+            range(12, 23, 3)
+        )  # bias towards larger sizes, which are more representative of real-world shapes
+
+        args = parse_op_args(self.extra_args)
+        self.B = args.B
+        self.M = args.M
+        self.seqlen = args.seqlen
+        self.sparsity = args.sparsity
+
+    @register_benchmark(baseline=True)
+    def torch_jagged_mean_unbind_torch_mean(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        return lambda: torch.cat(
+            [torch.mean(t, dim=0).unsqueeze(0) for t in x.unbind()]
+        )  # in 3D tensor (B, *, M), takes the mean of B 2D tensors (*, M)
+
+    def get_x_val(self, example_inputs):
+        if self.B is None:
+            return example_inputs[1]
+        if self.M is None:
+            return example_inputs[2]
+        if self.seqlen is None:
+            return example_inputs[3]
+        return example_inputs[4]
+
+    def get_x_vals(self) -> Tuple[List[int], List[int], List[int], List[float]]:
+        return generate_input_vals(
+            self.B, self.M, self.seqlen, self.sparsity, self.sizes
+        )
+
+    def get_input_iter(self) -> Generator:
+        """
+        Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+        """
+
+        B_vals, M_vals, seqlen_vals, sparsity_vals = self.get_x_vals()
+
+        for nt, B, M, max_seqlen, sparsity in generate_random_nested_tensors(
+            B_vals,
+            M_vals,
+            seqlen_vals,
+            sparsity_vals,
+            device=self.device,
+            dtype=self.dtype,
+            TENSOR_BYTES_LIMIT=TENSOR_BYTES_LIMIT,
+            RANDOM_CHOICE_MARGIN=RANDOM_CHOICE_MARGIN,
+        ):
+            yield (nt, B, M, max_seqlen, sparsity)
+
+    @register_metric()
+    def gbps(self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics):
+        return (
+            example_inputs[0].element_size()
+            * example_inputs[0].numel()
+            / metrics.latency
+            * GIGABYTES_PER_BYTE
+        )
+
+    @register_metric(x_only=True)
+    def input_shape(
+        self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics
+    ):
+        return (
+            f"B: {example_inputs[1]}",  # B
+            "*",
+            f"M: {example_inputs[2]}",  # M
+            f"max seqlen: {example_inputs[3]}",  # seqlen
+            f"sparsity: {example_inputs[4]}",  # sparsity
+        )  # return (B, '*', M, max seqlen, sparsity) for each example input
+
+    def plot(self):
+        str_B, str_M, str_seqlen, str_sparsity = (
+            f"-B-{self.B}",
+            f"-M-{self.M}",
+            f"-seqlen-{self.seqlen}",
+            f"-sparsity-{self.sparsity}",
+        )
+        if self.B is None:
+            x_axis = "B"
+            params = str_M + str_seqlen + str_sparsity
+        elif self.M is None:
+            x_axis = "M"
+            params = str_B + str_seqlen + str_sparsity
+        elif self.seqlen is None:
+            x_axis = "seqlen"
+            params = str_B + str_M + str_sparsity
+        else:
+            x_axis = "sparsity"
+            params = str_B + str_M + str_seqlen
+
+        line_vals = ["torch_jagged_mean_unbind_torch_mean"]
+        line_names = ["PyTorch jagged mean, torch.mean"]
+        styles = [("blue", "-")]
+
+        plot_name = f"jagged-mean-perf-var-{x_axis}" + params
+
+        @triton.testing.perf_report(
+            triton.testing.Benchmark(
+                x_names=["x_axis"],
+                x_vals=self.output.x_vals,
+                line_arg="provider",
+                line_vals=line_vals,
+                line_names=line_names,
+                styles=styles,
+                xlabel=x_axis,
+                ylabel="latency",
+                plot_name=plot_name,
+                args={},
+            )
+        )
+        def _plot(x_axis, provider):
+            return self.output.get_y_vals(x_axis, provider, "latency")
+
+        save_path = (
+            os.getcwd()
+            + f"/pytorch/benchmark/torchbenchmark/operators/jagged_mean/jagged_mean_performance/{plot_name}"
+        )
+
+        if not os.path.exists(save_path):
+            os.mkdir(save_path)
+
+        _plot.run(show_plots=True, print_data=True, save_path=save_path)

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -43,6 +43,12 @@ parser_args = {
         "[Optional] For Triton kernels, determines whether to sum individual blocks then add to a buffer or add to a buffer then sum; 1: sum then buffer, 0: buffer then sum; default 0",
         0,
     ),
+    "plot_benchmarks": (
+        "--plot-benchmarks",
+        str,
+        "[Optional] Determines which benchmarks to plot: all, torch, triton",
+        "all",
+    ),
 }
 
 

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -1,0 +1,148 @@
+"""
+Utils for nested (jagged) tensor operators
+e.g. jagged_sum, jagged_mean
+"""
+
+import argparse
+import itertools
+import math
+import random
+from typing import List, Tuple
+
+import torch
+
+
+parser_args = {
+    "B": ("--B", int, "[Optional] Size of dimension 0 in shape (B, *, M) (integer)"),
+    "M": ("--M", int, "[Optional] Size of dimension 2 in shape (B, *, M) (integer)"),
+    "seqlen": (
+        "--seqlen",
+        int,
+        "[Optional] Maximum sequence length on ragged dimension (integer)",
+    ),
+    "sparsity": (
+        "--sparsity",
+        float,
+        "[Optional] Average sparsity for nested tensor (float, (0.0-1.0))",
+    ),
+}
+
+
+def get_parse_op_args(*args):
+    parser = argparse.ArgumentParser()
+    for arg in args:
+        if arg not in parser_args:
+            raise ValueError(f"jagged_utils: {arg} not in parser_args")
+        parser.add_argument(
+            parser_args[arg][0],
+            type=parser_args[arg][1],
+            help=parser_args[arg][2],
+        )
+    return parser
+
+
+def get_dim_vals(sizes):
+    vals = []
+    vals.extend([2**n for n in sizes])
+    vals.extend(
+        [
+            (n - 1) * (n + 1)
+            for n in sizes
+            if n - 1 > 0 and (n - 1) * (n + 1) not in vals
+        ]
+    )
+    return vals
+
+
+def generate_input_vals(B, M, max_seqlen, sparsity, sizes):
+    """
+    Generate values for input parameters B, M, max_seqlen, sparsity for
+    nested tensor of logical shape (B, *, M) with maximum sequence length
+    `max_seqlen` along the ragged dimension `*` and average sparsity `sparsity
+    """
+
+    B_vals, M_vals, seqlen_vals, sparsity_vals = [], [], [], []
+
+    if B is None:
+        B_vals.extend(get_dim_vals(sizes))
+    else:
+        B_vals.extend([B])
+
+    if M is None:
+        M_vals.extend(get_dim_vals(sizes))
+    else:
+        M_vals.extend([M])
+
+    if max_seqlen is None:
+        seqlen_vals.extend(list(range(100, 1000, 100)) + list(range(1000, 20000, 1000)))
+    else:
+        seqlen_vals.extend([max_seqlen])
+
+    if sparsity is None:
+        sparsity_vals.extend([n / 10 for n in range(1, 10)])
+    else:
+        sparsity_vals.extend([sparsity])
+
+    return B_vals, M_vals, seqlen_vals, sparsity_vals
+
+
+def get_size_in_bytes(shape, dtype) -> int:
+    num_elements = math.prod(shape)
+    element_size = dtype.itemsize
+    return math.floor(num_elements * element_size)
+
+
+def generate_random_nested_tensors(
+    B_vals,
+    M_vals,
+    seqlen_vals,
+    sparsity_vals,
+    device,
+    dtype,
+    TENSOR_BYTES_LIMIT=8 * 1e9,
+    RANDOM_CHOICE_MARGIN=0.3,
+):
+    """
+    Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+    with maximum sequence length `max_seqlen` and average sparsity `sparsity`
+    """
+
+    nested_tensors = []
+    vals = itertools.product(B_vals, M_vals, seqlen_vals, sparsity_vals)
+
+    for B, M, max_seqlen, sparsity in vals:
+        if (
+            get_size_in_bytes((B, M, max_seqlen), dtype) < TENSOR_BYTES_LIMIT
+        ):  # ensure that GPU memory is not exceeded
+            tensors = []
+
+            # greater sparsity --> shorter sequence lengths on ragged dimension
+            seqlen_avg = math.floor(
+                max_seqlen * (1 - sparsity)
+            )  # average sequence length across all tensors in nested tensor
+            seqlen_margin = math.floor(
+                max_seqlen * RANDOM_CHOICE_MARGIN
+            )  # use margin to constrain sequence lengths to range [seqlen_avg - seqlen_margin, seqlen_avg + seqlen_margin] to approximate an average sequence length, which correlates with sparsity
+
+            for _ in range(B):
+                seqlen_randint = random.randint(
+                    max(
+                        seqlen_avg - seqlen_margin, 1
+                    ),  # seqlen_randint must be at least 1
+                    min(
+                        seqlen_avg + seqlen_margin, max_seqlen
+                    ),  # seqlen_randint must not exceed self.seqlen
+                )
+                tensor_2d = torch.randn((seqlen_randint, M), device=device, dtype=dtype)
+                tensors.append(tensor_2d)
+
+            nt = torch.nested.nested_tensor(
+                tensors,
+                layout=torch.jagged,
+                device=device,
+                dtype=dtype,
+            )
+
+            nested_tensors.append((nt, B, M, max_seqlen, sparsity))
+
+    return nested_tensors

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -13,17 +13,35 @@ import torch
 
 
 parser_args = {
-    "B": ("--B", int, "[Optional] Size of dimension 0 in shape (B, *, M) (integer)"),
-    "M": ("--M", int, "[Optional] Size of dimension 2 in shape (B, *, M) (integer)"),
+    "B": (
+        "--B",
+        int,
+        "[Optional] Size of dimension 0 in shape (B, *, M) (integer)",
+        None,
+    ),
+    "M": (
+        "--M",
+        int,
+        "[Optional] Size of dimension 2 in shape (B, *, M) (integer)",
+        None,
+    ),
     "seqlen": (
         "--seqlen",
         int,
         "[Optional] Maximum sequence length on ragged dimension (integer)",
+        None,
     ),
     "sparsity": (
         "--sparsity",
         float,
         "[Optional] Average sparsity for nested tensor (float, (0.0-1.0))",
+        None,
+    ),
+    "sum_then_buffer": (
+        "--sum-then-buffer",
+        int,
+        "[Optional] For Triton kernels, determines whether to sum individual blocks then add to a buffer or add to a buffer then sum; 1: sum then buffer, 0: buffer then sum; default 0",
+        0,
     ),
 }
 
@@ -37,6 +55,7 @@ def get_parse_op_args(*args):
             parser_args[arg][0],
             type=parser_args[arg][1],
             help=parser_args[arg][2],
+            default=parser_args[arg][3],
         )
     return parser
 


### PR DESCRIPTION
Summary:
Add Triton kernel benchmark implementing a fast, variable-length loop upon the simple fused `mean` kernels in D59146627. This diff enables looping from the beginning (`ragged_start`) to the end (`ragged_end`) of the specific variable-length subsection of the input nested tensor, which eliminates the extra work done by the simple fused kernel in looping over the entire range of the maximum sequence length, `MAX_SEQLEN`. Specifically, this diff eliminates the need to loop over extraneous data beyond the nested tensor's jagged length, terminating the loop before it starts reading, reducing, and writing extra zeros.

This diff also contains implementations for `sum_then_buffer` and `buffer_then_sum`, as seen in the simple fused kernels in D59146627.

This diff draws from a similar binary search implementation found [here](https://www.internalfb.com/code/fbsource/[d33668c8c8fe3cc7d75beb58b4b0dc51dc6e96a1][diffs]/fbcode/caffe2/torch/_inductor/runtime/triton_helpers.py?lines=195).

These Triton kernels are benchmarked against three PyTorch implementations (one of which uses `torch.mean`, another `torch.nanmean` with padding, and the last `torch.sum` with padding) and one Triton implementation (simple fused).

This diff follows the general framework found in the `jagged_sum` operator (D59026460, D59034792).

Reviewed By: jbschlosser

Differential Revision: D59175612
