### PR TITLE
Revert "Fix the benchmark CI failure due to Opacus 1.5.4 (#2621)"

### DIFF
--- a/torchbenchmark/models/opacus_cifar10/__init__.py
+++ b/torchbenchmark/models/opacus_cifar10/__init__.py
@@ -30,10 +30,6 @@ class Model(BenchmarkModel):
         )
 
         self.model = models.resnet18(num_classes=10)
-        for m in self.model.modules():
-            if type(m) == torch.nn.ReLU:
-                m.inplace = False
-
         prev_wo_envvar = os.environ.get("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", None)
         os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
         self.model = ModuleValidator.fix(self.model)

--- a/torchbenchmark/models/opacus_cifar10/requirements.txt
+++ b/torchbenchmark/models/opacus_cifar10/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/pytorch/functorch.git
 # must include the fix https://github.com/pytorch/opacus/pull/426
 # Pinning to 1.5.3. Remove once is resolved https://github.com/pytorch/pytorch/issues/154446
-opacus>=1.1.2
+opacus>=1.1.2,<1.5.4


### PR DESCRIPTION
This reverts commit 9486136d36bbd7f1769cf3c35613ea8aabb6d1ed.

As reported by @tugsbayasgalan , this doesn't seem to fix the issue, and the model is still failing when upgrading TorchBench pinned commit https://github.com/pytorch/pytorch/actions/runs/16982292907/job/48434047213