### PR TITLE
[tritonbench] Fix dimension order for FlashAttention-3

### DIFF
--- a/torchbenchmark/operators/flash_attention/operator.py
+++ b/torchbenchmark/operators/flash_attention/operator.py
@@ -189,13 +189,17 @@ class Operator(BenchmarkOperator):
         )
         return fn
 
-    @register_benchmark(enabled=False)
+    @register_benchmark()
     def flash_v3(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
     ) -> Callable:
+        # [B, H, S, D] -> [B, S, H, D]
+        q = q.transpose(1, 2).contiguous()
+        k = k.transpose(1, 2).contiguous()
+        v = v.transpose(1, 2).contiguous()
         fn = lambda: flashattn_hopper_cuda.fwd(q, k, v, None, self.sm_scale, self.causal)
         return fn
 
@@ -291,7 +295,7 @@ class Operator(BenchmarkOperator):
                 tk_fwd.attention_forward(q, k, v, o)
             return o
         return tk_dispatcher
-    
+
     @register_benchmark(enabled=False, label=f"cudnn_{torch.backends.cudnn.version()}")
     def cudnn(self, q, k, v):
         os.environ["TORCH_CUDNN_SDPA_ENABLED"] = "1"
@@ -315,9 +319,9 @@ class Operator(BenchmarkOperator):
     def tflops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
-        flops_per_matmul = (
-            2.0 * self.BATCH * self.H * self.N_CTX * self.N_CTX * self.D_HEAD
-        )
+        q, k, v = example_inputs
+        BATCH, H, N_CTX, D_HEAD = q.shape
+        flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
         tflops = 2 * flops_per_matmul
         if self.causal:
             tflops *= 0.5
@@ -338,12 +342,12 @@ class Operator(BenchmarkOperator):
         return fn
 
     def get_input_iter(self) -> Generator:
-        BATCH = self.BATCH
-        H = self.H
         D_HEAD = self.D_HEAD
-        ctx_vals = [2**i for i in range(7, 15)]
+        ctx_vals = [2**i for i in range(9, 15)]
         requires_grad = True
         for N_CTX in ctx_vals:
+            BATCH = 16384 // N_CTX
+            H = 2048 // D_HEAD
             q = torch.randn(
                 (BATCH, H, N_CTX, D_HEAD),
                 dtype=self.dtype,
@@ -365,9 +369,11 @@ class Operator(BenchmarkOperator):
             self.N_CTX = N_CTX
             yield (q, k, v)
 
-    @register_x_val(label="SeqLen")
+    @register_x_val(label="(Batch, Heads, SeqLen, Dhead")
     def get_x_val(self, example_inputs) -> float:
-        return self.N_CTX
+        q, k, v = example_inputs
+        B, H, S, D = q.shape
+        return (B, H, S, D)
 
     def plot(self):
         y_metric_name = "tflops"


### PR DESCRIPTION
Summary: We were passing tensors as B, H, S, D, which is expected by the Triton kernel, but FA3 expects B, S, H, D.

Also, the FA3 paper sizes inputs such that B*S=16k and H*Dhead=2048.  Let's replicate that here.  Also, print the complete tensor sizes in the output table, not just the sequence length.

Test Plan:
```
python run_benchmark.py triton --op flash_attention --only triton_tutorial_flash_v2,flash_v3 --metrics tflops --d-head 128
  (Batch, Heads, SeqLen, Dhead    triton_tutorial_flash_v2-tflops    flash_v3-tflops
------------------------------  ---------------------------------  -----------------
            (32, 16, 512, 128)                            328.882            430.32
           (16, 16, 1024, 128)                            389.723            517.099
            (8, 16, 2048, 128)                            433.721            565.544
            (4, 16, 4096, 128)                            458.359            590.233
            (2, 16, 8192, 128)                            470.732            614.234
           (1, 16, 16384, 128)                            476.753            620.73
```