### PR TITLE
Ignore Torchbench CI on Tritonbench paths

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,6 +1,11 @@
 name: TorchBench PR Test
 on:
   pull_request:
+    # ignore tritonbench paths
+    paths-ignore:
+      - 'torchbenchmark/operators'
+      - 'torchbenchmark/util/triton_op.py'
+      - 'userbenchmark/triton'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches:
       - main
+    # ignore tritonbench paths
+    paths-ignore:
+      - 'torchbenchmark/operators'
+      - 'torchbenchmark/util/triton_op.py'
+      - 'userbenchmark/triton'
 
 jobs:
   cpu-test:


### PR DESCRIPTION
Right now, Tritonbench is still sharing codebase with Torchbench.
Skip the Torchbench tests when the PR is on Tritonbench paths.