### PR TITLE
Check for requirements before installing `conda` packages during `doctr_(det|reco)_predictor`

### DIFF
--- a/torchbenchmark/models/doctr_det_predictor/install.py
+++ b/torchbenchmark/models/doctr_det_predictor/install.py
@@ -1,23 +1,25 @@
 import subprocess
 import warnings
+import json
 
 from utils.python_utils import pip_install_requirements
 
 
 def pip_install_requirements_doctr():
+    required_pkgs = ["expecttest", "libglib", "pango"]
     try:
-        subprocess.check_call(
-            [
-                "conda",
-                "install",
-                "-y",
-                "expecttest",
-                "libglib",
-                "pango",
-                "-c",
-                "conda-forge",
-            ]
-        )
+        installed_pkgs = [x["name"] for x in json.loads(subprocess.check_output(["conda", "list", "--json"], text=True))]
+        if not all(pkg in installed_pkgs for pkg in required_pkgs):
+            subprocess.check_call(
+                [
+                    "conda",
+                    "install",
+                    "-y",
+                    *required_pkgs,
+                    "-c",
+                    "conda-forge",
+                ]
+            )
     except:
         warnings.warn(
             "The doctr_det_predictor model requires conda binary libaries to be installed. Missing conda packages might break this model."

--- a/torchbenchmark/models/doctr_reco_predictor/install.py
+++ b/torchbenchmark/models/doctr_reco_predictor/install.py
@@ -1,23 +1,25 @@
 import subprocess
 import warnings
+import json
 
 from utils.python_utils import pip_install_requirements
 
 
 def pip_install_requirements_doctr():
+    required_pkgs = ["expecttest", "libglib", "pango"]
     try:
-        subprocess.check_call(
-            [
-                "conda",
-                "install",
-                "-y",
-                "expecttest",
-                "libglib",
-                "pango",
-                "-c",
-                "conda-forge",
-            ]
-        )
+        installed_pkgs = [x["name"] for x in json.loads(subprocess.check_output(["conda", "list", "--json"], text=True))]
+        if not all(pkg in installed_pkgs for pkg in required_pkgs):
+            subprocess.check_call(
+                [
+                    "conda",
+                    "install",
+                    "-y",
+                    *required_pkgs,
+                    "-c",
+                    "conda-forge",
+                ]
+            )
     except:
         warnings.warn(
             "The doctr_reco_predictor model requires conda binary libaries to be installed. Missing conda packages might break this model."


### PR DESCRIPTION
In the `install.py` for two modules, `conda` is invoked to install packages. This PR adds a short check to only invoke `conda install` if the packages don't already exist in the conda environment. This speeds up the installation significantly in cases where the requirements already exist in the environment.