### PR TITLE
Run optim benchmarks on new runner

### DIFF
--- a/.github/workflows/userbenchmark-regression-detector.yml
+++ b/.github/workflows/userbenchmark-regression-detector.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-userbenchmark:
-    runs-on: [a100-runner]
+    runs-on: linux.aws.a100
     timeout-minutes: 1440 # 24 hours
     environment: docker-s3-upload
     env:


### PR DESCRIPTION
Workflow has been failing due to runner migration, this should be the right one now.