### PR TITLE
[Userbenchmark] Add `--skip` arg for `test_bench`

### DIFF
--- a/torchbenchmark/util/experiment/instantiator.py
+++ b/torchbenchmark/util/experiment/instantiator.py
@@ -31,6 +31,7 @@ class TorchBenchModelConfig:
     extra_args: List[str]
     extra_env: Optional[Dict[str, str]] = None
     output_dir: Optional[pathlib.Path] = None
+    skip: bool = False
 
 
 def _set_extra_env(extra_env):


### PR DESCRIPTION
### Usage

```
python run_benchmark.py test_bench --accuracy -d mps --models BERT_pytorch,hf_GPT2 --skip BERT_pytorch --output result.json
```

### Result

```
$ python run_benchmark.py test_bench --accuracy -d mps --models BERT_pytorch,hf_GPT2 --skip BERT_pytorch --output result.json
Running TorchBenchModelConfig(name='BERT_pytorch', test='eval', device='mps', batch_size=None, extra_args=['--accuracy'], extra_env=None, output_dir=None, skip=True) ... [skip]
Running TorchBenchModelConfig(name='hf_GPT2', test='eval', device='mps', batch_size=None, extra_args=['--accuracy'], extra_env=None, output_dir=None, skip=False) ... [done]
{
    "name": "test_bench",
    "environ": {
        "pytorch_git_version": "dd2e6d61409aac22198ec771560a38adb0018ba2",
        "pytorch_version": "2.6.0.dev20241120"
    },
    "metrics": {
        "model=BERT_pytorch, test=eval, device=mps, bs=None, extra_args=['--accuracy'], metric=accuracy": "skip",
        "model=hf_GPT2, test=eval, device=mps, bs=None, extra_args=['--accuracy'], metric=accuracy": "pass"
    }
}
```