### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/torchbenchmark/models/sam_fast/requirements.txt
+++ b/torchbenchmark/models/sam_fast/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/pytorch-labs/segment-anything-fast.git
+git+https://github.com/meta-pytorch/segment-anything-fast.git
 opencv-python
 pycocotools

--- a/torchbenchmark/models/simple_gpt/origin
+++ b/torchbenchmark/models/simple_gpt/origin
@@ -1,1 +1,1 @@
-https://github.com/pytorch-labs/simple_gpt/
+https://github.com/meta-pytorch/simple_gpt/


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Only modified files with extensions: .py, .md, .sh, .rst, .cpp, .h, .txt, .yml
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-12T20:57:25.715537+00:00Z