### PR TITLE
[tritonbench] Add ThunderKittens support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "submodules/kernels"]
 	path = submodules/kernels
 	url = https://github.com/triton-lang/kernels
+[submodule "submodules/ThunderKittens"]
+	path = submodules/ThunderKittens
+	url = https://github.com/HazyResearch/ThunderKittens.git

--- a/torchbenchmark/operators/flash_attention/operator.py
+++ b/torchbenchmark/operators/flash_attention/operator.py
@@ -91,8 +91,14 @@ except (ImportError, IOError, AttributeError):
 
 # [Optional] ThunderKittens backend
 try:
-    import h100_fwd as tk_fwd
-    import h100_fwd_causal as tk_fwd_causal
+    if not hasattr(torch.version, "git_version"):
+        import h100_fwd as tk_fwd
+        import h100_fwd_causal as tk_fwd_causal
+    else:
+        # causal is not supported right now
+        from userbenchmark.triton.loader import load_library
+        load_library("tk/tk_attn_h100_fwd.so")
+        tk_fwd = torch.ops.tk
 except (ImportError, IOError, AttributeError):
     tk_fwd = None
     tk_fwd_causal = None
@@ -128,6 +134,7 @@ class Operator(BenchmarkOperator):
     def __init__(self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None):
         super().__init__(tb_args, extra_args)
         args = parse_op_args(self.extra_args)
+        self.use_cuda_graphs = False
         self.BATCH = args.batch
         self.H = args.n_heads
         self.D_HEAD = args.d_head

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -51,12 +51,23 @@ def install_fa3():
     cmd = [sys.executable, "setup.py", "install"]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()))
 
+def install_tk():
+    try:
+        from .tk.install import install_tk
+    except ImportError:
+        try:
+            from tk.install import install_tk
+        except ImportError:
+            from userbenchmark.triton.tk.install import install_tk
+    install_tk()
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--fbgemm", action="store_true", help="Install FBGEMM GPU")
     parser.add_argument("--cutlass", action="store_true", help="Install optional CUTLASS kernels")
     parser.add_argument("--flash", action="store_true", help="Install optional FA3 kernels")
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
+    parser.add_argument("--tk", action="store_true", help="Install ThunderKittens")
     parser.add_argument("--test", action="store_true", help="Run test")
     args = parser.parse_args()
 
@@ -72,3 +83,5 @@ if __name__ == "__main__":
         install_cutlass()
     if args.jax and not args.test:
         install_jax()
+    if args.tk and not args.test:
+        install_tk()

--- a/userbenchmark/triton/tk/install.py
+++ b/userbenchmark/triton/tk/install.py
@@ -1,0 +1,77 @@
+import os
+from pathlib import Path
+import subprocess
+import torch
+
+CUDA_HOME = "/usr/local/cuda" if not "CUDA_HOME" in os.environ else os.environ["CUDA_HOME"]
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent.parent
+TK_PATH = REPO_PATH.joinpath("submodules", "ThunderKittens")
+TRITONBENCH_TK_PATH = REPO_PATH.joinpath("userbenchmark", "triton", "tk")
+
+NVCC_GENCODE = "-gencode=arch=compute_90a,code=[sm_90a]"
+
+NVCC_FLAGS = [
+    NVCC_GENCODE,
+    "-DNDEBUG",
+    "-Xcompiler=-fPIE",
+    "--expt-extended-lambda",
+    "--expt-relaxed-constexpr",
+    "-Xcompiler=-Wno-psabi",
+    "-Xcompiler=-fno-strict-aliasing",
+    "--use_fast_math",
+    "-forward-unknown-to-host-compiler",
+    "-O3",
+    "-Xnvlink=--verbose",
+    "-Xptxas=--verbose",
+    "-Xptxas=--warn-on-spills",
+    "--std=c++20",
+    "-MD",
+    "-MT",
+    "-MF",
+    "-x",
+    "cu",
+    "-DKITTENS_HOPPER",
+    "-D_GLIBCXX_USE_CXX11_ABI=0",
+]
+LINKER_FLAGS = [
+    "-ltorch",
+    "-ltorch_cuda",
+    "-lc10",
+    "-lc10_cuda",
+    "-lcuda",
+    "-lcudadevrt",
+    "-lcudart_static",
+    "-lcublas",
+    "-lrt",
+    "-lpthread",
+    "-ldl",
+]
+TK_ATTN_H100_FWD_SOURCES = [
+    # Source 1
+    f"{str(TK_PATH.joinpath('examples', 'attn', 'h100', 'h100_fwd.cu').resolve())}",
+    # Source 2
+    f"{str(TRITONBENCH_TK_PATH.joinpath('src', 'attn_h100_fwd', 'register_op.cu').resolve())}",
+    "-o",
+    "attn_h100_fwd.so",
+]
+
+
+def test_tk_attn_h100_fwd(tk_attn_h100_fwd_lib: str):
+    assert os.path.exists(tk_attn_h100_fwd_lib), \
+        f"{tk_attn_h100_fwd_lib} should exist as the built cutlass kernel."
+    torch.ops.load_library(tk_attn_h100_fwd_lib)
+
+
+def install_tk():
+    # compile thunderkitten kernels
+    output_dir = TRITONBENCH_TK_PATH.joinpath(".data")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = ["nvcc"]
+    cmd.extend(NVCC_FLAGS)
+    cmd.extend(TK_ATTN_H100_FWD_SOURCES)
+    cmd.extend(LINKER_FLAGS)
+    print(" ".join(cmd))
+    print(str(output_dir.resolve()))
+    subprocess.check_call(cmd, cwd=str(output_dir.resolve()))
+    tk_attn_h100_fwd_lib = str(output_dir.joinpath(TK_ATTN_H100_FWD_SOURCES[-1]).resolve())
+    test_tk_attn_h100_fwd(tk_attn_h100_fwd_lib)

