### PR TITLE
Fix CUPTI and Debugger libraries in the docker image

### DIFF
--- a/docker/gcp-a100-runner-dind.dockerfile
+++ b/docker/gcp-a100-runner-dind.dockerfile
@@ -33,8 +33,14 @@ RUN sudo mkdir -p /workspace; sudo chown runner:runner /workspace
 # Use the CUDA installation scripts from pytorch/builder
 # Install CUDA 12.4 only to reduce docker size
 RUN cd /workspace; mkdir -p pytorch-ci; cd pytorch-ci; wget https://raw.githubusercontent.com/pytorch/pytorch/main/.ci/docker/common/install_cuda.sh
-# do not prune CUDA libraries as they are being used by Kineto and NCU
-RUN sudo bash -c "set -x;export OVERRIDE_GENCODE=\"${OVERRIDE_GENCODE}\" OVERRIDE_GENCODE_CUDNN=\"${OVERRIDE_GENCODE_CUDNN}\"; . /workspace/pytorch-ci/install_cuda.sh; install_124"
+RUN sudo bash -c "set -x;export OVERRIDE_GENCODE=\"${OVERRIDE_GENCODE}\" OVERRIDE_GENCODE_CUDNN=\"${OVERRIDE_GENCODE_CUDNN}\"; bash /workspace/pytorch-ci/install_cuda.sh 12.4"
+
+# Move CUPTI libraries to the cuda directory
+RUN sudo bash -c "set -x; mv /usr/local/cuda/extras/CUPTI/include/* /usr/local/cuda/include"
+RUN sudo bash -c "set -x; mv /usr/local/cuda/extras/CUPTI/lib64/* /usr/local/cuda/lib64"
+# Move Debugger libraries to the cuda directory
+RUN sudo bash -c "set -x; mv /usr/local/cuda/extras/Debugger/include/* /usr/local/cuda/include"
+RUN sudo bash -c "set -x; mv /usr/local/cuda/extras/Debugger/lib64/* /usr/local/cuda/lib64"
 
 # Install miniconda
 RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /workspace/Miniconda3-latest-Linux-x86_64.sh


### PR DESCRIPTION
CUPTI and Debugger libraries are moved in the new cuda installer, we need to move the header files and libraries to the original place.

Test plan: 
https://github.com/pytorch/benchmark/actions/runs/10326154546
docker:
https://github.com/pytorch/benchmark/actions/runs/10326881008