### PR TITLE
Run only a subset for optim benchmarks, attempt to fix

### DIFF
--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -58,7 +58,8 @@ jobs:
           if [ -d .userbenchmark ]; then rm -Rf .userbenchmark; fi
 
           # TODO: scale this to run other benchmarks, but let's start with optim
-          python -m userbenchmark.optim.run_optim_benchmarks -c ${{ github.event.inputs.userbenchmark_options }}
+          # Only run a subset, see if this fixes the workflow
+          python -m userbenchmark.optim.run_optim_benchmarks -s -c ${{ github.event.inputs.userbenchmark_options }}
           cp -r ./.userbenchmark/optim ../benchmark-output
       - name: Detect potential regressions
         continue-on-error: true
@@ -66,7 +67,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           pushd benchmark
           RESULTS=($(find ${PWD}/../benchmark-output -name "metrics-*.json" -maxdepth 2 | sort -r))
-          # TODO: the following assumes only one metrics-*.json is found. It will keep 
+          # TODO: the following assumes only one metrics-*.json is found. It will keep
           # overwriting gh-issue.md if multiple are found. Scaling this up is a potential next step.
           for r in ${RESULTS[@]}; do
             python regression_detector.py --platform "${PLATFORM_NAME}" --treatment "${r}" --owner @janeyx99 \

--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -42,7 +42,8 @@ jobs:
           set -x
           . "${SETUP_SCRIPT}"
           pushd benchmark
-          python install.py
+          # only install the subset of models currently running.
+          python install.py BERT_pytorch DALLE2_pytorch hf_GPT2_large hf_T5_large resnet50 timm_vision_transformer_large yolov3
       - name: Print torch.version.git_version
         run: |
           set -x

--- a/regression_detector.py
+++ b/regression_detector.py
@@ -412,7 +412,7 @@ if __name__ == "__main__":
     if not start_date:
         raise RuntimeError(
             f"No start date in previous JSONS found to compare towards the end date {end_date}. User specified start date: {args.start_date}. "
-            + f"Available JSON dates: {available_metrics_jsons.keys()}. No regression info has been generated."
+            + "No regression info has been generated."
         )
 
     print(

--- a/userbenchmark/optim/run.py
+++ b/userbenchmark/optim/run.py
@@ -60,7 +60,7 @@ SUBSET_OF_MODEL_NAMES: List[str] = [
     "hf_GPT2_large",
     "hf_T5_large",
     "resnet50",
-    "timm_vision_transformer",
+    "timm_vision_transformer_large",
     "yolov3",
 ]
 
@@ -803,8 +803,9 @@ def run(args: List[str]):
     compare.colorize(rowwise=True)
     compare.print()
 
-    print("----------------- COMPILE TIME RESULTS -----------------")
-    print(compile_metrics)
+    if 'pt2_' in args.funcs:
+        print("----------------- COMPILE TIME RESULTS -----------------")
+        print(compile_metrics)
 
 
 if __name__ == "__main__":

--- a/userbenchmark/optim/run.py
+++ b/userbenchmark/optim/run.py
@@ -170,6 +170,19 @@ OPTIMIZERS = [
             "momentum": 0.9,
         },
     ),
+    (
+        SGD,
+        {
+            "fused": True,
+        },
+    ),
+    (
+        SGD,
+        {
+            "fused": True,
+            "momentum": 0.9,
+        },
+    ),
     (RAdam, {}),
     (RAdam, {"foreach": False}),
     (RAdam, {"differentiable": True}),
@@ -579,8 +592,6 @@ def run_model(modelName, device, Optim, defaults, maybe_pt2_):
             len(params),
             params[0].device,
         )
-        if Optim.__name__ == "SGD":
-            defaults["lr"] = 1e-2
         optim = Optim(params, **defaults)
         generate_random_gradients(params)
         pt2_description = "" if maybe_pt2_ == "" else "(pt2) "

--- a/userbenchmark/optim/run_optim_benchmarks.py
+++ b/userbenchmark/optim/run_optim_benchmarks.py
@@ -18,6 +18,7 @@ import sys
 import itertools
 import json
 from userbenchmark.utils import REPO_PATH, add_path, dump_output, get_output_json
+from userbenchmark.optim.run import SUBSET_OF_MODEL_NAMES
 
 with add_path(REPO_PATH):
     from torchbenchmark.util.experiment.instantiator import list_models
@@ -67,8 +68,12 @@ def main() -> None:
     assert not OUTPUT_DIR.exists() or not any(OUTPUT_DIR.glob("*")), \
            f'{OUTPUT_DIR} must be empty or nonexistent. Its contents will be wiped by this script.'
 
+    models = args.models
+    if "-c" in optim_bm_args:
+        models = [m for m in models if m in SUBSET_OF_MODEL_NAMES]
+
     # Run benchmarks in subprocesses to take isolate contexts and memory
-    for m, d, f in itertools.product(args.models, args.devices, args.funcs):
+    for m, d, f in itertools.product(models, args.devices, args.funcs):
         command = [sys.executable, '-m', 'userbenchmark.optim.run', '--continue-on-error',
                    '--output-dir', OUTPUT_DIR, '--models', m, '--devices', d, '--funcs', f] + optim_bm_args
         # Use check=True to force this process to go serially since our capacity


### PR DESCRIPTION
A first attempt to fix https://github.com/pytorch/benchmark/actions/workflows/userbenchmark-regression-detector.yml by only running a subset of models

Impact of this change:
This workflow is green: https://github.com/pytorch/benchmark/actions/runs/10066723358/job/27828703722

It also takes so much shorter. At one point, the benchmark was 7 hours! Now it's 7 minutes.

## Test Plan

Test run: https://github.com/pytorch/benchmark/actions/runs/10065401507

Final test run: https://github.com/pytorch/benchmark/actions/runs/10066723358/job/27828703722