### PR TITLE
Maintain 2 versions of maml_omniglot for numpy 1x and 2x

### DIFF
--- a/torchbenchmark/data/index.yaml
+++ b/torchbenchmark/data/index.yaml
@@ -14,4 +14,5 @@ INPUT_TARBALLS:
   - sam_inputs.tar.gz
 MODEL_PKLS:
   - drq/obs.pkl
-  - maml_omniglot/batch-20250825.pt
+  - maml_omniglot/batch-np-1x.pt
+  - maml_omniglot/batch-np-2x.pt

--- a/torchbenchmark/models/functorch_maml_omniglot/__init__.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/__init__.py
@@ -96,8 +96,9 @@ class Model(BenchmarkModel):
                 ),
             ]
         ):
+            filename = "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
             self.meta_inputs = torch.load(
-                f"{root}/maml_omniglot/batch-20250825.pt", weights_only=True
+                f"{root}/maml_omniglot/{filename}", weights_only=True
             )
         self.meta_inputs = tuple(
             [torch.from_numpy(i).to(self.device) for i in self.meta_inputs]

--- a/torchbenchmark/models/functorch_maml_omniglot/__init__.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/__init__.py
@@ -96,7 +96,9 @@ class Model(BenchmarkModel):
                 ),
             ]
         ):
-            filename = "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
+            filename = (
+                "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
+            )
             self.meta_inputs = torch.load(
                 f"{root}/maml_omniglot/{filename}", weights_only=True
             )

--- a/torchbenchmark/models/functorch_maml_omniglot/install.py
+++ b/torchbenchmark/models/functorch_maml_omniglot/install.py
@@ -3,6 +3,7 @@ from utils.python_utils import pip_install_requirements
 
 if __name__ == "__main__":
     pip_install_requirements()
-    s3_utils.checkout_s3_data(
-        "MODEL_PKLS", "maml_omniglot/batch-20250825.pt", decompress=False
-    )
+    for filename in ["batch-np-1x.pt", "batch-np-2x.pt"]:
+        s3_utils.checkout_s3_data(
+            "MODEL_PKLS", f"maml_omniglot/{filename}", decompress=False
+        )

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -101,10 +101,10 @@ class Model(BenchmarkModel):
                 ),
             ]
         ):
-            filename = "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
-            self.meta_inputs = torch.load(
-                f"{root}/{filename}", weights_only=True
+            filename = (
+                "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
             )
+            self.meta_inputs = torch.load(f"{root}/{filename}", weights_only=True)
         self.meta_inputs = tuple(
             [torch.from_numpy(i).to(self.device) for i in self.meta_inputs]
         )

--- a/torchbenchmark/models/maml_omniglot/__init__.py
+++ b/torchbenchmark/models/maml_omniglot/__init__.py
@@ -101,8 +101,9 @@ class Model(BenchmarkModel):
                 ),
             ]
         ):
+            filename = "batch-np-2x.pt" if np.__version__ >= "2.0.0" else "batch-np-1x.pt"
             self.meta_inputs = torch.load(
-                f"{root}/batch-20250825.pt", weights_only=True
+                f"{root}/{filename}", weights_only=True
             )
         self.meta_inputs = tuple(
             [torch.from_numpy(i).to(self.device) for i in self.meta_inputs]

--- a/torchbenchmark/models/maml_omniglot/install.py
+++ b/torchbenchmark/models/maml_omniglot/install.py
@@ -3,6 +3,7 @@ from utils.python_utils import pip_install_requirements
 
 if __name__ == "__main__":
     pip_install_requirements()
-    s3_utils.checkout_s3_data(
-        "MODEL_PKLS", "maml_omniglot/batch-20250825.pt", decompress=False
-    )
+    for filename in ["batch-np-1x.pt", "batch-np-2x.pt"]:
+        s3_utils.checkout_s3_data(
+            "MODEL_PKLS", f"maml_omniglot/{filename}", decompress=False
+        )


### PR DESCRIPTION
I want to update TorchBench pinned commit on PyTorch CI and need to maintain 2 flavors of this file for numpy 1.x and 2.x.  The discrepancy here is because TorchBench CI uses latest numpy (2.x) while PyTorch CI pins [numpy to 1.x](https://github.com/pytorch/pytorch/blob/main/.ci/docker/requirements-ci.txt#L137) for Python =< 3.13.  I don't want to update numpy on PyTorch CI because it's far from easy.  So, it's easier to maintain 2 flavors here.

This will unblock https://github.com/pytorch/pytorch/pull/161461