### PR TITLE
Add custom ops kl_div and swiglu

### DIFF
--- a/torchbenchmark/operators/kl_div/__init__.py
+++ b/torchbenchmark/operators/kl_div/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/kl_div/operator.py
+++ b/torchbenchmark/operators/kl_div/operator.py
@@ -1,0 +1,54 @@
+import argparse
+from typing import Callable, Generator, List, Optional
+
+import torch
+
+from torchbenchmark.util.triton_op import BenchmarkOperator, register_benchmark
+
+try:
+    from liger_kernel.transformers.kl_div import LigerKLDIVLoss
+except ModuleNotFoundError:
+    LigerKLDIVLoss = None
+
+# Reference: https://github.com/linkedin/Liger-Kernel/
+# blob/main/benchmark/scripts/benchmark_kl_div.py
+
+
+class Operator(BenchmarkOperator):
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ):
+        super().__init__(tb_args, extra_args)
+        self.B = 8
+        self.T = 512
+        self.baseline_op = torch.nn.KLDivLoss(reduction="batchmean").to(self.device)
+        self.liger_op = LigerKLDIVLoss(reduction="batchmean").to(self.device)
+        self.use_cuda_graphs = False
+
+    def get_input_iter(self) -> Generator:
+        for V in [2**i for i in range(12, 18)]:
+            _input = torch.randn(
+                self.B * self.T, V, requires_grad=True, device=self.device
+            ).log_softmax(dim=-1)
+            target = torch.randn(self.B * self.T, V, device=self.device).softmax(dim=-1)
+            yield _input, target
+
+    @register_benchmark(baseline=True)
+    def torch_kl_div(self, input, target) -> Callable:
+        return lambda: self.baseline_op(input, target)
+
+    @register_benchmark()
+    def liger_kl_div(self, input, target) -> Callable:
+        return lambda: self.liger_op(input, target)
+
+    @register_benchmark()
+    def inductor_kl_div(self, input, target) -> Callable:
+        compiled = torch.compile(self.baseline_op, dynamic=False)
+        return lambda: compiled(input, target)
+
+    def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
+        y = fwd_fn()
+        return lambda: y.backward(retain_graph=True)
+
+    def get_grad_to_none(self, args) -> List[torch.Tensor]:
+        return [args[0]]

--- a/torchbenchmark/operators/swiglu/__init__.py
+++ b/torchbenchmark/operators/swiglu/__init__.py
@@ -1,0 +1,1 @@
+from .operator import Operator

--- a/torchbenchmark/operators/swiglu/operator.py
+++ b/torchbenchmark/operators/swiglu/operator.py
@@ -1,0 +1,65 @@
+import argparse
+from typing import Callable, Generator, List, Optional
+
+import torch
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaMLP
+
+from torchbenchmark.util.triton_op import BenchmarkOperator, register_benchmark
+
+try:
+    from liger_kernel.transformers.swiglu import LigerSwiGLUMLP
+except ModuleNotFoundError:
+    LigerSwiGLUMLP = None
+
+# Reference: https://github.com/linkedin/Liger-Kernel/
+# blob/main/benchmark/scripts/benchmark_swiglu.py
+
+
+class Operator(BenchmarkOperator):
+    def __init__(
+        self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
+    ):
+        super().__init__(tb_args, extra_args)
+        self.B = 4
+        self.hidden_size = 4096
+        self.dtype = torch.bfloat16
+        self.intermediate_size = 11008
+        self.hidden_act = "silu"
+        llama_config = LlamaConfig(
+            hidden_size=self.hidden_size,
+            intermediate_size=self.intermediate_size,
+            hidden_act=self.hidden_act,
+        )
+        self.baseline_op = LlamaMLP(config=llama_config).to(self.device).to(self.dtype)
+        self.liger_op = (
+            LigerSwiGLUMLP(config=llama_config).to(self.device).to(self.dtype)
+        )
+        self.use_cuda_graphs = False
+
+    def get_input_iter(self) -> Generator:
+        for seq_len in [2**i for i in range(10, 14)]:
+            x_shape = (self.B, seq_len, self.hidden_size)
+            x = torch.randn(
+                *x_shape, device=self.device, dtype=self.dtype, requires_grad=True
+            )
+
+            yield (x,)
+
+    @register_benchmark(baseline=True)
+    def torch_swiglu(self, input) -> Callable:
+        return lambda: self.baseline_op(input)
+
+    @register_benchmark()
+    def liger_swiglu(self, input) -> Callable:
+        return lambda: self.liger_op(input)
+
+    @register_benchmark()
+    def inductor_swiglu(self, input) -> Callable:
+        compiled = torch.compile(self.baseline_op, dynamic=False)
+        return lambda: compiled(input)
+
+    def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
+        y = fwd_fn()
+        # TODO: we should get rid of this randn_like
+        return lambda: y.backward(torch.randn_like(y), retain_graph=True)

--- a/torchbenchmark/operators/swiglu/operator.py
+++ b/torchbenchmark/operators/swiglu/operator.py
@@ -61,5 +61,5 @@ class Operator(BenchmarkOperator):
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()
-        # TODO: we should get rid of this randn_like
-        return lambda: y.backward(torch.randn_like(y), retain_graph=True)
+        do = torch.randn_like(y)
+        return lambda: y.backward(do, retain_graph=True)

--- a/torchbenchmark/operators/swiglu/operator.py
+++ b/torchbenchmark/operators/swiglu/operator.py
@@ -63,3 +63,6 @@ class Operator(BenchmarkOperator):
         y = fwd_fn()
         do = torch.randn_like(y)
         return lambda: y.backward(do, retain_graph=True)
+
+    def get_grad_to_none(self, args) -> List[torch.Tensor]:
+        return [args[0]]

--- a/torchbenchmark/operators_collection/liger/__init__.py
+++ b/torchbenchmark/operators_collection/liger/__init__.py
@@ -1,4 +1,4 @@
-liger_operators = ["FusedLinearCrossEntropy"]
+liger_operators = ["FusedLinearCrossEntropy", "kl_div", "swiglu"]
 
 
 def get_operators():


### PR DESCRIPTION
Add kl_div and swiglu from liger kernel

Test Plan:

```
% python run_benchmark.py triton --op swiglu  --num-inputs 1
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.55s/it]
  x_val    torch_swiglu-latency    liger_swiglu-latency    inductor_swiglu-latency
-------  ----------------------  ----------------------  -------------------------
      0                 3.23677                 3.37923                    3.30358
% python run_benchmark.py triton --op kl_div  --num-inputs 1 --fwd_bwd
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.34s/it]
  x_val    torch_kl_div-latency    liger_kl_div-latency    inductor_kl_div-latency
-------  ----------------------  ----------------------  -------------------------
      0                0.762816                0.538752                   0.409888
```