### PR TITLE
Fix: Ensure install_diffusers() is called before HUGGING FACE token check

### DIFF
--- a/torchbenchmark/canary_models/stable_diffusion_xl/install.py
+++ b/torchbenchmark/canary_models/stable_diffusion_xl/install.py
@@ -16,10 +16,10 @@ def load_model_checkpoint():
 
 
 if __name__ == "__main__":
+    install_diffusers()
     if not "HUGGING_FACE_HUB_TOKEN" in os.environ:
         warnings.warn(
             "Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights"
         )
     else:
-        install_diffusers()
         load_model_checkpoint()


### PR DESCRIPTION
stable_diffusion_xl model is failing to run in both eager and compile mode because it's missing the diffusers import requirement.

The proposed fix will runinstall_diffusers() before error checking for the HUGGING FACE token.