### PR TITLE
[tritonbench] Print traceback when exception occurs during benchmarking

### DIFF
--- a/torchbenchmark/util/triton_op.py
+++ b/torchbenchmark/util/triton_op.py
@@ -557,7 +557,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 del self.example_inputs
                 gc.collect()
         except (KeyboardInterrupt, Exception):
-            warnings.warn("Caught exception, terminating early with partial results", stacklevel=1)
+            logger.warning("Caught exception, terminating early with partial results", exc_info=True)
             raise
         finally:
             self.output = BenchmarkOperatorResult(


### PR DESCRIPTION
Without the traceback it's impossible to tell what went wrong.