### PR TITLE
Pin opacus to 1.5.3 on opacus_cifar10 model

### DIFF
--- a/torchbenchmark/models/opacus_cifar10/requirements.txt
+++ b/torchbenchmark/models/opacus_cifar10/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/pytorch/functorch.git
 # must include the fix https://github.com/pytorch/opacus/pull/426
 # Pinning to 1.5.3. Remove once is resolved https://github.com/pytorch/pytorch/issues/154446
-opacus==1.5.3
+opacus>=1.1.2,<1.5.4

--- a/torchbenchmark/models/opacus_cifar10/requirements.txt
+++ b/torchbenchmark/models/opacus_cifar10/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/pytorch/functorch.git
 # must include the fix https://github.com/pytorch/opacus/pull/426
-opacus>=1.1.2
+# Pinning to 1.5.3. Remove once is resolved https://github.com/pytorch/pytorch/issues/154446
+opacus==1.5.3


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/154446