### PR TITLE
fix t4m 

### DIFF
--- a/.github/workflows/userbenchmark-t4-metal.yml
+++ b/.github/workflows/userbenchmark-t4-metal.yml
@@ -40,7 +40,7 @@ jobs:
           pip install -U py-cpuinfo psutil distro boto3
           sudo ${HOME}/miniconda3/envs/${CONDA_ENV_NAME}/bin/python3 torchbenchmark/util/machine_config.py
           # Check if nightly builds are available
-          NIGHTLIES=$(python torchbenchmark/util/torch_nightly.py --packages torch)
+          NIGHTLIES=$(python utils/torch_nightly_utils.py --packages torch)
           # If failed, the script will generate empty result
           if [ -z $NIGHTLIES ]; then
               echo "Torch nightly build failed. Cancel the workflow."

--- a/userbenchmark/cuda-compare/run.py
+++ b/userbenchmark/cuda-compare/run.py
@@ -15,8 +15,8 @@ BM_NAME = "cuda-compare"
 
 def install_nightlies(dryrun):
     default_cuda_version = CUDA_VERSION_MAP[DEFAULT_CUDA_VERSION]["pytorch_url"]
-    install_cmd = ["pip", "install", "--pre", "torch", "torchvision", "torchaudio",
-                    "-f", f"https://download.pytorch.org/whl/nightly/{default_cuda_version}/torch_nightly.html"]
+    install_cmd = ["pip", "install", "--pre", "--no-cache-dir", "torch", "torchvision", "torchaudio",
+                    "-i", f"https://download.pytorch.org/whl/nightly/{CUDA_VERSION_MAP[default_cuda_version]['pytorch_url']}"]
     print(f"Installing pytorch packages: {install_cmd}")
     if not dryrun:
         subprocess.check_call(install_cmd, cwd=REPO_PATH)

--- a/utils/torch_nightly_utils.py
+++ b/utils/torch_nightly_utils.py
@@ -8,7 +8,6 @@ import argparse
 import os
 import re
 import subprocess
-import sys
 import urllib.parse
 from collections import defaultdict
 from datetime import date, timedelta
@@ -19,26 +18,8 @@ from typing import List
 import requests
 from bs4 import BeautifulSoup
 
-REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
-
-
-class add_path:
-    def __init__(self, path):
-        self.path = path
-
-    def __enter__(self):
-        sys.path.insert(0, self.path)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        try:
-            sys.path.remove(self.path)
-        except ValueError:
-            pass
-
-
-with add_path(str(REPO_ROOT)):
-    from utils.cuda_utils import CUDA_VERSION_MAP, DEFAULT_CUDA_VERSION
-    from utils.python_utils import DEFAULT_PYTHON_VERSION, PYTHON_VERSION_MAP
+from cuda_utils import CUDA_VERSION_MAP, DEFAULT_CUDA_VERSION
+from python_utils import DEFAULT_PYTHON_VERSION, PYTHON_VERSION_MAP
 
 PYTORCH_CUDA_VERISON = CUDA_VERSION_MAP[DEFAULT_CUDA_VERSION]["pytorch_url"]
 PYTORCH_PYTHON_VERSION = PYTHON_VERSION_MAP[DEFAULT_PYTHON_VERSION]["pytorch_url"]
@@ -46,7 +27,7 @@ PYTORCH_PYTHON_VERSION = PYTHON_VERSION_MAP[DEFAULT_PYTHON_VERSION]["pytorch_url
 torch_wheel_nightly_base = (
     f"https://download.pytorch.org/whl/nightly/{PYTORCH_CUDA_VERISON}/"
 )
-torch_nightly_wheel_index = f"https://download.pytorch.org/whl/nightly/{PYTORCH_CUDA_VERISON}/torch_nightly.html"
+torch_nightly_wheel_index = f"https://download.pytorch.org/whl/nightly/{PYTORCH_CUDA_VERISON}/torch"
 torch_nightly_wheel_index_override = "torch_nightly.html"
 
 
@@ -88,7 +69,7 @@ def get_wheel_index_data(
         pkg, version, py, py_m, platform = group_match.groups()
         version = urllib.parse.unquote(version)
         if py == py_version and platform == platform_version:
-            full_url = os.path.join(torch_wheel_nightly_base, link.text)
+            full_url = os.path.join(torch_wheel_nightly_base, urllib.parse.quote_plus(link.text))
             data[pkg][version] = full_url
     return data
 


### PR DESCRIPTION
Summary:
Starting from June 6, torch nightly wheel URLs are not published at https://download.pytorch.org/whl/nightly/cu124/torch_nightly.html.

We update the new URL to https://download.pytorch.org/whl/nightly/cu124/torch

Pull Request resolved: https://github.com/pytorch/benchmark/pull/2363

Reviewed By: atalman

Differential Revision: D59376206

Pulled By: xuzhao9

fbshipit-source-id: 58d93ddba2ab2e9dfad695a4cb7105249ed42a34