### PR TITLE
Deleting recursion loop for fambench_xlmr

### DIFF
--- a/torchbenchmark/canary_models/fambench_xlmr/install.py
+++ b/torchbenchmark/canary_models/fambench_xlmr/install.py
@@ -21,7 +21,6 @@ def update_fambench_submodule():
 
 def pip_install_requirements():
     try:
-        pip_install_requirements()
         # pin fairseq version
         # ignore deps specified in requirements.txt
         subprocess.check_call(


### PR DESCRIPTION
The installation helper function `pip_install_requirements` for `fambench_xlmr` keeps calling itself resulting in indefinite recursion loops (`RecursionError: maximum recursion depth exceeded`). This fixes it and finishes the installation.