### PR TITLE
Add torch.sum benchmark for jagged_softmax operator

### DIFF
--- a/torchbenchmark/operators/jagged_softmax/__init__.py
+++ b/torchbenchmark/operators/jagged_softmax/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/jagged_softmax/operator.py
+++ b/torchbenchmark/operators/jagged_softmax/operator.py
@@ -1,0 +1,218 @@
+import argparse
+import itertools
+import math
+import os
+import random
+from typing import Callable, Generator, List, Optional, Tuple
+
+import torch
+import triton
+from torchbenchmark.util.jagged_utils import (
+    generate_input_vals,
+    generate_random_nested_tensors,
+    get_parse_op_args,
+)
+
+from torchbenchmark.util.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    register_benchmark,
+    register_metric,
+)
+
+
+seed = 16
+random.seed(seed)
+
+GIGABYTES_PER_BYTE = 1e-6
+RANDOM_CHOICE_MARGIN = 0.3
+ABSOLUTE_TOLERANCE = 1e-4
+RELATIVE_TOLERANCE = 1e-3
+TENSOR_BYTES_LIMIT = 8 * 1e9  # allocate tensors no greater than 8GB
+
+
+def parse_op_args(args: List[str]):
+    parser = get_parse_op_args("B", "M", "seqlen", "sparsity")
+    return parser.parse_args(args)
+
+
+class Operator(BenchmarkOperator):
+
+    DEFAULT_METRICS = ["latency", "accuracy"]
+    use_cuda_graphs = (
+        False  # enables GPU/CPU sync (for methods like NestedTensor unbind)
+    )
+
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ):
+        super().__init__(tb_args, extra_args)
+        self.sizes = list(range(2, 12, 4)) + list(
+            range(12, 23, 3)
+        )  # bias towards larger sizes, which are more representative of real-world shapes
+
+        args = parse_op_args(self.extra_args)
+        self.B = args.B
+        self.M = args.M
+        self.seqlen = args.seqlen
+        self.sparsity = args.sparsity
+
+    @register_benchmark(baseline=True)
+    def torch_jagged_softmax_unbind_torch_softmax(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        return lambda: torch.cat(
+            [
+                torch.softmax(t, dim=0) for t in x.unbind()
+            ],  # torch.softmax already stabilizes the input (x - max(x))
+            dim=0,
+        )  # in 3D tensor (B, *, M), takes the softmax of B 2D tensors (*, M)
+
+    @register_benchmark()
+    def torch_jagged_softmax_torch_sum(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        def _inner():
+            padded = torch.ops.aten._jagged_to_padded_dense_forward(
+                x.values(),
+                [x.offsets()],  # pyre-ignore: Undefined attribute [16]: `torch._tensor.Tensor` has no attribute `offsets`.
+                max_lengths=[seqlen],  # max length of ragged dimension
+                padding_value=float("-inf"),  # e^-inf = 0
+            )
+            padded_softmax = torch.softmax(padded, dim=1)
+
+            return torch.ops.aten._padded_dense_to_jagged_forward(
+                padded_softmax,
+                [x.offsets()],
+                total_L=x.values().shape[
+                    0
+                ],  # providing this parameter helps avoid a GPU/CPU sync
+            )
+
+        return _inner
+
+    def get_x_val(self, example_inputs):
+        if self.B is None:
+            return example_inputs[1]
+        if self.M is None:
+            return example_inputs[2]
+        if self.seqlen is None:
+            return example_inputs[3]
+        return example_inputs[4]
+
+    def get_x_vals(self) -> Tuple[List[int], List[int], List[int], List[float]]:
+        return generate_input_vals(
+            self.B, self.M, self.seqlen, self.sparsity, self.sizes
+        )
+
+    def get_input_iter(self) -> Generator:
+        """
+        Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+        """
+
+        B_vals, M_vals, seqlen_vals, sparsity_vals = self.get_x_vals()
+
+        for nt, B, M, max_seqlen, sparsity in generate_random_nested_tensors(
+            B_vals,
+            M_vals,
+            seqlen_vals,
+            sparsity_vals,
+            device=self.device,
+            dtype=self.dtype,
+            TENSOR_BYTES_LIMIT=TENSOR_BYTES_LIMIT,
+            RANDOM_CHOICE_MARGIN=RANDOM_CHOICE_MARGIN,
+        ):
+            yield (nt, B, M, max_seqlen, sparsity)
+
+    def _get_accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:
+        output = fn()
+        baseline_output = baseline_fn()
+        return torch.allclose(
+            output, baseline_output, atol=ABSOLUTE_TOLERANCE, rtol=RELATIVE_TOLERANCE
+        )
+
+    @register_metric(skip_baseline=True)
+    def gbps(self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics):
+        return (
+            example_inputs[0].element_size()
+            * example_inputs[0].numel()
+            / metrics.latency
+            * GIGABYTES_PER_BYTE
+        )
+
+    @register_metric(x_only=True)
+    def input_shape(
+        self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics
+    ):
+        return (
+            f"B: {example_inputs[1]}",  # B
+            "*",
+            f"M: {example_inputs[2]}",  # M
+            f"max seqlen: {example_inputs[3]}",  # seqlen
+            f"sparsity: {example_inputs[4]}",  # sparsity
+        )  # return (B, '*', M, max seqlen, sparsity) for each example input
+
+    @register_metric(skip_baseline=True)
+    def best_config(
+        self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics
+    ) -> str:
+        return ""
+
+    def plot(self):
+        str_B, str_M, str_seqlen, str_sparsity = (
+            f"-B-{self.B}",
+            f"-M-{self.M}",
+            f"-seqlen-{self.seqlen}",
+            f"-sparsity-{self.sparsity}",
+        )
+        if self.B is None:
+            x_axis = "B"
+            params = str_M + str_seqlen + str_sparsity
+        elif self.M is None:
+            x_axis = "M"
+            params = str_B + str_seqlen + str_sparsity
+        elif self.seqlen is None:
+            x_axis = "seqlen"
+            params = str_B + str_M + str_sparsity
+        else:
+            x_axis = "sparsity"
+            params = str_B + str_M + str_seqlen
+
+        line_vals = [
+            "torch_jagged_softmax_torch_sum",
+        ]
+        line_names = [
+            "PyTorch jagged softmax, torch.sum",
+        ]
+        styles = [
+            ("blue", "-"),
+        ]
+
+        plot_name = f"jagged-softmax-perf-var-{x_axis}" + params
+
+        @triton.testing.perf_report(
+            triton.testing.Benchmark(
+                x_names=["x_axis"],
+                x_vals=self.output.x_vals,
+                line_arg="provider",
+                line_vals=line_vals,
+                line_names=line_names,
+                styles=styles,
+                xlabel=x_axis,
+                ylabel="latency",
+                plot_name=plot_name,
+                args={},
+            )
+        )
+        def _plot(x_axis, provider):
+            return self.output.get_y_vals(x_axis, provider, "latency")
+
+        save_path = (
+            os.getcwd()
+            + f"/pytorch/benchmark/torchbenchmark/operators/jagged_softmax/jagged_softmax_performance/{plot_name}"
+        )
+
+        if not os.path.exists(save_path):
+            os.mkdir(save_path)
+
+        _plot.run(show_plots=True, print_data=True, save_path=save_path)

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -170,4 +170,18 @@ def generate_random_nested_tensors(
 
             nested_tensors.append((nt, B, M, max_seqlen, sparsity))
 
+    # add 0-seqlen nested tensor
+    tensors = [
+        torch.randn((seqlen_vals[0], M), device=device, dtype=dtype),
+        torch.randn((0, M), device=device, dtype=dtype),
+        torch.randn((seqlen_vals[0] // 2, M), device=device, dtype=dtype),
+    ]
+    nt = torch.nested.nested_tensor(
+        tensors,
+        layout=torch.jagged,
+        device=device,
+        dtype=dtype,
+    )
+    nested_tensors.append((nt, 3, M, seqlen_vals[0], 0.5))
+
     return nested_tensors


### PR DESCRIPTION
Summary:
Add to TritonBench a `jagged_softmax` reduction operator benchmark for nested tensors using the PyTorch `torch.sum` function, [`torch.ops.aten._jagged_to_padded_dense_forward`](https://www.internalfb.com/code/fbsource/[92c2a067ab04e3eebc999254fed4ae2fbea6def3]/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/inductor_lowerings/elementwise_ops.py?lines=26), and [`torch.ops.aten._padded_dense_to_jagged_forward`](https://www.internalfb.com/code/fbsource/[16a15f9537d5a41100caaf394a398a0ab447d865]/xplat/caffe2/torch/_inductor/jagged_lowerings.py?lines=251).

This diff implements two benchmarks:
1. The baseline PyTorch benchmark uses `unbind` to call `torch.softmax` on each variable-length tensor in the nested tensor. This implementation is extremely slow, resulting in very high latency for all input shapes.
2. The more efficient PyTorch benchmark leverages `torch.sum` as well as aten lowerings to pad a jagged tensor, perform operations that execute a softmax, and unpad back into a jagged tensor format. First, the benchmark pads the input tensor using [`torch.ops.aten._jagged_to_padded_dense_forward`](https://www.internalfb.com/code/fbsource/[92c2a067ab04e3eebc999254fed4ae2fbea6def3]/fbcode/deeplearning/fbgemm/fbgemm_gpu/fb/inductor_lowerings/elementwise_ops.py?lines=26). It then stabilizes the padded tensor by subtracting the maximum value in the padded tensor. Next, it performs a softmax operation by dividing the exponent of the padded tensor by the `sum` of the exponent tensor. Lastly, it unpads the padded dense tensor using [`torch.ops.aten._padded_dense_to_jagged_forward`](https://www.internalfb.com/code/fbsource/[16a15f9537d5a41100caaf394a398a0ab447d865]/xplat/caffe2/torch/_inductor/jagged_lowerings.py?lines=251), which returns the `values` tensor as a result.

The efficient PyTorch benchmark in this diff avoids a GPU/CPU sync as long as I provide to [`torch.ops.aten._padded_dense_to_jagged_forward`](https://www.internalfb.com/code/fbsource/[16a15f9537d5a41100caaf394a398a0ab447d865]/xplat/caffe2/torch/_inductor/jagged_lowerings.py?lines=251) the [`total_L`](https://www.internalfb.com/code/fbsource/[4b8f2012e316d83f01a16078b334cb485d31b04c]/fbcode/caffe2/test/test_nestedtensor.py?lines=5419) parameter, which is the total length of the `values` tensor of a nested tensor.

Notes
- This [Stack Overflow post](https://stackoverflow.com/questions/49036993/pytorch-softmax-what-dimension-to-use) was helpful in understanding how to perform softmax along a specific dimension!
- [`log_softmax`](https://pytorch.org/docs/stable/generated/torch.nn.functional.log_softmax.html) may be faster and is worth a shot in the future
- This implementation works for nested tensors where variable-length tensors have `seqlen = 0`

Note on 0-seqlen nested tensors: As discussed offline, we chose to allow 0-seqlen nested tensors (a nested tensor with at least one tensor of dimension (0, M) for a nested tensor of shape (B, *, M)) to no-op cleanly while supporting offsets with duplicated values (e.g. [0, 2, 2, 3, 5]). The PyTorch softmax implementation pads 0-seqlen tensors with NaNs, which are then entirely removed from the result via the unpadding. The custom Triton implementations will perform no operations on the 0-seqlen tensors, effectively performing a no-op.

Reviewed By: davidberard98

Differential Revision: D59288946
