### PR TITLE
Add variable-length loop Triton kernel benchmark for jagged_softmax

### DIFF
--- a/torchbenchmark/operators/jagged_softmax/__init__.py
+++ b/torchbenchmark/operators/jagged_softmax/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/jagged_softmax/kernels.py
+++ b/torchbenchmark/operators/jagged_softmax/kernels.py
@@ -1,0 +1,120 @@
+import itertools
+
+import triton
+import triton.language as tl
+
+
+BLOCK_SIZES_RAGGED = [2**n for n in range(3, 12, 4)]
+BLOCK_SIZES_M = [2**n for n in range(3, 7, 3)]
+NUM_WARPS = [4, 8]
+NUM_STAGES = [2, 4]
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_softmax_kernel_simple_fused_buffer_then_sum(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    MAX_SEQLEN,  # max length of ragged dimension
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    # generate offsets and mask for BLOCK_SIZE_M (corresponding to pid_m)
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+
+    buffer_max_all = tl.full(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), value=float("-inf"), dtype=tl.float32
+    )  # compile buffer max (maximum value of buffer along ragged dimension)
+
+    # calculate maximum value of buffer (along ragged dimension)
+    for block_pos in range(
+        0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=float("-inf"))
+        buffer_max_all = tl.maximum(buffer_max_all, input)
+
+    buffer_max = tl.max(buffer_max_all, axis=0, keep_dims=True)
+
+    # add exponentiated stable input to the buffer
+    for block_pos in range(
+        0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(
+            input_ptr_values + idxs, mask=mask, other=float("-inf")
+        )  # cannot pad with 0, because input values may be 0
+        buffer += tl.exp(input - buffer_max)
+
+    # calculate sum of exponents (denominator of softmax function)
+    buffer_exp_sum = tl.sum(buffer, axis=0)  # 2D tensor of shape (1, BLOCK_SIZE_M)
+
+    # divide input (numerator of softmax function) by sum of exponents
+    for block_pos in range(
+        0, MAX_SEQLEN, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        block_start_ragged = (
+            ragged_start + block_pos
+        )  # offset block position by start of current program
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=float("-inf"))
+        output = tl.fdiv(tl.exp(input - buffer_max), buffer_exp_sum)
+
+        tl.store(output_ptr + idxs, output, mask=mask)

--- a/torchbenchmark/operators/jagged_softmax/kernels.py
+++ b/torchbenchmark/operators/jagged_softmax/kernels.py
@@ -118,3 +118,103 @@ def triton_jagged_softmax_kernel_simple_fused_buffer_then_sum(
         output = tl.fdiv(tl.exp(input - buffer_max), buffer_exp_sum)
 
         tl.store(output_ptr + idxs, output, mask=mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {
+                "BLOCK_SIZE_RAGGED": b_r,
+                "BLOCK_SIZE_M": b_m,
+            },
+            num_warps=w,
+            num_stages=s,
+        )
+        for b_r, b_m, w, s in itertools.product(
+            BLOCK_SIZES_RAGGED,  # block sizes on non-reduction dimension
+            BLOCK_SIZES_M,  # block sizes on reduction dimension
+            NUM_WARPS,  # number of warps
+            NUM_STAGES,  # number of stages
+        )
+    ],
+    key=["M"],
+)
+@triton.jit
+def triton_jagged_softmax_kernel_variable_length_loop_buffer_then_sum(
+    input_ptr_values,  # pointer to input values (2D tensor)
+    input_ptr_offsets,  # pointer to input offsets (1D tensor)
+    output_ptr,  # pointer to output tensor (2D tensor)
+    # matrix dimensions (input)
+    M,  # number of elements in M-th dimension, with logical dimensions (B, *, M)
+    # block sizes (input)
+    BLOCK_SIZE_RAGGED: tl.constexpr,  # number of elements in ragged dimension per block, with logical dimensions (B, *, M)
+    BLOCK_SIZE_M: tl.constexpr,  # number of elements in M-th dimension per block, with logical dimensions (B, *, M)
+):
+    pid = tl.program_id(axis=0)  # i-th tensor in nested tensor
+    pid_b = pid // tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % tl.cdiv(M, BLOCK_SIZE_M)
+
+    buffer = tl.zeros(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), dtype=tl.float32
+    )  # create buffer as a row tensor
+
+    # generate offsets and mask for BLOCK_SIZE_M (corresponding to pid_m)
+    block_start_m = pid_m * BLOCK_SIZE_M
+    offsets_m = block_start_m + tl.arange(0, BLOCK_SIZE_M)
+    mask_m = offsets_m < M
+
+    ragged_start, ragged_end = tl.load(input_ptr_offsets + pid_b), tl.load(
+        input_ptr_offsets + (pid_b + 1)
+    )  # load start and end offsets for current program, similar to offsets[i] and offsets[i + 1]
+
+    buffer_max_all = tl.full(
+        (BLOCK_SIZE_RAGGED, BLOCK_SIZE_M), value=float("-inf"), dtype=tl.float32
+    )  # compile buffer max (maximum value of buffer along ragged dimension)
+
+    # calculate maximum value of buffer (along ragged dimension)
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=float("-inf"))
+        buffer_max_all = tl.maximum(buffer_max_all, input)
+
+    buffer_max = tl.max(buffer_max_all, axis=0, keep_dims=True)
+
+    # add exponentiated stable input to the buffer
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(
+            input_ptr_values + idxs, mask=mask, other=float("-inf")
+        )  # cannot pad with 0, because input values may be 0
+        buffer += tl.exp(input - buffer_max)
+
+    # calculate sum of exponents (denominator of softmax function)
+    buffer_exp_sum = tl.sum(buffer, axis=0)  # 2D tensor of shape (1, BLOCK_SIZE_M)
+
+    # divide input (numerator of softmax function) by sum of exponents
+    for block_start_ragged in range(
+        ragged_start, ragged_end, BLOCK_SIZE_RAGGED
+    ):  # loop over ragged dimension, ranging until maximum seqlen
+        offsets_ragged = block_start_ragged + tl.arange(0, BLOCK_SIZE_RAGGED)
+        mask_ragged = offsets_ragged < ragged_end
+
+        idxs = (offsets_ragged[:, None] * M) + offsets_m
+        mask = mask_ragged[:, None] & mask_m
+
+        input = tl.load(input_ptr_values + idxs, mask=mask, other=float("-inf"))
+        output = tl.fdiv(tl.exp(input - buffer_max), buffer_exp_sum)
+
+        tl.store(output_ptr + idxs, output, mask=mask)

