### PR TITLE
Add HSTU kernel repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/ThunderKittens"]
 	path = submodules/ThunderKittens
 	url = https://github.com/HazyResearch/ThunderKittens.git
+[submodule "submodules/generative-recommenders"]
+	path = submodules/generative-recommenders
+	url = https://github.com/facebookresearch/generative-recommenders.git

--- a/torchbenchmark/operators/addmm/hstu.py
+++ b/torchbenchmark/operators/addmm/hstu.py
@@ -1,0 +1,88 @@
+import importlib
+
+from typing import Tuple
+
+import torch
+import triton
+from torchbenchmark import add_path, SUBMODULE_PATH
+
+with add_path(str(SUBMODULE_PATH)):
+    triton_addmm = importlib.import_module(
+        "generative-recommenders.ops.triton.triton_addmm"
+    )
+    _addmm_fwd = triton_addmm._addmm_fwd
+
+
+class _AddMmFunction(torch.autograd.Function):
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        w: torch.Tensor,
+        y: torch.Tensor,
+    ) -> torch.Tensor:
+        M, K = x.shape
+        KB, N = w.shape
+        assert K == KB, f"incompatible dimensions {K}, {KB}"
+
+        is_y_1d = y.dim() == 1
+        NY = y.shape[0] if is_y_1d else y.shape[1]
+        assert N == NY, f"incompatible dimensions {N}, {NY}"
+
+        # Allocate output
+        z = torch.empty((M, N), device=x.device, dtype=x.dtype)
+        if M == 0 or N == 0:
+            ctx.save_for_backward(x, w)
+            ctx.is_y_1d = False
+            return z
+
+        def grid(META):
+            return (triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),)
+
+        _addmm_fwd[grid](
+            x,
+            w,
+            y,
+            z,
+            M,
+            N,
+            K,
+            x.stride(0),
+            x.stride(1),
+            w.stride(0),
+            w.stride(1),
+            y.stride(0) if not is_y_1d else 0,
+            y.stride(1) if not is_y_1d else y.stride(0),
+            z.stride(0),
+            z.stride(1),
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            BROADCAST_Y=is_y_1d,
+        )
+        ctx.save_for_backward(x, w)
+        ctx.is_y_1d = is_y_1d
+        return z
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        ctx, dz: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        (x, w) = ctx.saved_tensors
+        if ctx.is_y_1d:
+            dy = torch.sum(dz, dim=0)
+        else:
+            dy = dz
+        dw = torch.mm(x.t(), dz)
+        dx = torch.mm(dz, w.t())
+
+        return dx, dw, dy
+
+
+@torch.fx.wrap
+def triton_addmm(
+    input: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+) -> torch.Tensor:
+    return _AddMmFunction.apply(mat1, mat2, input)

--- a/torchbenchmark/operators/addmm/operator.py
+++ b/torchbenchmark/operators/addmm/operator.py
@@ -7,7 +7,12 @@ import numpy
 import torch
 import torch._inductor.config as inductor_config
 import triton
-from hammer.ops.triton.triton_hstu_linear import _addmm_fwd, triton_addmm
+from torchbenchmark import add_path, SUBMODULE_PATH
+
+try:
+    from hammer.ops.triton.triton_hstu_linear import triton_addmm
+except ModuleNotFoundError:
+    from .hstu import triton_addmm
 
 from torchbenchmark.util.triton_op import (
     BenchmarkOperator,


### PR DESCRIPTION
Enable HSTU kernels in the OSS.

Test plan:

```
$ python run_benchmark.py triton --op addmm 

         (M, N, K)    aten_addmm-best_config    aten_addmm-gbps    aten_addmm-tflops                                                                                       triton_addmm-best_config    triton_addmm-gbps    triton_addmm-tflops    pt2_triton_matmul-best_config    pt2_triton_matmul-gbps    pt2_triton_matmul-tflops
------------------  ------------------------  -----------------  -------------------  -------------------------------------------------------------------------------------------------------------  -------------------  ---------------------  -------------------------------  ------------------------  --------------------------
(20120, 512, 1536)                                      1160.11              351.026  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1216.43                368.066                                                    1308.75                     396.001
(34579, 512, 1536)                                      1125.96              342.85   {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1224.4                 372.823                                                    1298.57                     395.408
(34839, 512, 1536)                                      1124.87              342.539  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1219.59                371.382                                                    1306.15                     397.743
(35561, 512, 1536)                                      1139.21              346.967  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1249.18                380.461                                                    1306.04                     397.779
(35916, 512, 1536)                                      1143.34              348.254  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1260.98                384.087                                                    1320.5                      402.218
(19735, 512, 1536)                                      1138.85              344.491  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1203.84                364.152                                                    1298.74                     392.859
(34533, 512, 1536)                                      1123.04              341.956  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1216.59                370.441                                                    1295.59                     394.497
(35791, 512, 1536)                                      1139.15              346.97   {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1248.83                380.377                                                    1313.14                     399.965
(35844, 512, 1536)                                      1140.38              347.348  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1253.16                381.699                                                    1317.08                     401.168
(20116, 512, 1536)                                      1161.16              351.342  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1213.56                367.198                                                    1318.74                     399.024
(33887, 512, 1536)                                      1154.66              351.525  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1203.08                366.267                             
1292.43                     393.468
(20203, 512, 1536)                                      1147.38              347.197  {'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64, 'GROUP_M': 8, 'num_warps': 8, 'num_ctas': 1, 'num_stages': 3}              1218.65                368.761                                                    1321.78                     399.968
```