### PR TITLE
fixed a bug in triton fused attention when using fp16

### DIFF
--- a/torchbenchmark/util/kernels/triton_fused_attention.py
+++ b/torchbenchmark/util/kernels/triton_fused_attention.py
@@ -246,7 +246,7 @@ def _attn_fwd_inner_tma(acc, l_i, m_i, q,  #
         if fp8_v:
             p = p.to(tl.float8e5)
         else:
-            p = p.to(tl.bfloat16)
+            p = p.to(tl.float16)
         acc = tl.dot(p, v, acc)
         # update m_i and l_i
         m_i = m_ij


### PR DESCRIPTION
Previously, it gave an error when using fp16:

AssertionError: First input (bf16) and second input (fp16) must have the same dtype!
