### PR TITLE
Use np._core instead of np.core

### DIFF
--- a/torchbenchmark/models/functorch_maml_omniglot/__init__.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/__init__.py
@@ -77,7 +77,7 @@ class Model(BenchmarkModel):
         root = str(Path(__file__).parent.parent)
         with torch.serialization.safe_globals(
             [
-                np.core.multiarray._reconstruct,
+                np._core.multiarray._reconstruct,
                 np.ndarray,
                 np.dtype,
                 (

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -82,7 +82,7 @@ class Model(BenchmarkModel):
         root = str(Path(__file__).parent)
         with torch.serialization.safe_globals(
             [
-                np.core.multiarray._reconstruct,
+                np._core.multiarray._reconstruct,
                 np.ndarray,
                 np.dtype,
                 (


### PR DESCRIPTION
Deprecated.

```
DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.multiarray.
```

Current numpy version used in TorchBench `numpy==2.2.6`