### PR TITLE
NotImplementedError: Model's DEFAULT_TRAIN_BSIZE is not implemented.

### DIFF
--- a/torchbenchmark/models/cm3leon_generate/__init__.py
+++ b/torchbenchmark/models/cm3leon_generate/__init__.py
@@ -7,6 +7,7 @@ from .model import create_model, SequenceGenerator
 
 class Model(BenchmarkModel):
     task = NLP.LANGUAGE_MODELING
+    DEFAULT_TRAIN_BSIZE = 1
     DEFAULT_EVAL_BSIZE = 1
 
     def __init__(self, test, device, batch_size=None, extra_args=[]):


### PR DESCRIPTION
Some tests fail in train mode. I found missing fields in specific models and added DEFAULT_TRAIN_BSIZE with the same value as eval batch size. 