### PR TITLE
Add --output-warmup-metrics flag to cpu userbenchmark scripts

### DIFF
--- a/userbenchmark/cpu/README.md
+++ b/userbenchmark/cpu/README.md
@@ -32,6 +32,7 @@ All parameters of `cpu` userbenchmark as below,
 - `--niter` benchmark iteration number. Default value is 30.
 - `--output, -o` output dir. By default will create folder under
   `.userbenchmark/cpu`.
+- `--output-warmup-metrics` include warmup metrics in output.
 - `--output-iter-metrics` include per-iteration metrics in output.
 - `--timeout` limit single model test run time. Default `None` means no
   limitation.

--- a/userbenchmark/cpu/cpu_utils.py
+++ b/userbenchmark/cpu/cpu_utils.py
@@ -118,33 +118,57 @@ def add_test_results(runs, result_metrics):
         run_base_name = f"{run['model']}-{run['test']}"
         ins_number = len(run["results"])
         assert ins_number
+        warmup_latency_metric = "warmup_latency" in run["results"][0]["metrics"]
         latency_metric = "latency" in run["results"][0]["metrics"]
+        warmup_iter_latencies_metric = "warmup_iter_latencies" in run["results"][0]["metrics"]
         iter_latencies_metric = "iter_latencies" in run["results"][0]["metrics"]
+        warmup_throughput_metric = "warmup_throughput" in run["results"][0]["metrics"]
         throughput_metric = "throughput" in run["results"][0]["metrics"]
+        warmup_iter_throughputs_metric = "warmup_iter_throughputs" in run["results"][0]["metrics"]
         iter_throughputs_metric = "iter_throughputs" in run["results"][0]["metrics"]
         cmem_metric = "cpu_peak_mem" in run["results"][0]["metrics"]
+        warmup_latency_sum = 0
+        warmup_iter_latencies = []
         latency_sum = 0
         iter_latencies = []
+        warmup_throughput_sum = 0
+        warmup_iter_throughputs = []
         throughput_sum = 0
         iter_throughputs = []
         cmem_sum = 0
         for ins_res in run["results"]:
+            if warmup_latency_metric:
+                warmup_latency_sum += ins_res["metrics"]["warmup_latency"]
             if latency_metric:
                 latency_sum += ins_res["metrics"]["latency"]
+            if warmup_iter_latencies_metric:
+                warmup_iter_latencies += ins_res["metrics"]["warmup_iter_latencies"]
             if iter_latencies_metric:
                 iter_latencies += ins_res["metrics"]["iter_latencies"]
+            if warmup_throughput_metric:
+                warmup_throughput_sum += ins_res["metrics"]["warmup_throughput"]
             if throughput_metric:
                 throughput_sum += ins_res["metrics"]["throughput"]
+            if warmup_iter_throughputs_metric:
+                warmup_iter_throughputs += ins_res["metrics"]["warmup_iter_throughputs"]
             if iter_throughputs_metric:
                 iter_throughputs += ins_res["metrics"]["iter_throughputs"]
             if cmem_metric:
                 cmem_sum += ins_res["metrics"]["cpu_peak_mem"]
+        if warmup_latency_metric:
+            result_metrics[f"{run_base_name}_warmup_latency"] = warmup_latency_sum / ins_number
         if latency_metric:
             result_metrics[f"{run_base_name}_latency"] = latency_sum / ins_number
+        if warmup_iter_latencies_metric:
+            result_metrics[f"{run_base_name}_warmup_iter_latencies"] = warmup_iter_latencies
         if iter_latencies_metric:
             result_metrics[f"{run_base_name}_iter_latencies"] = iter_latencies
+        if warmup_throughput_metric:
+            result_metrics[f"{run_base_name}_warmup_throughput"] = warmup_throughput_sum
         if throughput_metric:
             result_metrics[f"{run_base_name}_throughput"] = throughput_sum
+        if warmup_iter_throughputs_metric:
+            result_metrics[f"{run_base_name}_warmup_iter_throughputs"] = warmup_iter_throughputs
         if iter_throughputs_metric:
             result_metrics[f"{run_base_name}_iter_throughputs"] = iter_throughputs
         if cmem_metric:


### PR DESCRIPTION
Adds a new `--output-warmup-metrics` flag which adds warmup metrics to benchmark result JSON files. This allows us to analyse warmup iterations and decide how many are enough.