### PR TITLE
Turn on TMA by default for row-wise GEMM

### DIFF
--- a/torchbenchmark/operators/fp8_gemm_rowwise/operator.py
+++ b/torchbenchmark/operators/fp8_gemm_rowwise/operator.py
@@ -24,7 +24,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--no_fp8_fast_accum", dest="fp8_fast_accum", action="store_false"
     )
-    parser.add_argument("--use_tma", action="store_true")
+    parser.add_argument("--no_use_tma", dest="use_tma", action="store_false")
     args = parser.parse_args(args)
     return args
 


### PR DESCRIPTION
Summary: Enabling the TMA row-wise GEMM by default it TMA appears to give quite some speedup across-the-board, up to 40% for some shapes.

Differential Revision: D62212842
