### PR TITLE
add support for auto-tune TMA grid constant

### DIFF
--- a/torchbenchmark/util/kernels/triton_fused_attention.py
+++ b/torchbenchmark/util/kernels/triton_fused_attention.py
@@ -17,6 +17,13 @@ import numpy as np
 import triton
 import triton.language as tl
 
+# check if we have the TMA version in Triton PR #4498 (https://github.com/triton-lang/triton/pull/4498). 
+try:
+    import triton.tools.experimental_descriptor.TmaDescKernelParam
+    HAS_TMA_DESC = True
+except ImportError:
+    HAS_TMA_DESC = False
+
 
 @triton.jit
 def _attn_fwd_inner(acc, l_i, m_i, q,  #

--- a/torchbenchmark/util/kernels/triton_fused_attention.py
+++ b/torchbenchmark/util/kernels/triton_fused_attention.py
@@ -23,6 +23,10 @@ if "nv_tma_desc_type" in dir(tl):
 else:
     HAS_TMA_DESC = False
 
+if HAS_TMA_DESC:
+    print("Running with experimental grid constant TMA descriptor.")
+else:
+    print("Running without grid constant TMA descriptor.")
 
 class TmaAutoTuneHelper:
 

--- a/torchbenchmark/util/kernels/triton_fused_attention.py
+++ b/torchbenchmark/util/kernels/triton_fused_attention.py
@@ -54,8 +54,6 @@ class TmaAutoTuneHelper:
     def init_tma_descriptor(self, name):
         if self.has_tma_desc:
             self.descriptors[name] = torch.empty(self.tma_size, device="cpu", dtype=torch.int8)
-            # pass
-            # self.descriptors[name] = None
         else:
             self.cuda_descriptors[name] = torch.empty(self.tma_size, device="cuda", dtype=torch.int8)
 

--- a/torchbenchmark/util/kernels/triton_fused_attention.py
+++ b/torchbenchmark/util/kernels/triton_fused_attention.py
@@ -23,61 +23,71 @@ if "nv_tma_desc_type" in dir(tl):
 else:
     HAS_TMA_DESC = False
 
-if HAS_TMA_DESC:
-    import triton.tools.experimental_descriptor
 
-class TmaDescriptorHelper:
+class TmaAutoTuneHelper:
+
+    # duck typing wrapper to implement the same interface as TmaDescKernelParam in Triton PR #4498
+    class KernelParamWrapper:
+        def __init__(self, desc):
+            self.desc = desc
+        
+        def tma_desc_cpu_ptr(self):
+            return self.desc.data_ptr()
+
     def __init__(self, tma_size=128):
+        self.fill_1d_tma_descriptor_inner = triton.runtime.driver.active.utils.fill_1d_tma_descriptor
+        self.fill_2d_tma_descriptor_inner = triton.runtime.driver.active.utils.fill_2d_tma_descriptor
         self.tma_size = tma_size
         self.has_tma_desc = HAS_TMA_DESC
         if self.has_tma_desc:
             self.descriptors = {}
-            self.create_1d_tma_descriptor = triton.tools.experimental_descriptor.create_1d_tma_descriptor
-            self.create_2d_tma_descriptor = triton.tools.experimental_descriptor.create_2d_tma_descriptor
         else:
             self.cuda_descriptors = {}
             self.cpu_descriptors = {}
-            self.fill_1d_tma_descriptor = triton.runtime.driver.active.utils.fill_1d_tma_descriptor
-            self.fill_2d_tma_descriptor = triton.runtime.driver.active.utils.fill_2d_tma_descriptor
 
 
     # Call this method outside of the lambda function for grid size
     def init_tma_descriptor(self, name):
         if self.has_tma_desc:
-            pass
+            self.descriptors[name] = torch.empty(self.tma_size, device="cpu", dtype=torch.int8)
+            # pass
             # self.descriptors[name] = None
         else:
             self.cuda_descriptors[name] = torch.empty(self.tma_size, device="cuda", dtype=torch.int8)
 
 
     # Call this method inside the lambda function for grid size
-    def create_1d_tma_descriptor(self, name, ptr, dim, block_dim, element_size):
+    def fill_1d_tma_descriptor(self, name, ptr, dim, block_dim, element_size):
         if self.has_tma_desc:
-            self.descriptors[name] = self.create_1d_tma_descriptor(ptr, dim, block_dim, element_size)
+            desc_x = self.descriptors[name]
+            assert desc_x.data_ptr() % 64 == 0
+            self.fill_1d_tma_descriptor_inner(ptr, dim, block_dim, element_size, desc_x.data_ptr())
         else:
             desc_x = self.cuda_descriptors[name]
             buf_x = torch.empty_like(desc_x, device="cpu", pin_memory=True)
             self.cpu_descriptors[name] = buf_x
-            self.fill_1d_tma_descriptor(ptr, dim, block_dim, element_size, buf_x.numpy())
-
-
-    # Call this method inside the lambda function for grid size
-    def create_2d_tma_descriptor(self, name, ptr, dim1, dim0, block_dim1, block_dim0, element_size):
-        if self.has_tma_desc:
-            self.descriptors[name] = self.create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size)
-        else:
-            desc_x = self.cuda_descriptors[name]
-            assert desc_x is not None
-            buf_x = torch.empty_like(desc_x, device="cpu", pin_memory=True)
-            self.cpu_descriptors[name] = buf_x
-            self.fill_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size, buf_x.numpy())
+            self.fill_1d_tma_descriptor_inner(ptr, dim, block_dim, element_size, buf_x.numpy())
             desc_x.copy_(buf_x, non_blocking=True)
 
 
