### PR TITLE
Handling of skip category of tests

### DIFF
--- a/test_bench.py
+++ b/test_bench.py
@@ -69,7 +69,7 @@ class TestBenchNetwork:
                 extra_args=[],
                 metadata=get_metadata_from_yaml(model_path),
             ):
-                pytest.skip(f"Test train on {device} is not implemented, skipping...")
+                pytest.skip(f"Test train on {device} is skipped by its metadata skipping...")
             # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
             # api, enable after PyTorch 1.13 release
             if "quantized" in model_name:
@@ -91,7 +91,7 @@ class TestBenchNetwork:
             if isinstance(e, NotImplementedError):
                 print(f"Test train on {device} is not implemented")
             else:
-                print(f"Exception occured due to: {e}")
+                pytest.fail(f"Test train failed on {device} due to this error: {e}")
 
     def test_eval(self, model_path, device, benchmark, pytestconfig):
         try:
@@ -102,7 +102,7 @@ class TestBenchNetwork:
                 extra_args=[],
                 metadata=get_metadata_from_yaml(model_path),
             ):
-                pytest.skip(f"Test eval on {device} is not implemented, skipping...")
+                pytest.skip(f"Test eval on {device} is skipped by its metadata skipping...")
             # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
             # api, enable after PyTorch 1.13 release
             if "quantized" in model_name:
@@ -125,7 +125,7 @@ class TestBenchNetwork:
             if isinstance(e, NotImplementedError):
                 print(f"Test eval on {device} is not implemented")
             else:
-                print(f"Exception occured due to: {e}")
+                pytest.fail(f"Test eval failed on {device} due to this error: {e}")
 
 
 @pytest.mark.benchmark(

--- a/test_bench.py
+++ b/test_bench.py
@@ -69,7 +69,7 @@ class TestBenchNetwork:
                 extra_args=[],
                 metadata=get_metadata_from_yaml(model_path),
             ):
-                raise NotImplementedError("Test skipped by its metadata.")
+                pytest.skip(f"Test train on {device} is not implemented, skipping...")
             # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
             # api, enable after PyTorch 1.13 release
             if "quantized" in model_name:
@@ -88,9 +88,7 @@ class TestBenchNetwork:
             benchmark.extra_info["test"] = "train"
 
         except Exception as e:
-            if "skip" in str(e).lower():
-                pytest.skip(f"Test train on {device} is not implemented, skipping...")
-            elif isinstance(e, NotImplementedError):
+            if isinstance(e, NotImplementedError):
                 print(f"Test train on {device} is not implemented")
             else:
                 print(f"Exception occured due to: {e}")
@@ -104,7 +102,7 @@ class TestBenchNetwork:
                 extra_args=[],
                 metadata=get_metadata_from_yaml(model_path),
             ):
-                raise NotImplementedError("Test skipped by its metadata.")
+                pytest.skip(f"Test eval on {device} is not implemented, skipping...")
             # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
             # api, enable after PyTorch 1.13 release
             if "quantized" in model_name:
@@ -124,9 +122,7 @@ class TestBenchNetwork:
             benchmark.extra_info["test"] = "eval"
 
         except Exception as e:
-            if "skip" in str(e).lower():
-                pytest.skip(f"Test eval on {device} is not implemented, skipping...")
-            elif isinstance(e, NotImplementedError):
+            if isinstance(e, NotImplementedError):
                 print(f"Test eval on {device} is not implemented")
             else:
                 print(f"Exception occured due to: {e}")

--- a/test_bench.py
+++ b/test_bench.py
@@ -88,8 +88,12 @@ class TestBenchNetwork:
             benchmark.extra_info["test"] = "train"
 
         except Exception as e:
-            print(f"Exception occured due to: {e}")
-            pytest.skip(f"Test train on {device} is not implemented, skipping...")
+            if "skip" in str(e).lower():
+                pytest.skip(f"Test train on {device} is not implemented, skipping...")
+            elif isinstance(e, NotImplementedError):
+                print(f"Test train on {device} is not implemented")
+            else:
+                print(f"Exception occured due to: {e}")
 
     def test_eval(self, model_path, device, benchmark, pytestconfig):
         try:
@@ -120,8 +124,12 @@ class TestBenchNetwork:
             benchmark.extra_info["test"] = "eval"
 
         except Exception as e:
-            print(f"Exception occured due to: {e}")
-            pytest.skip(f"Test train on {device} is not implemented, skipping...")
+            if "skip" in str(e).lower():
+                pytest.skip(f"Test eval on {device} is not implemented, skipping...")
+            elif isinstance(e, NotImplementedError):
+                print(f"Test eval on {device} is not implemented")
+            else:
+                print(f"Exception occured due to: {e}")
 
 
 @pytest.mark.benchmark(

--- a/test_bench.py
+++ b/test_bench.py
@@ -87,8 +87,9 @@ class TestBenchNetwork:
             )
             benchmark.extra_info["test"] = "train"
 
-        except NotImplementedError:
-            print(f"Test train on {device} is not implemented, skipping...")
+        except Exception as e:
+            print(f"Exception occured due to: {e}")
+            pytest.skip(f"Test train on {device} is not implemented, skipping...")
 
     def test_eval(self, model_path, device, benchmark, pytestconfig):
         try:
@@ -118,8 +119,9 @@ class TestBenchNetwork:
             )
             benchmark.extra_info["test"] = "eval"
 
-        except NotImplementedError:
-            print(f"Test eval on {device} is not implemented, skipping...")
+        except Exception as e:
+            print(f"Exception occured due to: {e}")
+            pytest.skip(f"Test train on {device} is not implemented, skipping...")
 
 
 @pytest.mark.benchmark(


### PR DESCRIPTION
many test got skipped either due to metadat.yaml or any other reason but at the end showing result passed instead of skipped
so these change will help to distinguish genuine skipped vs real passed models 