### PR TITLE
moco: add ddp backend support with xccl

### DIFF
--- a/torchbenchmark/models/moco/__init__.py
+++ b/torchbenchmark/models/moco/__init__.py
@@ -70,6 +70,16 @@ class Model(BenchmarkModel):
                 )
             except RuntimeError:
                 pass  # already initialized?
+        elif device == "xpu":
+            try:
+                dist.init_process_group(
+                    backend="xccl",
+                    init_method="tcp://localhost:10001",
+                    world_size=1,
+                    rank=0,
+                )
+            except RuntimeError:
+                pass  # already initialized?
         elif device == "xla":
             import torch_xla.distributed.xla_backend
 


### PR DESCRIPTION
Fix issue https://github.com/intel/torch-xpu-ops/issues/489
To enable moco on xpu devices, the PR adds the distributed backend scripts with xccl backend.
xccl reference: https://github.com/pytorch/pytorch/issues/141741
