### PR TITLE
Fallback to delete-package-versions v4 to use node16

### DIFF
--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   clean-push-docker:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, linux.4xlarge]
+    runs-on: [self-hosted, linux.2xlarge]
     environment: docker-s3-upload
     steps:
       - uses: actions/delete-package-versions@v4

--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -2,6 +2,10 @@ name: TorchBench Nightly Docker Cleanup
 on:
   workflow_dispatch:
 
+env:
+  # We have to fallback to node16 as Amazon Linux 2 is not ready for node20
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   clean-push-docker:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -2,23 +2,19 @@ name: TorchBench Nightly Docker Cleanup
 on:
   workflow_dispatch:
 
-env:
-  # We have to fallback to node16 as Amazon Linux 2 is not ready for node20
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   clean-push-docker:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: [self-hosted, linux.4xlarge]
     environment: docker-s3-upload
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@v4
         with:
           package-name: torchbench
           package-type: container
           delete-only-untagged-versions: true
           token: ${{ secrets.TORCHBENCH_ACCESS_TOKEN }}
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@v4
         with:
           package-name: torchbench
           package-type: container

--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -1,6 +1,9 @@
 name: TorchBench Nightly Docker Cleanup
 on:
   workflow_dispatch:
+  schedule:
+    # Cleanup the nightly Docker images every 3 months
+    - cron: '0 0 1 */3 *'
 
 jobs:
   clean-push-docker:


### PR DESCRIPTION
actions/clean-package-version v5 requires node20 which pytorch infra is not ready yet.
fallback to v4 to use node 16.

Test plan: 
https://github.com/pytorch/benchmark/actions/runs/9811750556

We only keep the most recent 200 images after running the workflow: 
https://github.com/pytorch/benchmark/pkgs/container/torchbench