### PR TITLE
Install the benchmark before running.

### DIFF
--- a/.github/workflows/_linux-benchmark-cuda.yml
+++ b/.github/workflows/_linux-benchmark-cuda.yml
@@ -62,6 +62,11 @@ jobs:
         run: |
           CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
           conda create --name "${CONDA_ENV}" --clone "${BASE_CONDA_ENV}"
+      - name: Install benchmark
+        run: |
+          . "${SETUP_SCRIPT}"
+          pushd benchmark
+          python install.py
       - name: Run benchmark
         run: |
           . "${SETUP_SCRIPT}"


### PR DESCRIPTION
In workflows like https://github.com/pytorch/benchmark/actions/runs/10513238627/job/29128387392, we are hitting errors like `No module named 'torchbenchmark.util.framework.fb'`, this is because we directly run the benchmark without installing it.

We need to first install the benchmark before running the models.

Test plan:

https://github.com/pytorch/benchmark/actions/runs/10533763643