### PR TITLE
[1/n][Optimus][Auto-AC] Support activation quantization without scaling

### DIFF
--- a/userbenchmark/dynamo/dynamobench/_dynamo/utils.py
+++ b/userbenchmark/dynamo/dynamobench/_dynamo/utils.py
@@ -4589,3 +4589,7 @@ def maybe_disable_inference_mode_for_fake_prop() -> Generator[None, None, None]:
             yield
     else:
         yield
+
+
+def is_node_meta_valid(node: Optional[torch.fx.Node]) -> bool:
+    return node is None or "example_value" in node.meta or "val" in node.meta


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/148380

We enable the activation quantization in the forward pass, and users can customize the dtype they want to quantize.

Differential Revision: D70522237


