### PR TITLE
Add kernels submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "submodules/cutlass-kernels"]
 	path = submodules/cutlass-kernels
 	url = https://github.com/ColfaxResearch/cutlass-kernels.git
+[submodule "submodules/kernels"]
+	path = submodules/kernels
+	url = https://github.com/triton-lang/kernels

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -26,6 +26,7 @@ class ModelNotFoundError(RuntimeError):
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
 DATA_PATH = os.path.join(REPO_PATH, "torchbenchmark", "data", ".data")
+SUBMODULE_PATH = REPO_PATH.joinpath("submodules")
 
 
 class add_path:

--- a/torchbenchmark/operators/flash_attention/operator.py
+++ b/torchbenchmark/operators/flash_attention/operator.py
@@ -36,8 +36,10 @@ import math
 import os
 import torch
 import triton  # @manual=//triton:triton
+from torchbenchmark import add_path, SUBMODULE_PATH
 
-from triton.ops.flash_attention import attention as triton_op_FA2
+with add_path(SUBMODULE_PATH.joinpath("kernels")):
+    from kernels.flash_attention import attention as triton_op_FA2
 from torchbenchmark.util.kernels.triton_fused_attention import attention as triton_tutorial_FA2
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.nn.functional import scaled_dot_product_attention as sdpa


### PR DESCRIPTION
`triton.ops` has been deprecated. We are now importing kernels from triton-lang/kernels submodule.

Since there is a bug in triton-lang/kernels (https://github.com/xuzhao9/kernels/commit/c907d8ec7aa46d7c722dc06f9020e91b346cafbd), we are using submodules in a downstream fork.