### PR TITLE
[tritonbench] Add FlexAttention

### DIFF
--- a/torchbenchmark/operators/flash_attention/operator.py
+++ b/torchbenchmark/operators/flash_attention/operator.py
@@ -46,8 +46,12 @@ except BaseException:
     HAS_KERNELS = False
 
 from torchbenchmark import add_ld_library_path
-from torchbenchmark.util.kernels.triton_fused_attention import attention as triton_tutorial_FA2
-from torchbenchmark.util.kernels.triton_fused_attention import attention_tma as triton_tutorial_FA2_tma
+from torchbenchmark.util.kernels.triton_fused_attention import (
+    attention as triton_tutorial_FA2,
+)
+from torchbenchmark.util.kernels.triton_fused_attention import (
+    attention_tma as triton_tutorial_FA2_tma,
+)
 from torch.nn.attention import SDPBackend, sdpa_kernel
 from torch.nn.functional import scaled_dot_product_attention as sdpa
 
@@ -56,7 +60,9 @@ from typing import Callable, Optional
 # [Optional] flash_attn v2
 try:
     from .test_fmha_utils import make_packed_qkv
-    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func as flash_attn_func
+    from flash_attn.flash_attn_interface import (
+        flash_attn_qkvpacked_func as flash_attn_func,
+    )
 except (ImportError, IOError, AttributeError):
     pass
 
@@ -87,6 +93,7 @@ try:
         torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
     else:
         from userbenchmark.triton.loader import load_library
+
         load_library("cutlass_kernels/fmha_forward_lib.so")
     colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward
 except (ImportError, IOError, AttributeError):
@@ -100,6 +107,7 @@ try:
     else:
         # causal is not supported right now
         from userbenchmark.triton.loader import load_library
+
         load_library("tk/tk_attn_h100_fwd.so")
         tk_fwd = torch.ops.tk
 except (ImportError, IOError, AttributeError):
@@ -134,7 +142,9 @@ def parse_op_args(args: List[str]):
 class Operator(BenchmarkOperator):
     DEFAULT_PRECISION = "bf16"
 
-    def __init__(self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None):
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ):
         super().__init__(tb_args, extra_args)
         self.use_cuda_graphs = False
         args = parse_op_args(self.extra_args)
@@ -213,7 +223,9 @@ class Operator(BenchmarkOperator):
         q = q.transpose(1, 2).contiguous()
         k = k.transpose(1, 2).contiguous()
         v = v.transpose(1, 2).contiguous()
-        fn = lambda: flashattn_hopper_cuda.fwd(q, k, v, None, self.sm_scale, self.causal)
+        fn = lambda: flashattn_hopper_cuda.fwd(
+            q, k, v, None, self.sm_scale, self.causal
+        )
         return fn
 
     @register_benchmark()
@@ -304,23 +316,32 @@ class Operator(BenchmarkOperator):
         default_scale = 1.0 / math.sqrt(float(self.D_HEAD))
         colfax_q, colfax_k, colfax_v = self.colfax_cutlass_preprocess(q, k, v)
         return lambda: colfax_cutlass_fmha(
-            self.N_CTX, self.N_CTX, self.BATCH, colfax_q, colfax_k, colfax_v, default_scale
+            self.N_CTX,
+            self.N_CTX,
+            self.BATCH,
+            colfax_q,
+            colfax_k,
+            colfax_v,
+            default_scale,
         )
 
     @register_benchmark(enabled=False)
     def tk(self, q, k, v):
         o = torch.zeros_like(v)
+
         def tk_dispatcher():
             if self.causal:
                 tk_fwd_causal.attention_forward_causal(q, k, v, o)
             else:
                 tk_fwd.attention_forward(q, k, v, o)
             return o
+
         return tk_dispatcher
 
     @register_benchmark(enabled=False, label=f"cudnn_{torch.backends.cudnn.version()}")
     def cudnn(self, q, k, v):
         os.environ["TORCH_CUDNN_SDPA_ENABLED"] = "1"
