### PR TITLE
Add oss support to ncu rep

### DIFF
--- a/torchbenchmark/util/triton_op.py
+++ b/torchbenchmark/util/triton_op.py
@@ -878,7 +878,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         import sys
         import subprocess
 
-        op_task_args = copy.deepcopy(sys.argv)
+        op_task_args = [] if IS_FBCODE else [sys.executable]
+        op_task_args.extend(copy.deepcopy(sys.argv))
         for override_option in ["--only", "--input-id", "--num-inputs", "--metrics"]:
             op_task_args = _remove_params(
                 op_task_args, _find_param_loc(op_task_args, override_option)


### PR DESCRIPTION
We need to append the `sys.executable` when running NCU in OSS environment. This is not needed in Meta internal.


Test plan:

```
TORCH_CUDA_ARCH_LIST=9.0a CUDA_VISIBLE_DEVICES=5 python run_benchmark.py triton --op flash_attention --only flash_v3 --num-inputs 1 --dump-csv --metrics ncu_rep --batch 8 --n-heads 16 --d-head 128

  SeqLen                                                           flash_v3-ncu_rep
--------  -------------------------------------------------------------------------
     128  /tmp/tritonbench/flash_attention/ncu_traces/flash_v3_0/ncu_output.ncu-rep
```