-    def get_tma_descriptor(self, name):
+    # Call this method inside the lambda function for grid size
+    def fill_2d_tma_descriptor(self, name, ptr, dim1, dim0, block_dim1, block_dim0, element_size):
+        if self.has_tma_desc:
+            desc_x = self.descriptors[name]
+            assert desc_x.data_ptr() % 64 == 0
+            self.fill_2d_tma_descriptor_inner(ptr, dim1, dim0, block_dim1, block_dim0, element_size, desc_x.data_ptr())
+        else:
+            desc_x = self.cuda_descriptors[name]
+            buf_x = torch.empty_like(desc_x, device="cpu", pin_memory=True)
+            self.cpu_descriptors[name] = buf_x
+            self.fill_2d_tma_descriptor_inner(ptr, dim1, dim0, block_dim1, block_dim0, element_size, buf_x.numpy())
+            desc_x.copy_(buf_x, non_blocking=True)
+
+
+    def get_tma_descriptor_kernel_param(self, name):
         if self.has_tma_desc:
             assert self.descriptors[name] is not None
-            return self.descriptors[name]
+            return self.KernelParamWrapper(self.descriptors[name])
         else:
             return self.cuda_descriptors[name]
 
@@ -793,22 +803,14 @@ class _attention_tma(torch.autograd.Function):
         desc_v = torch.tensor(desc_v, device=v.device)
         grid = lambda args: (triton.cdiv(q.shape[2], args["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
         '''
-        desc_helper = TmaDescriptorHelper(TMA_SIZE)
+        desc_helper = TmaAutoTuneHelper(TMA_SIZE)
         desc_helper.init_tma_descriptor('k')
         desc_helper.init_tma_descriptor('v')
         desc_helper.init_tma_descriptor('q')
         desc_helper.init_tma_descriptor('o')
-        # descriptors = {}
-        # if HAS_TMA_DESC:
-        #     pass
-        # else:
-        #     descriptors['k'] = torch.empty((TMA_SIZE), device="cuda", dtype=torch.int8)
-        #     descriptors['v'] = torch.empty((TMA_SIZE), device="cuda", dtype=torch.int8)
-        #     descriptors['q'] = torch.empty((TMA_SIZE), device="cuda", dtype=torch.int8)
-        #     descriptors['o'] = torch.empty((TMA_SIZE), device="cuda", dtype=torch.int8)
         def grid_tma(META):
             nonlocal desc_helper
-            desc_helper.create_2d_tma_descriptor('k',
+            desc_helper.fill_2d_tma_descriptor('k',
                 k.data_ptr(),
                 BATCH * H * N_CTX,
                 HEAD_DIM_Q,
@@ -817,7 +819,7 @@ class _attention_tma(torch.autograd.Function):
                 k.element_size(),
             )
             if v.dtype == torch.float8_e5m2:
-                desc_helper.create_2d_tma_descriptor('v',
+                desc_helper.fill_2d_tma_descriptor('v',
                     v.data_ptr(),
                     BATCH * H * HEAD_DIM_Q,
                     N_CTX,
@@ -826,7 +828,7 @@ class _attention_tma(torch.autograd.Function):
                     v.element_size(),
                 )
             else:
-                desc_helper.create_2d_tma_descriptor('v',
+                desc_helper.fill_2d_tma_descriptor('v',
                     v.data_ptr(),
                     BATCH * H * N_CTX,
                     HEAD_DIM_Q,
@@ -834,7 +836,7 @@ class _attention_tma(torch.autograd.Function):
                     HEAD_DIM_Q,
                     v.element_size(),
                 )
-            desc_helper.create_2d_tma_descriptor('q',
+            desc_helper.fill_2d_tma_descriptor('q',
                 q.data_ptr(),
                 BATCH * H * N_CTX,
                 HEAD_DIM_Q,
@@ -842,7 +844,7 @@ class _attention_tma(torch.autograd.Function):
                 HEAD_DIM_Q,
                 q.element_size(),
             )
-            desc_helper.create_2d_tma_descriptor('o',
+            desc_helper.fill_2d_tma_descriptor('o',
                 o.data_ptr(),
                 BATCH * H * N_CTX,
                 HEAD_DIM_Q,
@@ -852,10 +854,10 @@ class _attention_tma(torch.autograd.Function):
             )
             return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
 
-        desc_q = desc_helper.get_tma_descriptor('q')
-        desc_k = desc_helper.get_tma_descriptor('k')
-        desc_v = desc_helper.get_tma_descriptor('v')
-        desc_o = desc_helper.get_tma_descriptor('o')
+        desc_q = desc_helper.get_tma_descriptor_kernel_param('q')
+        desc_k = desc_helper.get_tma_descriptor_kernel_param('k')
+        desc_v = desc_helper.get_tma_descriptor_kernel_param('v')
+        desc_o = desc_helper.get_tma_descriptor_kernel_param('o')
 
         M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
         _attn_fwd_tma[grid_tma](


### PR DESCRIPTION
This PR follows [a recent PR in Triton](https://github.com/triton-lang/triton/pull/4498) that supports passing TMA descriptors by-value using `__grid_constant__`.

In this PR, we update the kernel `_attn_fwd_inner` to support the above new feature in Triton. To support auto-tune, we implement a helper class that wraps operations for TMA during auto-tune and computations in kernel respectively.
In addition, the benchmark program now also checks whether the triton version supports this new feature. If it doesn't, the helper class applies the old way of handling TMA.

The change has been tested on Triton from the standard installation of pytorch on conda, as well as the recent Triton including the above PR.