### PR TITLE
[tritonbench] make --dump-ir also dump sass

### DIFF
--- a/torchbenchmark/util/triton_op.py
+++ b/torchbenchmark/util/triton_op.py
@@ -1155,3 +1155,11 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         ir_dir / f"{fn._name}_{kernel.name}_{input_id}.{ir}", "w"
                     ) as f:
                         f.write(kernel.asm[ir])
+            if "cubin" in kernel.asm:
+                from triton.tools.disasm import get_sass
+
+                sass = get_sass(kernel.asm["cubin"])
+                with open(
+                    ir_dir / f"{fn._name}_{kernel.name}_{input_id}.sass", "w"
+                ) as f:
+                    f.write(sass)


### PR DESCRIPTION
Triton has a `get_sass` utility that disassembles the cubin and gets the sass - in this PR, we try to use `get_sass` when running with `--dump-ir`, if we can find a cubin file.