### PR TITLE
Remove + signs from package versions

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -25,7 +25,7 @@ def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
     versions = {}
     for module in packages:
         cmd = [sys.executable, "-c", f"import {module}; print({module}.__version__)"]
-        version = subprocess.check_output(cmd).decode().strip()
+        version = subprocess.check_output(cmd).decode().split("+")[0].strip()
         versions[module] = version
     return versions
 


### PR DESCRIPTION
From the latest PyTorch installation via uv/pip, `torch.__version__` contains a cuda version appendix such as  `2.7.0+cu126`. This occurs a pip dependency conflict.

This pull request removes characters after the first plus sign.

<details>
    <summary>Error log</summary>

```
python install.py
checking packages numpy, torch, torchvision, torchaudio are installed, generating constaints...OK
Failed to install torchbenchmark requirements:
b"Collecting git+https://github.com/huggingface/pytorch-image-models.git@730b907 (from -r requirements.txt (line 12))\n  Cloning https://github.com/huggingface/pytorch-image-models.git (to revision 730b907) to /tmp/pip-req-build-843c4ldb\n  Running command git clone --filter=blob:none --quiet https://github.com/huggingface/pytorch-image-models.git /tmp/pip-req-build-843c4ldb\n  WARNING: Did not find branch or tag '730b907', assuming revision or ref.\n  Running command git checkout -q 730b907\n  Resolved https://github.com/huggingface/pytorch-image-models.git to commit 730b907\n  Installing build dependencies: started\n  Installing build dependencies: finished with status 'done'\n  Getting requirements to build wheel: started\n  Getting requirements to build wheel: finished with status 'done'\n  Preparing metadata (pyproject.toml): started\n  Preparing metadata (pyproject.toml): finished with status 'done'\nRequirement already satisfied: accelerate in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 1)) (1.6.0)\nRequirement already satisfied: boto3 in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 2)) (1.38.10)\nRequirement already satisfied: bs4 in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 3)) (0.0.2)\nRequirement already satisfied: patch in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 4)) (1.16)\nRequirement already satisfied: py-cpuinfo in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 5)) (9.0.0)\nRequirement already satisfied: distro in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 6)) (1.9.0)\nRequirement already satisfied: iopath in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 7)) (0.1.10)\nRequirement already satisfied: pytest in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 8)) (8.3.5)\nRequirement already satisfied: pytest-benchmark in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 9)) (5.1.0)\nRequirement already satisfied: requests in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 10)) (2.32.3)\nRequirement already satisfied: tabulate in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 11)) (0.9.0)\nRequirement already satisfied: transformers==4.44.2 in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 15)) (4.44.2)\nRequirement already satisfied: MonkeyType in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 16)) (23.3.0)\nRequirement already satisfied: psutil in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 17)) (7.0.0)\nRequirement already satisfied: pyyaml in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 18)) (6.0.2)\nRequirement already satisfied: numpy in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 19)) (2.2.5)\nRequirement already satisfied: opencv-python in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 20)) (4.11.0.86)\nRequirement already satisfied: submitit in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 21)) (1.5.2)\nRequirement already satisfied: pynvml>=12.0.0 in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 22)) (12.0.0)\nRequirement already satisfied: pandas in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 23)) (2.2.3)\nRequirement already satisfied: scipy in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 24)) (1.15.2)\nRequirement already satisfied: numba in /home/gpuadmin/uv/pfeife/lib/python3.11/site-packages (from -r requirements.txt (line 25)) (0.61.2)\nINFO: pip is looking at multiple versions of timm to determine which version is compatible with other requirements. This could take a while.\nERROR: Cannot install -r requirements.txt (line 12) because these package versions have conflicting dependencies.\n\nThe conflict is caused by:\n    timm 0.9.7 depends on torch>=1.7\n    The user requested (constraint) torch==2.7.0+cu126\n\nTo fix this you could try to:\n1. loosen the range of package versions you've specified\n2. remove package versions to allow pip to attempt to solve the dependency conflict\n\nERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts\n"
```
</details>


