### PR TITLE
logging hardware specific data in userbench

### DIFF
--- a/userbenchmark/triton/run.py
+++ b/userbenchmark/triton/run.py
@@ -162,8 +162,8 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
             else:
                 print(metrics)
         if not hasattr(torch_version, "git_version") and args.log_scuba:
-            from userbenchmark.triton.fb import log_benchmark
-            log_benchmark(metrics)
+            from pytorch.benchmark.fb.run_utils import log_benchmark
+            log_benchmark(metrics, args.op)
         if args.plot:
             try:
                 opbench.plot()


### PR DESCRIPTION
Summary:
currently we are saving the device type in this table ie cuda vs rocm vs cpu etc. We want to further update to allow for hardware specific data ie a100 vs h100. Here we are specifying this for cuda based devices only.

If using cuda we will dynamically find the gpu model via nvidia-smi and log that model.

in this case for H100 we will see "Nvidia H100" and for a100 we will see "NVidia A100"

this will allow us to run the same benchmark on both types of gpu and find the difference in the results quickly via scuba at any given time

Differential Revision: D61229059


