### PR TITLE
Add optional flag_gems support

### DIFF
--- a/torchbenchmark/operators/addmm/operator.py
+++ b/torchbenchmark/operators/addmm/operator.py
@@ -14,6 +14,13 @@ try:
 except ModuleNotFoundError:
     from .hstu import triton_addmm
 
+
+try:
+    from flag_gems.ops.addmm import addmm as flaggems_addmm
+    HAS_FLAGGEMS =True
+except ModuleNotFoundError:
+    HAS_FLAGGEMS = False
+
 from torchbenchmark.util.triton_op import (
     BenchmarkOperator,
     BenchmarkOperatorMetrics,
@@ -111,6 +118,10 @@ class Operator(BenchmarkOperator):
             compiled = torch.compile(f, dynamic=False)
             compiled(a, mat1, mat2)
         return lambda: compiled(a, mat1, mat2)
+
+    @register_benchmark(enabled=HAS_FLAGGEMS)
+    def flaggems(self, a, mat1, mat2) -> Callable:
+        return lambda: flaggems_addmm(a, mat1, mat2)
 
     @register_metric()
     def gbps(

--- a/userbenchmark/triton/install.py
+++ b/userbenchmark/triton/install.py
@@ -73,6 +73,10 @@ def install_liger():
     subprocess.check_call(cmd)
 
 
+def install_flaggems():
+    cmd = ["pip", "install", "git+https://github.com/FlagOpen/FlagGems.git@0534d4d"]
+    subprocess.check_call(cmd)
+
 def install_tk():
     try:
         from .tk.install import install_tk
@@ -96,6 +100,7 @@ if __name__ == "__main__":
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
     parser.add_argument("--tk", action="store_true", help="Install ThunderKittens")
     parser.add_argument("--liger", action="store_true", help="Install Liger-kernel")
+    parser.add_argument("--flaggems", action="store_true", help="Install FlagGems")
     parser.add_argument("--test", action="store_true", help="Run test")
     args = parser.parse_args()
 
@@ -115,3 +120,5 @@ if __name__ == "__main__":
         install_tk()
     if args.liger and not args.test:
         install_liger()
+    if args.flaggems and not args.test:
+        install_flaggems()


### PR DESCRIPTION
Import optional Triton kernels FlagGems: https://github.com/FlagOpen/FlagGems.
Support softmax and addmm operators.


Test plan:

```
$ python run_benchmark.py triton --op addmm --only flaggems,triton_addmm --num-inputs 2 --metrics latency,gbps,tflops
         (M, N, K)    flaggems-gbps    flaggems-latency    flaggems-tflops    triton_addmm-gbps    triton_addmm-latency    triton_addmm-tflops
------------------  ---------------  ------------------  -----------------  -------------------  ----------------------  ---------------------
(20120, 512, 1536)          220.794            0.473686            66.808               234.791                0.445449                71.043
(34579, 512, 1536)          224.696            0.79493             68.4186              231.003                0.773224                70.3393

```