### PR TITLE
Ignore local version identifiers in constraints.

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -26,6 +26,7 @@ def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
     for module in packages:
         cmd = [sys.executable, "-c", f"import {module}; print({module}.__version__)"]
         version = subprocess.check_output(cmd).decode().strip()
+        version = version.split('+')[0] # Remove any local version identifiers
         versions[module] = version
     return versions
 


### PR DESCRIPTION
Torch is frequently installed with a local version identifier (e.g. `+cu126`), but that identifier causes an issue with pip because there is no public package with that identifier unless an explicit alternative index is used. The issue also happens to come with a quite cryptic ResolutionImpossible error (pypa/pip#13422) which completely obscures the actual issue.

Stripping the local version identifier should be safe, as we are only using constraints to ensure that per-model dependencies are aligned with existing installations.