### PR TITLE
Run performance test non-alternately

### DIFF
--- a/userbenchmark/dynamo/dynamobench/common.py
+++ b/userbenchmark/dynamo/dynamobench/common.py
@@ -4389,7 +4389,13 @@ def run(runner, args, original_dir=None):
                 fullgraph=args.nopython,
                 mode=args.inductor_compile_mode,
             )
-            runner.model_iter_fn = baseline_ctx(runner.model_iter_fn)
+            model_iter_fn = baseline_ctx(runner.model_iter_fn)
+            # needed to avoid error that causes inconsistent timing due to:
+            # Unable to hit fast path of CUDAGraphs because of pending, uninvoked backwards
+            def model_iter_fn_and_mark_step(*args, **kwargs):
+                torch.compiler.cudagraph_mark_step_begin()
+                model_iter_fn(*args, **kwargs)
+            runner.model_iter_fn = model_iter_fn_and_mark_step
             optimize_ctx = torchao_optimize_ctx(args.quantization)
         else:
             optimize_ctx = torch._dynamo.optimize(args.backend, nopython=args.nopython)

--- a/userbenchmark/dynamo/dynamobench/common.py
+++ b/userbenchmark/dynamo/dynamobench/common.py
@@ -668,7 +668,6 @@ def latency_experiment(args, model_iter_fn, model, example_inputs, mark, **kwarg
     should_randomize_input = args.randomize_input
 
     import contextlib
-
     from torch._inductor.utils import maybe_profile
 
     @contextlib.contextmanager
@@ -2933,10 +2932,8 @@ class BenchmarkRunner:
         self, name, model, example_inputs, optimize_ctx, experiment, tag=None
     ):
         "Run performance test in non-alternately."
-        assert (
-            experiment.func is latency_experiment
-        ), "Must run with latency_experiment."
-
+        assert experiment.func is latency_experiment, \
+            f"Must run with latency_experiment."
         def warmup(fn, model, example_inputs, mode, niters=10):
             peak_mem = 0
             start_stats = get_dynamo_stats()
@@ -2987,7 +2984,6 @@ class BenchmarkRunner:
             if tag is not None:
                 experiment_kwargs["tag"] = tag
             results = []
-
             with maybe_snapshot_memory(
                 self.args.snapshot_memory, f"eager_{self.args.only}"
             ):
@@ -2999,9 +2995,7 @@ class BenchmarkRunner:
                         self.model_iter_fn, model, example_inputs, "eager", niters=1
                     )
 
-            baseline_timings = experiment(
-                model, example_inputs, mark="expected", **experiment_kwargs
-            )
+            baseline_timings = experiment(model, example_inputs, mark="expected", **experiment_kwargs)
 
             if self.args.export_aot_inductor:
                 t_0 = time.perf_counter()
@@ -3079,13 +3073,9 @@ class BenchmarkRunner:
                 experiment = functools.partial(
                     experiment, optimized_model_iter_fn.context.onnx_model
                 )
-            backend_timings = experiment(
-                model, example_inputs, mark="expected", **experiment_kwargs
-            )
+            backend_timings = experiment(model, example_inputs, mark="expected", **experiment_kwargs)
             timings = np.stack((baseline_timings, backend_timings), axis=1)
-            result_summary = latency_experiment_summary(
-                self.args, model, timings, **experiment_kwargs
-            )
+            result_summary = latency_experiment_summary(self.args, model, timings, **experiment_kwargs)
             if not hasattr(model, name):
                 model.name = name
             results.append(result_summary)

--- a/userbenchmark/dynamo/dynamobench/torchao_backend.py
+++ b/userbenchmark/dynamo/dynamobench/torchao_backend.py
@@ -4,48 +4,46 @@ import torch
 
 
 def setup_baseline():
-    torch._dynamo.epilogue_fusion = False
+    from torchao.quantization.utils import recommended_inductor_config_setter
+    recommended_inductor_config_setter()
     torch._dynamo.config.automatic_dynamic_shapes = False
-    torch._dynamo.config.force_parameter_static_shapes = False
     torch._dynamo.config.cache_size_limit = 10000
-    torch._inductor.config.force_fuse_int_mm_with_mul = True
-    torch._inductor.config.use_mixed_mm = True
 
 
 def torchao_optimize_ctx(quantization: str):
     import torchao
     from torchao.quantization.quant_api import (
-        change_linear_weights_to_int4_woqtensors,
-        change_linear_weights_to_int8_dqtensors,
-        change_linear_weights_to_int8_woqtensors,
+        autoquant,
+        quantize_,
+        int8_dynamic_activation_int8_weight,
+        int4_weight_only,
+        int8_weight_only,
     )
+    from torchao.utils import unwrap_tensor_subclass
 
     def inner(model_iter_fn: Callable):
         def _torchao_apply(module: torch.nn.Module, example_inputs: Any):
             if getattr(module, "_quantized", None) is None:
                 if quantization == "int8dynamic":
-                    change_linear_weights_to_int8_dqtensors(module)
+                    quantize_(module, int8_dynamic_activation_int8_weight(), set_inductor_config=False)
                 elif quantization == "int8weightonly":
-                    change_linear_weights_to_int8_woqtensors(module)
+                    quantize_(module, int8_weight_only(), set_inductor_config=False)
                 elif quantization == "int4weightonly":
-                    change_linear_weights_to_int4_woqtensors(module)
-                elif quantization == "autoquant":
-                    torchao.autoquant(module, error_on_unseen=False)
+                    quantize_(module, int4_weight_only(), set_inductor_config=False)
+                if quantization == "autoquant":
+                    torchao.autoquant(module, error_on_unseen=False, set_inductor_config=False)
                     if isinstance(example_inputs, dict):
                         module(**example_inputs)
                     else:
                         module(*example_inputs)
                     from torchao.quantization.autoquant import AUTOQUANT_CACHE
 
-                    assert (
-                        len(AUTOQUANT_CACHE) > 0
-                    ), f"Err: found no autoquantizable layers in model {type(module)}, stopping autoquantization"
-                elif quantization == "noquant":
-                    pass
+                    if len(AUTOQUANT_CACHE) == 0:
+                        raise Exception("NotAutoquantizable"
+                            f"Found no autoquantizable layers in model {type(module)}, stopping autoquantized run"
+                        )
                 else:
-                    raise AssertionError(
-                        f"Unsupposed quantization mode {quantization}."
-                    )
+                    unwrap_tensor_subclass(module)
                 setattr(module, "_quantized", True)  # noqa: B010
             model_iter_fn(module, example_inputs)
 


### PR DESCRIPTION
Summary:
By default, performance tests (speedup experiments) will run the baseline and test backend alternately.

However, this does not work for the torchao backend, which will change the model in-place, therefore the baseline run will also run with torchao backend since the model has already been quantized.

Add a new experiment "latency_experiment" to run performance tests non-alternately (first run baseline for a few iterations, then run the test backend).

note: PR also has updates for torchao apis to make sure this works with newest version of torchao

Test command on A100:

```
Test Plan:

python run_benchmark.py torchao --only AlbertForMaskedLM --quantization noquant --performance --inference --bfloat16 --inductor-compile-mode max-autotune
python run_benchmark.py torchao --only BartForCausalLM --quantization noquant --performance --inference --bfloat16 --inductor-compile-mode max-autotune
python run_benchmark.py torchao --only timm_efficientnet --quantization noquant --performance --inference --bfloat16 --inductor-compile-mode max-autotune

(should all be ~1.0
0.997x
1.006x
0.994x
```

Differential Revision: D59332736
