### PR TITLE
Cast inputs type to dictionary.

### DIFF
--- a/torchbenchmark/models/hf_clip/__init__.py
+++ b/torchbenchmark/models/hf_clip/__init__.py
@@ -51,9 +51,9 @@ class Model(BenchmarkModel):
         text = "the dog is here"
         images = [image] * self.batch_size
         texts = [text] * self.batch_size
-        self.inputs = processor(
+        self.inputs = dict(processor(
             text=texts, images=images, return_tensors="pt", padding=True
-        )
+        ))
 
         # dict_keys(['input_ids', 'attention_mask', 'pixel_values'])
         for key in self.inputs:


### PR DESCRIPTION
I run some tests of hf_clip model using torchbench.py (https://github.com/pytorch/pytorch/blob/main/benchmarks/dynamo/torchbench.py). This script at one point clones input data with custom function (https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/utils.py, L1926):

```python
def clone_inputs(example_inputs):
    res: Union[dict[Any, Any], list[Any]]
    if type(example_inputs) is dict:
        res = dict(example_inputs)
        for key, value in res.items():
            if isinstance(value, tuple):
                res[key] = clone_inputs(value)
            else:
                assert isinstance(value, torch.Tensor), type(value)
                res[key] = clone_input(value)
        return res

    res = list(example_inputs)
    for i in range(len(res)):
        if isinstance(res[i], torch.Tensor):
            res[i] = clone_input(res[i])
    return res
```

hf_clip model generates example data using 'CLIPProcessor' class imported from transformers repo. We can use this data as a dictionary, but officialy its type is BatchEncoding (<class 'transformers.tokenization_utils_base.BatchEncoding'>). When clone_inputs() compares input types it doesn't see it as a dict type. Hence, it casts the data to list and returns only its keys leading to error: _AttributeError: 'str' object has no attribute 'shape'_

I proposed simple casting to dict in model's __init__ script. This fixed the issue and doesn't affect other test scripts.