### PR TITLE
[Device] Add more devices to `torchbenchmark.util.experiment.instantiator.list_devices()`

### DIFF
--- a/torchbenchmark/util/experiment/instantiator.py
+++ b/torchbenchmark/util/experiment/instantiator.py
@@ -122,8 +122,8 @@ def list_devices() -> List[str]:
     devices = ["cpu"]
     import torch
 
-    if torch.cuda.is_available():
-        devices.append("cuda")
+    if device_type := torch._utils._get_available_device_type():
+        devices.append(device_type)
     return devices
 
 

--- a/torchbenchmark/util/experiment/instantiator.py
+++ b/torchbenchmark/util/experiment/instantiator.py
@@ -122,7 +122,8 @@ def list_devices() -> List[str]:
     devices = ["cpu"]
     import torch
 
-    if device_type := torch._utils._get_available_device_type():
+    device_type = torch._C._get_accelerator().type
+    if device_type != "cpu":
         devices.append(device_type)
     return devices
 

--- a/torchbenchmark/util/experiment/metrics.py
+++ b/torchbenchmark/util/experiment/metrics.py
@@ -82,7 +82,7 @@ def get_peak_memory(
         raise ValueError(
             f"Expected metrics_needed to be non-empty, get: {metrics_needed}"
         )
-    if metrics_gpu_backend in ["dcgm", "nvml"]:
+    if device == "cuda" and metrics_gpu_backend in ["dcgm", "nvml"]:
         from torchbenchmark._components.model_analyzer.TorchBenchAnalyzer import (
             ModelAnalyzer,
         )


### PR DESCRIPTION
from https://github.com/pytorch/benchmark/issues/2543#issuecomment-2487216599

This change will allow all userbenchmarks to run on available devices.

## Userbenchmark - test_bench - BERT_pytorch

cuda:

```
$ python run_benchmark.py test_bench --models BERT_pytorch --device cuda
Running TorchBenchModelConfig(name='BERT_pytorch', test='eval', device='cuda', batch_size=None, extra_args=[], extra_env=None, output_dir=None) ... [done]
{
    "name": "test_bench",
    "environ": {
        "pytorch_git_version": "ac47a2d9714278889923ddd40e4210d242d8d4ee",
        "pytorch_version": "2.6.0.dev20241121+cu124",
        "device": "Tesla T4"
    },
    "metrics": {
        "model=BERT_pytorch, test=eval, device=cuda, bs=None, extra_args=[], metric=latencies": 122.69141,
        "model=BERT_pytorch, test=eval, device=cuda, bs=None, extra_args=[], metric=cpu_peak_mem": 0.6962890625,
        "model=BERT_pytorch, test=eval, device=cuda, bs=None, extra_args=[], metric=gpu_peak_mem": 1.573486328125
    }
}
```

mps:

```
$ python run_benchmark.py test_bench --models BERT_pytorch --device mps
Running TorchBenchModelConfig(name='BERT_pytorch', test='eval', device='mps', batch_size=None, extra_args=[], extra_env=None, output_dir=None) ... [done]
{
    "name": "test_bench",
    "environ": {
        "pytorch_git_version": "dd2e6d61409aac22198ec771560a38adb0018ba2",
        "pytorch_version": "2.6.0.dev20241120"
    },
    "metrics": {
        "model=BERT_pytorch, test=eval, device=mps, bs=None, extra_args=[], metric=latencies": 133.299,
        "model=BERT_pytorch, test=eval, device=mps, bs=None, extra_args=[], metric=cpu_peak_mem": 19.832832,
        "model=BERT_pytorch, test=eval, device=mps, bs=None, extra_args=[], metric=gpu_peak_mem": "failed"
    }
}
```

ascend npu:

```
python run_benchmark.py test_bench --models BERT_pytorch --device npu
Running TorchBenchModelConfig(name='BERT_pytorch', test='eval', device='npu', batch_size=None, extra_args=[], extra_env=None, output_dir=None) ... [done]
{
    "name": "test_bench",
    "environ": {
        "pytorch_git_version": "64141411e0de61b61857e216ae7a8766f4f5969b",
        "pytorch_version": "2.6.0.dev20240923"
    },
    "metrics": {
        "model=BERT_pytorch, test=eval, device=npu, bs=None, extra_args=[], metric=latencies": 21.688104,
        "model=BERT_pytorch, test=eval, device=npu, bs=None, extra_args=[], metric=cpu_peak_mem": 47.261696,
        "model=BERT_pytorch, test=eval, device=npu, bs=None, extra_args=[], metric=gpu_peak_mem": "failed"
    }
}
```



cc: @xuzhao9 @jgong5 @FFFrog