### PR TITLE
Log stack_trace to dynamo_compile

### DIFF
--- a/userbenchmark/dynamo/dynamobench/_dynamo/utils.py
+++ b/userbenchmark/dynamo/dynamobench/_dynamo/utils.py
@@ -1279,6 +1279,7 @@ class CompilationMetrics:
     compliant_custom_ops: Optional[set[str]] = None
     restart_reasons: Optional[set[str]] = None
     dynamo_time_before_restart_s: Optional[float] = None
+    stack_trace: Optional[list[str]] = None
     # Sometimes, we will finish analyzing a frame but conclude we don't want
     # to install any guarded code.  True means we actually decided to install
     # a compiled frame
@@ -1474,6 +1475,7 @@ def add_compilation_metrics_to_chromium(c: CompilationMetrics) -> None:
         fail_reason=c.fail_reason,
         fail_user_frame_filename=c.fail_user_frame_filename,
         fail_user_frame_lineno=c.fail_user_frame_lineno,
+        stack_trace=c.stack_trace,
         # Sets aren't JSON serializable
         non_compliant_ops=list(c.non_compliant_ops)
         if c.non_compliant_ops is not None


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/159648

Logging stack_trace of what we're actually compiling to dynamo_compile. Ref D79287964

Differential Revision: D79372519
