### PR TITLE
Changing llama_v2_70b to correct config class

### DIFF
--- a/torchbenchmark/util/framework/huggingface/basic_configs.py
+++ b/torchbenchmark/util/framework/huggingface/basic_configs.py
@@ -135,7 +135,7 @@ HUGGINGFACE_MODELS = {
         512,
         512,
         'AutoConfig.from_pretrained("meta-llama/Llama-2-70b-hf")',
-        "AutoModelForMaskedLM",
+        "AutoModelForCausalLM",
     ),
     "llama_v31_8b": (
         512,


### PR DESCRIPTION
The model `llama_v2_70b` fails to install with `ValueError: Unrecognized configuration class` because it has been listed as the wrong config class. It should be listed as a Causal Language Model instead.