--- a/userbenchmark/triton/tk/install.py
+++ b/userbenchmark/triton/tk/install.py
@@ -2,79 +2,84 @@ import os
 from pathlib import Path
 import subprocess
 import torch
+from utils import add_path
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 CUDA_HOME = "/usr/local/cuda" if not "CUDA_HOME" in os.environ else os.environ["CUDA_HOME"]
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent.parent
 TK_PATH = REPO_PATH.joinpath("submodules", "ThunderKittens")
+TK_PYUTILS_PATH = TK_PATH.joinpath("src","common","pyutils")
 TRITONBENCH_TK_PATH = REPO_PATH.joinpath("userbenchmark", "triton", "tk")
-
 TORCH_BASE_PATH = Path(torch.__file__).parent
 
-NVCC_GENCODE = "-gencode=arch=compute_90a,code=[sm_90a]"
 
-NVCC_FLAGS = [
-    NVCC_GENCODE,
-    "-DNDEBUG",
-    "-Xcompiler=-fPIE",
-    "--expt-extended-lambda",
-    "--expt-relaxed-constexpr",
-    "-Xcompiler=-Wno-psabi",
-    "-Xcompiler=-fno-strict-aliasing",
-    "--use_fast_math",
-    "-forward-unknown-to-host-compiler",
-    "-O3",
-    "-Xnvlink=--verbose",
-    "-Xptxas=--verbose",
-    "-Xptxas=--warn-on-spills",
-    "--std=c++20",
-    "-MD",
-    "-MT",
-    "-MF",
-    "-x",
-    "cu",
-    "-DKITTENS_HOPPER",
-    "-D_GLIBCXX_USE_CXX11_ABI=0",
-]
-COMPILER_FLAGS = [
-    f"-I{str(TK_PATH.joinpath('src').resolve())}",
-]
-LINKER_FLAGS = [
-    "--shared",
-    "-fPIC",
-    "-lcuda",
-    "-lcudadevrt",
-    "-lcudart_static",
-    "-lcublas",
-    "-lrt",
-    "-lpthread",
-    "-ldl",
-]
-TK_ATTN_H100_FWD_SOURCES = [
-    # Source 1
-    f"-L{str(TORCH_BASE_PATH.joinpath('lib').resolve())}",
-    f"{str(TK_PATH.joinpath('examples', 'attn', 'h100', 'h100_fwd.cu').resolve())}",
-    "-o",
-    "tk_attn_h100_fwd.so",
-]
+PKG_NAME_TO_SRC_NAME = {
+    "tk_attn_h100_fwd": "h100_fwd",
+}
 
+def _sources(name):
+    base_dir = TK_PATH.joinpath('examples', 'attn', 'h100')
+    src_name = PKG_NAME_TO_SRC_NAME[name]
+    frontend_cpp = str(base_dir.joinpath(f"{src_name}_frontend.cpp").resolve())
+    cu = str(base_dir.joinpath(f"{src_name}.cu").resolve())
+    return [frontend_cpp, cu]
 
