### PR TITLE
Add `--device_only` arg to `test_benchmark.py`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Run benchmarks on mps only and ignore machine configuration checks",
     )
+    parser.addoption(
+        "--device_only",
+        action="store",
+        default=None,
+        help="Run benchmarks on the specific device only and ignore machine configuration checks",
+    )
 
 
 def set_fuser(fuser):

--- a/test_bench.py
+++ b/test_bench.py
@@ -31,6 +31,9 @@ def pytest_generate_tests(metafunc):
     if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         devices.append("mps")
 
+    if device_only := metafunc.config.option.device_only:
+        devices = [device_only]
+
     if metafunc.config.option.cpu_only:
         devices = ["cpu"]
 


### PR DESCRIPTION
I noticed that `test_benchmark.py` only supports there devices: `cpu`, `cuda` and `mps`. And I think there should be a power to allow users to run benchmarks on other devices (e.g. `xpu`, `npu`, etc.). So I added an `--device_only` arg which can receive a string. Running `pytest test_bench.py --device_only foo` will make benchmarks to run on the foo device.

BTW, `test.py` use `ACCELERATOR ` environment variable to custom devices, should we make consistent?

https://github.com/pytorch/benchmark/blob/75c0f311423989108cbfead8f5e7f4d326762157/test.py#L174-L175