--- a/torchbenchmark/operators/jagged_softmax/operator.py
+++ b/torchbenchmark/operators/jagged_softmax/operator.py
@@ -1,0 +1,218 @@
+import argparse
+import itertools
+import math
+import os
+import random
+from typing import Callable, Generator, List, Optional, Tuple
+
+import torch
+import triton
+from torchbenchmark.util.jagged_utils import (
+    generate_input_vals,
+    generate_random_nested_tensors,
+    get_parse_op_args,
+)
+
+from torchbenchmark.util.triton_op import (
+    BenchmarkOperator,
+    BenchmarkOperatorMetrics,
+    register_benchmark,
+    register_metric,
+)
+
+
+seed = 16
+random.seed(seed)
+
+GIGABYTES_PER_BYTE = 1e-6
+RANDOM_CHOICE_MARGIN = 0.3
+ABSOLUTE_TOLERANCE = 1e-4
+RELATIVE_TOLERANCE = 1e-3
+TENSOR_BYTES_LIMIT = 8 * 1e9  # allocate tensors no greater than 8GB
+
+
+def parse_op_args(args: List[str]):
+    parser = get_parse_op_args("B", "M", "seqlen", "sparsity")
+    return parser.parse_args(args)
+
+
+class Operator(BenchmarkOperator):
+
+    DEFAULT_METRICS = ["latency", "accuracy"]
+    use_cuda_graphs = (
+        False  # enables GPU/CPU sync (for methods like NestedTensor unbind)
+    )
+
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ):
+        super().__init__(tb_args, extra_args)
+        self.sizes = list(range(2, 12, 4)) + list(
+            range(12, 23, 3)
+        )  # bias towards larger sizes, which are more representative of real-world shapes
+
+        args = parse_op_args(self.extra_args)
+        self.B = args.B
+        self.M = args.M
+        self.seqlen = args.seqlen
+        self.sparsity = args.sparsity
+
+    @register_benchmark(baseline=True)
+    def torch_jagged_softmax_unbind_torch_softmax(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        return lambda: torch.cat(
+            [
+                torch.softmax(t, dim=0) for t in x.unbind()
+            ],  # torch.softmax already stabilizes the input (x - max(x))
+            dim=0,
+        )  # in 3D tensor (B, *, M), takes the softmax of B 2D tensors (*, M)
+
+    @register_benchmark()
+    def torch_jagged_softmax_torch_sum(
+        self, x: torch.Tensor, B: int, M: int, seqlen: int, sparsity: float
+    ):
+        def _inner():
+            padded = torch.ops.aten._jagged_to_padded_dense_forward(
+                x.values(),
+                [x.offsets()],  # pyre-ignore: Undefined attribute [16]: `torch._tensor.Tensor` has no attribute `offsets`.
+                max_lengths=[seqlen],  # max length of ragged dimension
+                padding_value=float("-inf"),  # e^-inf = 0
+            )
+            padded_softmax = torch.softmax(padded, dim=1)
+
+            return torch.ops.aten._padded_dense_to_jagged_forward(
+                padded_softmax,
+                [x.offsets()],
+                total_L=x.values().shape[
+                    0
+                ],  # providing this parameter helps avoid a GPU/CPU sync
+            )
+
+        return _inner
+
+    def get_x_val(self, example_inputs):
+        if self.B is None:
+            return example_inputs[1]
+        if self.M is None:
+            return example_inputs[2]
+        if self.seqlen is None:
+            return example_inputs[3]
+        return example_inputs[4]
+
+    def get_x_vals(self) -> Tuple[List[int], List[int], List[int], List[float]]:
+        return generate_input_vals(
+            self.B, self.M, self.seqlen, self.sparsity, self.sizes
+        )
+
+    def get_input_iter(self) -> Generator:
+        """
+        Generate random nested tensors of shape (B, *, M), where * is the ragged dimension
+        """
+
+        B_vals, M_vals, seqlen_vals, sparsity_vals = self.get_x_vals()
+
+        for nt, B, M, max_seqlen, sparsity in generate_random_nested_tensors(
+            B_vals,
+            M_vals,
+            seqlen_vals,
+            sparsity_vals,
+            device=self.device,
+            dtype=self.dtype,
+            TENSOR_BYTES_LIMIT=TENSOR_BYTES_LIMIT,
+            RANDOM_CHOICE_MARGIN=RANDOM_CHOICE_MARGIN,
+        ):
+            yield (nt, B, M, max_seqlen, sparsity)
+
+    def _get_accuracy(self, fn: Callable, baseline_fn: Callable) -> bool:
+        output = fn()
+        baseline_output = baseline_fn()
+        return torch.allclose(
+            output, baseline_output, atol=ABSOLUTE_TOLERANCE, rtol=RELATIVE_TOLERANCE
+        )
+
+    @register_metric(skip_baseline=True)
+    def gbps(self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics):
+        return (
+            example_inputs[0].element_size()
+            * example_inputs[0].numel()
+            / metrics.latency
+            * GIGABYTES_PER_BYTE
+        )
+
+    @register_metric(x_only=True)
+    def input_shape(
+        self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics
+    ):
+        return (
+            f"B: {example_inputs[1]}",  # B
+            "*",
+            f"M: {example_inputs[2]}",  # M
+            f"max seqlen: {example_inputs[3]}",  # seqlen
+            f"sparsity: {example_inputs[4]}",  # sparsity
+        )  # return (B, '*', M, max seqlen, sparsity) for each example input
+
+    @register_metric(skip_baseline=True)
+    def best_config(
+        self, fn_name, example_inputs, metrics: BenchmarkOperatorMetrics
+    ) -> str:
+        return ""
+
+    def plot(self):
+        str_B, str_M, str_seqlen, str_sparsity = (
+            f"-B-{self.B}",
+            f"-M-{self.M}",
+            f"-seqlen-{self.seqlen}",
+            f"-sparsity-{self.sparsity}",
+        )
+        if self.B is None:
+            x_axis = "B"
+            params = str_M + str_seqlen + str_sparsity
+        elif self.M is None:
+            x_axis = "M"
+            params = str_B + str_seqlen + str_sparsity
+        elif self.seqlen is None:
+            x_axis = "seqlen"
+            params = str_B + str_M + str_sparsity
+        else:
+            x_axis = "sparsity"
+            params = str_B + str_M + str_seqlen
+
+        line_vals = [
+            "torch_jagged_softmax_torch_sum",
+        ]
+        line_names = [
+            "PyTorch jagged softmax, torch.sum",
+        ]
+        styles = [
+            ("blue", "-"),
+        ]
+
+        plot_name = f"jagged-softmax-perf-var-{x_axis}" + params
+
+        @triton.testing.perf_report(
+            triton.testing.Benchmark(
+                x_names=["x_axis"],
+                x_vals=self.output.x_vals,
+                line_arg="provider",
+                line_vals=line_vals,
+                line_names=line_names,
+                styles=styles,
+                xlabel=x_axis,
+                ylabel="latency",
+                plot_name=plot_name,
+                args={},
+            )
+        )
+        def _plot(x_axis, provider):
+            return self.output.get_y_vals(x_axis, provider, "latency")
+
+        save_path = (
+            os.getcwd()
+            + f"/pytorch/benchmark/torchbenchmark/operators/jagged_softmax/jagged_softmax_performance/{plot_name}"
+        )
+
+        if not os.path.exists(save_path):
+            os.mkdir(save_path)
+
+        _plot.run(show_plots=True, print_data=True, save_path=save_path)

--- a/torchbenchmark/util/jagged_utils.py
+++ b/torchbenchmark/util/jagged_utils.py
@@ -170,4 +170,18 @@ def generate_random_nested_tensors(
 
             nested_tensors.append((nt, B, M, max_seqlen, sparsity))
 
+    # add 0-seqlen nested tensor
+    tensors = [
+        torch.randn((seqlen_vals[0], M), device=device, dtype=dtype),
+        torch.randn((0, M), device=device, dtype=dtype),
+        torch.randn((seqlen_vals[0] // 2, M), device=device, dtype=dtype),
+    ]
+    nt = torch.nested.nested_tensor(
+        tensors,
+        layout=torch.jagged,
+        device=device,
+        dtype=dtype,
+    )
+    nested_tensors.append((nt, 3, M, seqlen_vals[0], 0.5))
+
     return nested_tensors


### PR DESCRIPTION
Summary:
Add Triton kernel benchmark implementing a variable-length loop `softmax` for the `jagged_softmax` operator. This Triton kernel performs a `softmax` operation along the ragged dimension of a nested tensor of logical dimensions `(B, *, M)`, where `*` is the ragged dimension.

The kernel implements `softmax` in two phases.
1. As with previous implementations of the variable-length loop kernel (e.g. D59175612), the first phase loops through the maximum sequence length `MAX_SEQLEN` and loads in the input, filling in any blocks outside of the ragged bounds with negative infinity (as `e^-inf = 0`). It then subtracts the maximum value in the input tensor from the input block and takes the exponent, then stores the exponentiated block into the buffer. After the first phase, the kernel takes the `sum` of the buffer along the ragged dimension, resulting in a `sum` over all exponentiated input.
2. The second phase iterates over `MAX_SEQLEN` again to load the input, then divides the input by the `sum` of the buffer and stores this result in the output. For division, I used `tl.fdiv`, which performs just a bit faster than the regular division operator `/`.

As with previous jagged operators, the kernel is benchmarked against a padded PyTorch implementation and the simple fused Triton kernel, and it verifies accuracy against a baseline PyTorch `unbind` implementation.

This implementation uses the `buffer_then_sum` method; it adds all exponentiated input to a buffer, then takes the `sum` at once. This method has been proven to be faster, as seen in previous jagged operators (like `jagged_sum` and `jagged_mean`) and seems to prove that storing to and loading from many registers is faster than taking multiple sums in Triton.

For more information regarding other approaches I tried and some notes on the implementation, see D59299726.

Reviewed By: davidberard98

Differential Revision: D59309772