-def test_tk_attn_h100_fwd(tk_attn_h100_fwd_lib: str):
-    assert os.path.exists(tk_attn_h100_fwd_lib), \
-        f"{tk_attn_h100_fwd_lib} should exist as the built cutlass kernel."
-    torch.ops.load_library(tk_attn_h100_fwd_lib)
+import distutils.command.build
+
+class BuildCommand(distutils.command.build.build):
+    def initialize_options(self):
+        distutils.command.build.build.initialize_options(self)
+        self.build_base = str(TRITONBENCH_TK_PATH.joinpath(".data").resolve())
+
+def cuda_extension(name, debug, gpu_type):
+    _cuda_flags  = [
+                    '--use_fast_math',
+                    '--generate-line-info',
+                    '--restrict', '-std=c++20',
+                    '--expt-relaxed-constexpr',
+                    '--expt-extended-lambda',
+                    '-Xcompiler=-fno-strict-aliasing',
+                    '-MD', '-MT', '-MF', '-x', 'cu', '-lrt', '-lpthread', '-ldl',
+                    '-lcuda', '-lcudadevrt', '-lcudart_static', '-lcublas',
+                    f"-I {str(TK_PATH.resolve())}"
+                    ]
+
+    if gpu_type == '4090':
+        _cuda_flags.append('-DKITTENS_4090')
+        _cuda_flags.append('-arch=sm_89')
+    elif gpu_type == 'H100':
+        _cuda_flags.append('-DKITTENS_HOPPER')
+        _cuda_flags.append('-arch=sm_90a')
+    elif gpu_type == 'A100':
+        _cuda_flags.append('-DKITTENS_A100')
+        _cuda_flags.append('-arch=sm_80')
+
+    if(debug): _cuda_flags += ['-D__DEBUG_PRINT', '-g', '-G']
+    return CUDAExtension(f'{name}',
+                        sources=_sources(name),
+                        extra_compile_args={'cxx' : ['-std=c++20'],
+                                            'nvcc' : ['-O3'] + _cuda_flags},
+                        libraries=['cuda'])
+
+def test_tk_attn_h100_fwd():
+    import tk_attn_h100_fwd
+    tk_attn_h100_fwd.attention_forward
 
 
 def install_tk():
     # compile thunderkitten kernels
     output_dir = TRITONBENCH_TK_PATH.joinpath(".data")
     output_dir.mkdir(parents=True, exist_ok=True)
-    cmd = ["nvcc"]
-    cmd.extend(NVCC_FLAGS)
-    cmd.extend(COMPILER_FLAGS)
-    cmd.extend(TK_ATTN_H100_FWD_SOURCES)
-    cmd.extend(LINKER_FLAGS)
-    print(" ".join(cmd))
-    print(str(output_dir.resolve()))
-    subprocess.check_call(cmd, cwd=str(output_dir.resolve()))
-    tk_attn_h100_fwd_lib = str(output_dir.joinpath(TK_ATTN_H100_FWD_SOURCES[-1]).resolve())
-    test_tk_attn_h100_fwd(tk_attn_h100_fwd_lib)
+    name = "tk_attn_h100_fwd"
+    gpu = "H100"
+    debug = False
+    cuda_ext = cuda_extension(name, debug, gpu)
+    import sys
+    backup_sys_argv = sys.argv.copy()
+    sys.argv = ['install.py', 'install']
+    setup(name=f"{name}",
+          ext_modules=[cuda_ext],
+          cmdclass={'build': BuildCommand, 'build_ext': BuildExtension})
+    sys.argv = backup_sys_argv
+    test_tk_attn_h100_fwd()

--- a/userbenchmark/triton/tk/install.py
+++ b/userbenchmark/triton/tk/install.py
@@ -8,6 +8,8 @@ REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent.parent
 TK_PATH = REPO_PATH.joinpath("submodules", "ThunderKittens")
 TRITONBENCH_TK_PATH = REPO_PATH.joinpath("userbenchmark", "triton", "tk")
 