+
         def sdpa_flash_attention(q, k, v):
             with sdpa_kernel([SDPBackend.CUDNN_ATTENTION]):
                 return sdpa(
@@ -330,6 +351,7 @@ class Operator(BenchmarkOperator):
                     is_causal=self.causal,
                     scale=self.sm_scale,
                 )
+
         return lambda: sdpa_flash_attention(
             q,
             k,
@@ -347,7 +369,9 @@ class Operator(BenchmarkOperator):
 
         if self.causal:
             B, H, S, D = q.shape
-            block_mask = create_block_mask(causal_mask, B=None, H=None, Q_LEN=S, KV_LEN=S)
+            block_mask = create_block_mask(
+                causal_mask, B=None, H=None, Q_LEN=S, KV_LEN=S
+            )
         else:
             block_mask = None
 


### PR DESCRIPTION
```
+ python ./run_benchmark.py triton --op flash_attention --d-head 128 --only sdpa,flash_v2,flex_attention
  (Batch, Heads, SeqLen, Dhead)    sdpa-latency    flash_v2-latency    flex_attention-latency
-------------------------------  --------------  ------------------  ------------------------
             (32, 16, 512, 128)        0.24512             0.236768                  0.257984
            (16, 16, 1024, 128)        0.442944            0.41968                   0.419008
             (8, 16, 2048, 128)        0.845728            0.798688                  0.74368
             (4, 16, 4096, 128)        1.65574             1.55882                   1.4041
             (2, 16, 8192, 128)        3.27904             3.08669                   2.73846
            (1, 16, 16384, 128)        6.55098             6.14246                   5.38931

+ python ./run_benchmark.py triton --op flash_attention --d-head 128 --only sdpa,flash_v2,flex_attention --causal
  (Batch, Heads, SeqLen, Dhead)    sdpa-latency    flash_v2-latency    flex_attention-latency
-------------------------------  --------------  ------------------  ------------------------
             (32, 16, 512, 128)        0.199136            0.187424                  0.201632
            (16, 16, 1024, 128)        0.298208            0.278048                  0.28912
             (8, 16, 2048, 128)        0.51504             0.481088                  0.46528
             (4, 16, 4096, 128)        0.9584              0.890688                  0.82928
             (2, 16, 8192, 128)        1.84317             1.70605                   1.55763
            (1, 16, 16384, 128)        3.62157             3.34694                   3.02374

+ python ./run_benchmark.py triton --op flash_attention --d-head 128 --only sdpa,flash_v2,flex_attention --bwd
  (Batch, Heads, SeqLen, Dhead)    sdpa-latency    flash_v2-latency    flex_attention-latency
-------------------------------  --------------  ------------------  ------------------------
             (32, 16, 512, 128)         1.36323             1.30051                   0.94192
            (16, 16, 1024, 128)         1.89187             1.80678                   1.40486
             (8, 16, 2048, 128)         2.93325             2.83165                   2.33082
             (4, 16, 4096, 128)         5.05456             4.91002                   4.19229
             (2, 16, 8192, 128)         9.34131             9.10381                   7.87952
            (1, 16, 16384, 128)        17.9824             17.5658                   15.4029

+ python ./run_benchmark.py triton --op flash_attention --d-head 128 --only sdpa,flash_v2,flex_attention --bwd --causal
  (Batch, Heads, SeqLen, Dhead)    sdpa-latency    flash_v2-latency    flex_attention-latency
-------------------------------  --------------  ------------------  ------------------------
             (32, 16, 512, 128)         1.14022             1.07926                  0.838688
            (16, 16, 1024, 128)         1.41398             1.33376                  1.06554
             (8, 16, 2048, 128)         1.97437             1.87725                  1.53197
             (4, 16, 4096, 128)         3.08925             2.95606                  2.48413
             (2, 16, 8192, 128)         5.28237             5.08138                  4.37834
            (1, 16, 16384, 128)         9.27056             8.94672                  8.24531
```