### PR TITLE
Install torchao in nightly docker build

### DIFF
--- a/.github/workflows/_linux-benchmark-cuda.yml
+++ b/.github/workflows/_linux-benchmark-cuda.yml
@@ -6,11 +6,6 @@ on:
         required: true
         type: string
         description: Name of the benchmark
-      userbenchmark-install-args:
-        required: false
-        type: string
-        default: ""
-        description: Userbenchmark installation command line arguments
       userbenchmark-run-args:
         required: true
         type: string
@@ -67,11 +62,6 @@ jobs:
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
           conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
-      - name: Install benchmark
-        run: |
-          . "${SETUP_SCRIPT}"
-          pushd benchmark
-          bash ./.ci/torchbench/install.sh --userbenchmark ${{ inputs.userbenchmark }} ${{ inputs.userbenchmark-install-args }}
       - name: Run benchmark
         run: |
           . "${SETUP_SCRIPT}"

--- a/docker/torchbench-nightly.dockerfile
+++ b/docker/torchbench-nightly.dockerfile
@@ -56,7 +56,12 @@ RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 && \
     bash .ci/tritonbench/test.sh && \
     sudo apt-get purge -y libnvidia-compute-550
 
-# Install Torchbench
+# Install TorchAO benchmark
+RUN cd /workspace/benchmark && \
+    . ${SETUP_SCRIPT} && \
+    python install.py --userbenchmark torchao
+
+# Install Torchbench models
 RUN cd /workspace/benchmark && \
     . ${SETUP_SCRIPT} && \
     python install.py


### PR DESCRIPTION
Add torchao to the nightly docker build, and benchmark on the docker built-in version instead of installing it at benchmark time.

This will fix the problem where different workstreams (torchbench, timm, huggingface) will use different versions of torchao.