+TORCH_BASE_PATH = Path(torch.__file__).parent
+
 NVCC_GENCODE = "-gencode=arch=compute_90a,code=[sm_90a]"
 
 NVCC_FLAGS = [
@@ -33,11 +35,12 @@ NVCC_FLAGS = [
     "-DKITTENS_HOPPER",
     "-D_GLIBCXX_USE_CXX11_ABI=0",
 ]
+COMPILER_FLAGS = [
+    f"-I{str(TK_PATH.joinpath('src').resolve())}",
+]
 LINKER_FLAGS = [
-    "-ltorch",
-    "-ltorch_cuda",
-    "-lc10",
-    "-lc10_cuda",
+    "--shared",
+    "-fPIC",
     "-lcuda",
     "-lcudadevrt",
     "-lcudart_static",
@@ -48,11 +51,10 @@ LINKER_FLAGS = [
 ]
 TK_ATTN_H100_FWD_SOURCES = [
     # Source 1
+    f"-L{str(TORCH_BASE_PATH.joinpath('lib').resolve())}",
     f"{str(TK_PATH.joinpath('examples', 'attn', 'h100', 'h100_fwd.cu').resolve())}",
-    # Source 2
-    f"{str(TRITONBENCH_TK_PATH.joinpath('src', 'attn_h100_fwd', 'register_op.cu').resolve())}",
     "-o",
-    "attn_h100_fwd.so",
+    "tk_attn_h100_fwd.so",
 ]
 
 
@@ -68,6 +70,7 @@ def install_tk():
     output_dir.mkdir(parents=True, exist_ok=True)
     cmd = ["nvcc"]
     cmd.extend(NVCC_FLAGS)
+    cmd.extend(COMPILER_FLAGS)
     cmd.extend(TK_ATTN_H100_FWD_SOURCES)
     cmd.extend(LINKER_FLAGS)
     print(" ".join(cmd))

--- a/userbenchmark/triton/tk/install.py
+++ b/userbenchmark/triton/tk/install.py
@@ -61,7 +61,8 @@ def cuda_extension(debug, gpu_type):
 def test_tk_attn_h100_fwd(tk_lib):
     assert os.path.exists(tk_lib), \
         f"{tk_lib} should exist as the built cutlass kernel."
-    torch.ops.load_library(tk_lib)    
+    torch.ops.load_library(tk_lib)
+    torch.ops.tk.attention_forward
 
 
 def install_tk():

--- a/userbenchmark/triton/tk/src/attn_h100_fwd/register_op.cu
+++ b/userbenchmark/triton/tk/src/attn_h100_fwd/register_op.cu
@@ -1,0 +1,150 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <cmath>
+#include <mutex>
+
+#include <ATen/Context.h>
+#include <ATen/ScalarOps.h>
+#include <ATen/Tensor.h>
+#include <ATen/core/Generator.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Optional.h>
+#include <torch/library.h>
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
+
+#include "h100_fwd.cu"
+
+
+void tk_attention_forward(
+    at::Tensor& q,
+    at::Tensor& k,
+    at::Tensor& v,
+    at::Tensor& o) {
+
+    TORCH_CHECK(q.dim() == 4);
+    TORCH_CHECK(k.dim() == 4);
+    TORCH_CHECK(v.dim() == 4);
+    // Batch sizes
+    TORCH_CHECK(query.size(0) == key.size(0));
+    TORCH_CHECK(query.size(0) == value.size(0));
+
+    // Sequence length
+    TORCH_CHECK(key.size(1) == value.size(1));
+
+    // Num heads
+    TORCH_CHECK(query.size(2) == key.size(2));
+    TORCH_CHECK(query.size(2) == value.size(2));
+
+    // Embedding per head
+    TORCH_CHECK(query.size(3) == key.size(3));
+
+    auto batch   = q.size(0);
+    auto heads   = q.size(1);
+    auto N       = q.size(2);
+    auto D       = q.size(3);
+
+    auto threads = NUM_WORKERS * kittens::WARP_THREADS;
+
+    // make sure sequence length is multiple of 128 for now
+    TORCH_CHECK(N % (NUM_WORKERS * kittens::TILE_DIM) == 0, "Please pad sequence length to be multiple of 128");
+
+    // make sure D = 64 or 128
+    TORCH_CHECK(D == 64 || D == 128, "Currently, only D = 64 or 128 is supported");
+
+    // input must be bf16
+    TORCH_CHECK(q.scalar_type() == at::kBFloat16, "q must be bf16");
+    TORCH_CHECK(k.scalar_type() == at::kBFloat16, "k must be bf16");
+    TORCH_CHECK(v.scalar_type() == at::kBFloat16, "v must be bf16");
+    TORCH_CHECK(o.scalar_type() == at::kBFloat16, "o must be bf16");
+
+    const bf16* q_bf = reinterpret_cast<const bf16*>(q_ptr);
+    const bf16* k_bf = reinterpret_cast<const bf16*>(k_ptr);
+    const bf16* v_bf = reinterpret_cast<const bf16*>(v_ptr);
+    bf16* o_bf = reinterpret_cast<bf16*>(o_ptr);
+
+    if (D == 64) {
+
+        CUtensorMap* tma_q_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<64>::qo_height, fwd_attend_ker_tile_dims<64>::tile_width, layout_q>>(q_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<64>::qo_height * 16));
+        CUtensorMap* tma_k_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<64>::kv_height, fwd_attend_ker_tile_dims<64>::tile_width, layout_k>>(k_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<64>::kv_height * 16));
+        CUtensorMap* tma_v_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<64>::kv_height, fwd_attend_ker_tile_dims<64>::tile_width, layout_v>>(v_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<64>::kv_height * 16));
+        CUtensorMap* tma_o_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<64>::qo_height, fwd_attend_ker_tile_dims<64>::tile_width, layout_o>>(o_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<64>::qo_height * 16));
+
+        unsigned long mem_size = 112000;
+        cudaFuncSetAttribute(fwd_attend_ker_dim<64>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+
+        dim3 grid(N/(NUM_WORKERS*kittens::TILE_DIM), batch*heads, 1);
+
+        fwd_attend_ker_dim<64><<<grid, threads, mem_size>>>(N, tma_q_d, tma_k_d, tma_v_d, tma_o_d);
+    }
+    else {
+        CUtensorMap* tma_q_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<128>::qo_height, fwd_attend_ker_tile_dims<128>::tile_width, layout_q>>(q_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<128>::qo_height * 16));
+        CUtensorMap* tma_k_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<128>::kv_height, fwd_attend_ker_tile_dims<128>::tile_width, layout_k>>(k_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<128>::kv_height * 16));
+        CUtensorMap* tma_v_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<128>::kv_height, fwd_attend_ker_tile_dims<128>::tile_width, layout_v>>(v_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<128>::kv_height * 16));
+        CUtensorMap* tma_o_d = tma::allocate_and_create_tensor_map<kittens::st_bf<fwd_attend_ker_tile_dims<128>::qo_height, fwd_attend_ker_tile_dims<128>::tile_width, layout_o>>(o_bf, (batch*heads*N)/(fwd_attend_ker_tile_dims<128>::qo_height * 16));
+
+        unsigned long mem_size = 112000;
+        cudaFuncSetAttribute(fwd_attend_ker_dim<128>, cudaFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+
+        dim3 grid(N/(NUM_WORKERS*kittens::TILE_DIM), batch*heads, 1);
+
+        fwd_attend_ker_dim<128><<<grid, threads, mem_size>>>(N, tma_q_d, tma_k_d, tma_v_d, tma_o_d);
+    }
+    
+    CHECK_CUDA_ERROR(cudaGetLastError());
+}
+
+// Abstract implementation
+void
+tk_attention_forward_meta(
+    at::Tensor& q,
+    at::Tensor& k,
+    at::Tensor& v,
+    at::Tensor& o) {
+
+  TORCH_CHECK(q.dim() == 4);
+  TORCH_CHECK(k.dim() == 4);
+  TORCH_CHECK(v.dim() == 4);
+
+  // Batch sizes
+  TORCH_CHECK(q.sym_size(0) == k.sym_size(0));
+  TORCH_CHECK(q.sym_size(0) == v.sym_size(0));
+
+  // Sequence length
+  TORCH_CHECK(k.sym_size(1) == v.sym_size(1));
+
+  // Num heads
+  TORCH_CHECK(q.sym_size(2) == k.sym_size(2));
+  TORCH_CHECK(q.sym_size(2) == v.sym_size(2));
+
+  // Embedding per head
+  TORCH_CHECK(q.sym_size(3) == k.sym_size(3));
+
+  TORCH_CHECK(q.scalar_type() == at::kBFloat16, "q must be bf16");
+  TORCH_CHECK(k.scalar_type() == at::kBFloat16, "k must be bf16");
+  TORCH_CHECK(v.scalar_type() == at::kBFloat16, "v must be bf16");
+  TORCH_CHECK(o.scalar_type() == at::kBFloat16, "o must be bf16");
+  return;
+}
+
+// torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor o
+TORCH_LIBRARY_FRAGMENT(tk, m) {
+  m.def(
+      "tk_attention_forward(Tensor q, Tensor k, Tensor v, Tensor o) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(tk, CUDA, m) {
+  m.impl("tk_attention_forward", tk_attention_forward);
+}
+
+TORCH_LIBRARY_IMPL(tk, Meta, m) {
+  m.impl(
+      "tk_attention_forward",
+      TORCH_FN(tk_attention_forward_meta));
+}

--- a/userbenchmark/triton/tk/src/attn_h100_fwd/register_op.cu
+++ b/userbenchmark/triton/tk/src/attn_h100_fwd/register_op.cu
@@ -138,15 +138,15 @@ tk_attention_forward_meta(
 // torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor o
 TORCH_LIBRARY_FRAGMENT(tk, m) {
   m.def(
-      "tk_attention_forward(Tensor q, Tensor k, Tensor v, Tensor o) -> ()");
+      "attention_forward(Tensor q, Tensor k, Tensor v, Tensor o) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(tk, CUDA, m) {
-  m.impl("tk_attention_forward", tk_attention_forward);
+  m.impl("attention_forward", tk_attention_forward);
 }
 
 TORCH_LIBRARY_IMPL(tk, Meta, m) {
   m.impl(
-      "tk_attention_forward",
+      "attention_forward",
       TORCH_FN(tk_attention_forward_meta));
 }

--- a/userbenchmark/triton/tk/src/attn_h100_fwd/torch_helpers.cuh
+++ b/userbenchmark/triton/tk/src/attn_h100_fwd/torch_helpers.cuh
@@ -1,0 +1,16 @@
+#include <iostream>
+
+// copied from online tutorial.
+#define CHECK_CUDA_ERROR(val) check((val), #val, __FILE__, __LINE__)
+template <typename T>
+void check(T err, char const* const func, char const* const file,
+           int const line)
+{
+    if (err != cudaSuccess)
+    {
+        std::cerr << "CUDA Runtime Error at: " << file << ":" << line
+                  << std::endl;
+        std::cerr << cudaGetErrorString(err) << " " << func << std::endl;
+        //std::exit(EXIT_FAILURE);
+    }
+}


### PR DESCRIPTION
Register TK kernels as torch custom ops.

Test Plan:

To install ThunderKittens:

```
$ python install.py --userbenchmark triton --tk

nvcc -I/home/xz/miniconda3/lib/python3.11/site-packages/torch/include -I/home/xz/git/benchmark/submodules/ThunderKittens/examples/attn/h100 -I/home/xz/git/benchmark/submodules/ThunderKittens --use_fast_math --generate-line-info --restrict -std=c++20 --expt-relaxed-constexpr --expt-extended-lambda -forward-unknown-to-host-compiler -Xcompiler=-fno-strict-aliasing -D_GLIBCXX_USE_CXX11_ABI=0 -MD -MT -MF -x cu -lrt -lpthread -ldl -lcuda -lcudadevrt -lcudart_static -lcublas -DKITTENS_HOPPER -arch=sm_90a /home/xz/git/benchmark/userbenchmark/triton/tk/src/attn_h100_fwd/register_op.cu -o tk_attn_h100_fwd.so --shared -fPIC -L/home/xz/miniconda3/lib/python3.11/site-packages/torch/lib -ltorch -ltorch_cuda -lc10 -lc10_cuda
/home/xz/git/benchmark/userbenchmark/triton/tk/.data
```

To run TK kernel on H100:

```
python run_benchmark.py triton --op flash_attention --only triton_tutorial_flash_v2,tk,flash_v3 --metrics tflops
  (Batch, Heads, SeqLen, Dhead)    triton_tutorial_flash_v2-tflops    tk-tflops    flash_v3-tflops
-------------------------------  ---------------------------------  -----------  -----------------
              (32, 32, 512, 64)                            290.005      258.142            288.021
             (16, 32, 1024, 64)                            323.831      299.238            325.056
              (8, 32, 2048, 64)                            339.322      327.398            375.369
              (4, 32, 4096, 64)                            347.665      334.122            395.358
              (2, 32, 8192, 64)                            350.095      340.935            415.751
             (1, 32, 16384, 64)                            353.185      346.928            415.99
```

Fixes https://github.com/pytorch/benchmark/issues/2329