### PR TITLE
Add flash attention v3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "submodules/cutlass-kernels"]
 	path = submodules/cutlass-kernels
 	url = https://github.com/ColfaxResearch/cutlass-kernels.git
+[submodule "submodules/flash-attention"]
+	path = submodules/flash-attention
+	url = https://github.com/Dao-AILab/flash-attention.git

--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -41,6 +41,20 @@ class add_path:
         except ValueError:
             pass
 
+class add_ld_library_path:
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        self.os_environ = os.environ.copy()
+        library_path = os.environ.get("LD_LIBRARY_PATH")
+        if not library_path:
+            os.environ["LD_LIBRARY_PATH"] = self.path
+        else:
+            os.environ["LD_LIBRARY_PATH"] = f"{library_path}:{self.path}"
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.environ = self.os_environ.copy()
 
 with add_path(str(REPO_PATH)):
     from utils import get_pkg_versions, TORCH_DEPS

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from utils.cuda_utils import DEFAULT_CUDA_VERSION, CUDA_VERSION_MAP
+from utils.python_utils import pip_install_requirements
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
 FBGEMM_PATH = REPO_PATH.joinpath("submodules", "FBGEMM", "fbgemm_gpu")
@@ -51,6 +52,8 @@ if __name__ == "__main__":
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
     parser.add_argument("--test", action="store_true", help="Run test")
     args = parser.parse_args()
+
+    pip_install_requirements("requirements.txt")
     if args.fbgemm:
         if args.test:
             test_fbgemm()

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -8,6 +8,7 @@ from utils.cuda_utils import DEFAULT_CUDA_VERSION, CUDA_VERSION_MAP
 from utils.python_utils import pip_install_requirements
 
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
+FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
 FBGEMM_PATH = REPO_PATH.joinpath("submodules", "FBGEMM", "fbgemm_gpu")
 
 def install_jax(cuda_version=DEFAULT_CUDA_VERSION):
@@ -45,10 +46,17 @@ def install_cutlass():
             from userbenchmark.triton.cutlass_kernels.install import install_colfax_cutlass
     install_colfax_cutlass()
 
+
+def install_fa3():
+    cmd = [sys.executable, "setup.py", "install"]
+    subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()))
+    subprocess.check_call([sys.executable, "-c", "import flashattn_hopper"])
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--fbgemm", action="store_true", help="Install FBGEMM GPU")
     parser.add_argument("--cutlass", action="store_true", help="Install optional CUTLASS kernels")
+    parser.add_argument("--flash", action="store_true", help="Install optional FA3 kernels")
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
     parser.add_argument("--test", action="store_true", help="Run test")
     args = parser.parse_args()
@@ -59,6 +67,8 @@ if __name__ == "__main__":
             test_fbgemm()
         else:
             install_fbgemm()
+    if args.flash:
+        install_fa3()
     if args.cutlass and not args.test:
         install_cutlass()
     if args.jax and not args.test:

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -50,7 +50,6 @@ def install_cutlass():
 def install_fa3():
     cmd = [sys.executable, "setup.py", "install"]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()))
-    subprocess.check_call([sys.executable, "-c", "import flashattn_hopper"])
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/userbenchmark/triton/requirements.txt
+++ b/userbenchmark/triton/requirements.txt
@@ -1,0 +1,1 @@
+flash-attn


### PR DESCRIPTION
First, install flash attention hopper:

```
python install.py --userbenchmark triton --flash
```

Second, run the following command:

```
$ python run_benchmark.py triton --op flash_attention --only flash_v2,flash_v3 --num-inputs 1 --metrics tflops
[00:00<00:00,  5.70it/s]
  SeqLen    flash_v2-tflops    flash_v3-tflops
--------  -----------------  -----------------
     128            49.2482             33.825
```