### PR TITLE
[model-tracing] Add model tracing benchmark

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -2,6 +2,7 @@ import contextlib
 import dataclasses
 import gc
 import importlib
+import inspect
 import io
 import os
 import pathlib
@@ -444,6 +445,19 @@ class ModelTask(base_task.TaskBase):
         """
         )
         self.gc_collect()
+
+    def run(self, fn: Callable):
+        fn_source = inspect.getsource(fn)
+        lines = ["            " + line for line in fn_source.split("\n")]
+        fn_source = "\n".join(lines)
+        fn_name = fn.__name__
+        fn_source_copy = (
+            fn_source
+            + f"""
+            {fn_name}(model)
+        """
+        )
+        self.worker.run(fn_source_copy)
 
     # =========================================================================
     # == Forward calls to `model` from parent to worker =======================

--- a/torchbenchmark/util/dispatch.py
+++ b/torchbenchmark/util/dispatch.py
@@ -13,6 +13,7 @@ from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
 torchvision = torch.ops.torchvision
+c10d = torch.ops.c10d
 
 
 dtype_abbrs = {
@@ -170,13 +171,15 @@ class OperatorInputsMode(TorchDispatchMode):
         for operator in sorted_operators:
             if skip_non_compute_operators and non_compute_operator(eval(operator)):
                 continue
-            json_obj[operator] = {}
+            json_obj[operator] = []
             operator_inputs = self.func_db[operator]
             for inputs, count in operator_inputs.items():
-                json_obj[operator]["count"] = count
+                op_hit = {}
+                op_hit["count"] = count
                 # repr will add quotation marks around the dtype strings
                 for dtype_abbr in dtype_abbrs.values():
                     inputs = inputs.replace("'" + dtype_abbr + "'", dtype_abbr)
-                json_obj[operator]["inputs"] = inputs
+                op_hit["inputs"] = inputs
+                json_obj[operator].append(op_hit)
         with open(output_filename, "w") as f:
             json.dump(json_obj, f, indent=4)

--- a/torchbenchmark/util/dispatch.py
+++ b/torchbenchmark/util/dispatch.py
@@ -1,0 +1,177 @@
+import functools
+from collections import Counter, defaultdict
+from functools import partial
+from typing import Any, Dict, Generator, Iterable, Tuple
+
+import torch
+from torch.utils import _pytree as pytree
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_map
+
+aten = torch.ops.aten
+
+
+dtype_abbrs = {
+    torch.bfloat16: "bf16",
+    torch.float64: "f64",
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.complex32: "c32",
+    torch.complex64: "c64",
+    torch.complex128: "c128",
+    torch.int8: "i8",
+    torch.int16: "i16",
+    torch.int32: "i32",
+    torch.int64: "i64",
+    torch.bool: "b8",
+    torch.uint8: "u8",
+}
+
+dtype_abbrs_parsing = {value: key for key, value in dtype_abbrs.items()}
+
+tensor_type = torch._C.TensorType.get()
+
+
+def truncate_input(arg):
+    if arg in dtype_abbrs:
+        return dtype_abbrs[arg]
+    elif isinstance(arg, torch.device):
+        return arg.type
+    else:
+        return arg
+
+
+def serialize_sparse_tensor(e):
+    if isinstance(e, torch._subclasses.FakeTensor):
+        return FuncCallWrapper("ST", list(e.shape), e.dtype, e.layout, e.is_coalesced())
+    else:
+        return FuncCallWrapper(
+            "ST", list(e.shape), e.dtype, e.layout, e.is_coalesced(), e._nnz()
+        )
+
+
+def contains_tensor(elems):
+    for elem in pytree.tree_leaves(elems):
+        if isinstance(elem, torch.Tensor):
+            return True
+    return False
+
+
+def serialize_tensor(e):
+    if not e.is_contiguous():
+        return FuncCallWrapper("T", list(e.shape), e.dtype, stride=e.stride())
+    else:
+        return FuncCallWrapper("T", list(e.shape), e.dtype)
+
+
+def serialize_torch_args(e):
+    if isinstance(e, torch.Tensor):
+        if e.is_sparse:
+            return serialize_sparse_tensor(e)
+        return serialize_tensor(e)
+    else:
+        return truncate_input(e)
+
+
+def skip_args(elems):
+    for i in pytree.tree_leaves(elems):
+        # only shows up in constructors and ops like that
+        if isinstance(i, (torch.memory_format, torch.storage.UntypedStorage)):
+            return True
+    return False
+
+
+def contains_tensor_types(type):
+    return type.isSubtypeOf(tensor_type) or any(
+        contains_tensor_types(e) for e in type.containedTypes()
+    )
+
+
+# Serialize Function Call
+class FuncCallWrapper:
+    def __init__(self, call, *args, **kwargs):
+        self.call = call
+        self.args = tree_map(truncate_input, args)
+        self.kwargs = tree_map(truncate_input, kwargs) if kwargs is not None else {}
+
+    def __repr__(self):
+        args = ", ".join([repr(arg) for arg in self.args])
+        kwargs = "".join(
+            [f", {str(key)}={value}" for key, value in self.kwargs.items()]
+        )
+        out = f"{self.call}({args}{kwargs})".strip('"')
+        # f strings introduce quotations we dont want
+        for key in dtype_abbrs_parsing:
+            out = out.replace(f"'{key}'", key)
+        return out
+
+
+@functools.lru_cache(None)
+def non_compute_operator(op):
+    schema = op._schema
+
+    # skip constructors
+    if not any(contains_tensor_types(arg.type) for arg in schema.arguments):
+        return True
+    if "_like" in op.name():
+        return True
+
+    # allow in place writes
+    if schema.is_mutable:
+        return False
+
+    tensor_inps = [arg for arg in schema.arguments if arg.type is tensor_type]
+    tensor_outputs = [ret for ret in schema.returns if ret.type is tensor_type]
+
+    # skip aliasing unless there are multiple outputs
+    if len(tensor_outputs) != 1:
+        return False
+
+    for inp in tensor_inps:
+        if inp.alias_info and tensor_outputs[0].alias_info:
+            if inp.alias_info.before_set.intersection(
+                tensor_outputs[0].alias_info.after_set
+            ):
+                return True
+
+    return False
+
+
+class OperatorInputsMode(TorchDispatchMode):
+    def __init__(self, output_filename, func_db=None):
+        super().__init__()
+        self.func_db = defaultdict(Counter) if func_db is None else func_db
+        self.output_filename = output_filename
+
+    def __torch_dispatch__(self, func_overload, types, args=(), kwargs=None):
+        kwargs = kwargs if kwargs else {}
+        arg_meta, kwarg_meta = tree_map(serialize_torch_args, (args, kwargs))
+
+        out = func_overload(*args, **kwargs)
+
+        inputs = (args, kwargs)
+        if contains_tensor(inputs) and not skip_args(inputs) and contains_tensor(out):
+            serialized_str = repr((arg_meta, kwarg_meta))
+            self.func_db[str(func_overload)][serialized_str] += 1
+
+        return out
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        super().__exit__(exc_type, exc_val, exc_tb)
+        self.log_to_file(self.output_filename)
+
+    def log_to_file(self, output_filename, skip_non_compute_operators=True):
+        sorted_operators = sorted(self.func_db.keys())
+        with open(output_filename, "w") as f:
+            for operator in sorted_operators:
+                if skip_non_compute_operators and non_compute_operator(eval(operator)):
+                    continue
+                f.write(f"Operator: {operator}\n")
+                operator_inputs = self.func_db[operator]
+                for inps, count in operator_inputs.items():
+                    f.write(f"cnt: {count}, ")
+                    # repr will add quotation marks around the dtype strings
+                    for dtype_abbr in dtype_abbrs.values():
+                        inps = inps.replace("'" + dtype_abbr + "'", dtype_abbr)
+                    f.write(inps)
+                    f.write("\n")

--- a/torchbenchmark/util/dispatch.py
+++ b/torchbenchmark/util/dispatch.py
@@ -12,7 +12,7 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
-torchvision = torch.ops.torchvision
+torchvision = torch.ops.torchvision  # noqa: F811
 c10d = torch.ops.c10d
 
 

--- a/torchbenchmark/util/dispatch.py
+++ b/torchbenchmark/util/dispatch.py
@@ -5,11 +5,14 @@ from functools import partial
 from typing import Any, Dict, Generator, Iterable, Tuple
 
 import torch
+import torchvision
+import torchvision.extension
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_map
 
 aten = torch.ops.aten
+torchvision = torch.ops.torchvision
 
 
 dtype_abbrs = {

--- a/userbenchmark/model-tracing/run.py
+++ b/userbenchmark/model-tracing/run.py
@@ -119,8 +119,9 @@ def run_models(models: List[str], args: argparse.Namespace, extra_env: Dict[str,
 
 
 def run_model_suite(args: argparse.Namespace, suite: str, extra_env: Dict[str, str]):
+    suite_name = "hf" if suite == "huggingface" else suite
     extra_env["TORCHBENCH_MODEL_TRACE_OUTPUT_DIR"] = (
-        f"{extra_env['TORCHBENCH_MODEL_TRACE_OUTPUT_DIR']}/{suite}_train/"
+        f"{extra_env['TORCHBENCH_MODEL_TRACE_OUTPUT_DIR']}/{suite_name}_train/"
     )
     if suite == "torchbench":
         models = list_models()

--- a/userbenchmark/model-tracing/run.py
+++ b/userbenchmark/model-tracing/run.py
@@ -54,7 +54,7 @@ def test_run_model(model) -> None:
     output_dir = os.environ.get("TORCHBENCH_MODEL_TRACE_OUTPUT_DIR", "")
     if output_dir and not output_dir.endswith("/"):
         output_dir += "/"
-    output_filename = f"{output_dir}{model.name}_{model.test}.txt"
+    output_filename = f"{output_dir}{model.name}_{model.test}.json"
     with OperatorInputsMode(output_filename=output_filename):
         model.invoke()
     return

--- a/userbenchmark/model-tracing/run.py
+++ b/userbenchmark/model-tracing/run.py
@@ -1,0 +1,36 @@
+"""
+Generate model traces that are runnable in Tritonbench.
+Example trace:
+"""
+
+import argparse
+from typing import List
+
+
+class ModelTrace:
+    pass
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", type=str, default=None, help="Model to trace, split by comma."
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="train,eval",
+        help="Mode to trace, default is train,eval.",
+    )
+    parser.add_argument("--output", type=str, help="Output directory.")
+    return parser
+
+
+def trace_model():
+    pass
+
+
+def run(args: List[str]):
+    parser = get_parser()
+    args = parser.parse_args(args)
+    run_traces(extra_args=args)

--- a/userbenchmark/model-tracing/run.py
+++ b/userbenchmark/model-tracing/run.py
@@ -4,7 +4,25 @@ Example trace:
 """
 
 import argparse
+import itertools
 from typing import List
+
+from torchbenchmark.util.experiment.instantiator import (
+    list_models,
+    load_model_isolated,
+    TorchBenchModelConfig,
+)
+
+
+def generate_model_config(model_name: str, mode: str) -> TorchBenchModelConfig:
+    return TorchBenchModelConfig(
+        name=model_name,
+        device="cuda",
+        test=mode,
+        batch_size=None,
+        extra_args=[],
+        extra_env=None,
+    )
 
 
 class ModelTrace:
@@ -14,23 +32,28 @@ class ModelTrace:
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--model", type=str, default=None, help="Model to trace, split by comma."
+        "--models", type=str, default=None, help="Model to trace, split by comma."
     )
     parser.add_argument(
         "--mode",
         type=str,
-        default="train,eval",
-        help="Mode to trace, default is train,eval.",
+        default="train",
+        help="Mode to trace, default is train.",
     )
     parser.add_argument("--output", type=str, help="Output directory.")
     return parser
 
 
-def trace_model():
-    pass
+def trace_model(cfg: TorchBenchModelConfig) -> ModelTrace:
+    task = load_model_isolated(cfg)
+    return ModelTrace()
 
 
 def run(args: List[str]):
     parser = get_parser()
-    args = parser.parse_args(args)
-    run_traces(extra_args=args)
+    args: argparse.Namespace = parser.parse_args(args)
+    models = args.models.split(",") if args.models else list_models()
+    modes = args.mode.split(",") if args.mode else ["train"]
+    model_args = list(itertools.product(models, modes))
+    cfgs = [generate_model_config(model_name, mode) for model_name, mode in model_args]
+    traces = [trace_model(cfg) for cfg in cfgs]

--- a/userbenchmark/model-tracing/run.py
+++ b/userbenchmark/model-tracing/run.py
@@ -52,6 +52,8 @@ def test_run_model(model) -> None:
     from torchbenchmark.util.dispatch import OperatorInputsMode
 
     output_dir = os.environ.get("TORCHBENCH_MODEL_TRACE_OUTPUT_DIR", "")
+    if output_dir and not output_dir.endswith("/"):
+        output_dir += "/"
     output_filename = f"{output_dir}{model.name}_{model.test}.txt"
     with OperatorInputsMode(output_filename=output_filename):
         model.invoke()
@@ -78,7 +80,7 @@ def run_models(models: List[str], args: argparse.Namespace, extra_env: Dict[str,
 
 def run_model_suite(args: argparse.Namespace, suite: str, extra_env: Dict[str, str]):
     extra_env["TORCHBENCH_MODEL_TRACE_OUTPUT_DIR"] = (
-        f"{extra_env['TORCHBENCH_MODEL_TRACE_OUTPUT_DIR']}/{suite}_train"
+        f"{extra_env['TORCHBENCH_MODEL_TRACE_OUTPUT_DIR']}/{suite}_train/"
     )
     if suite == "torchbench":
         models = list_models()


### PR DESCRIPTION
This is to bridge the gap between Torchbench (module-level-benchmarking) and Tritonbench (operator-level-benchmarking).

```
$ python run_benchmark.py model-tracing --output ./.userbenchmark/model-tracing
```

This will output the traces in to the directory. An example of the trace:

```
{
    "aten._foreach_add.List": [
        {
            "count": 1,
            "inputs": "(([T([20005, 768], f32), T([3, 768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([2, 768], f32), T([2], f32), T([20005, 768], f32), T([20005], f32)], [T([20005, 768], f32), T([3, 768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([2, 768], f32), T([2], f32), T([20005, 768], f32), T([20005], f32)]), {'alpha': 0.01})"
        }
    ],
    "aten._foreach_sqrt.default": [
        {
            "count": 1,
            "inputs": "(([T([20005, 768], f32), T([3, 768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([768, 768], f32), T([768], f32), T([3072, 768], f32), T([3072], f32), T([768, 3072], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([768], f32), T([2, 768], f32), T([2], f32), T([20005, 768], f32), T([20005], f32)],), {})"
        }
    ],
    "aten._log_softmax.default": [
        {
            "count": 1,
            "inputs": "((T([16, 2], f32), -1, False), {})"
        },
        {
            "count": 1,
            "inputs": "((T([16, 128, 20005], f32), -1, False), {})"
        }
    ],
    "aten._log_softmax_backward_data.default": [
        {
            "count": 1,
            "inputs": "((T([16, 128, 20005], f32, stride=(2560640, 1, 128)), T([16, 128, 20005], f32), -1, f32), {})"
        },
        {
            "count": 1,
            "inputs": "((T([16, 2], f32), T([16, 2], f32), -1, f32), {})"
        }
    ],
    "aten._softmax.default": [
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), -1, False), {})"
        }
    ],
    "aten._softmax_backward_data.default": [
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), T([16, 12, 128, 128], f32), -1, f32), {})"
        }
    ],
    "aten._unsafe_view.default": [
        {
            "count": 36,
            "inputs": "((T([16, 12, 128, 64], f32), [192, 128, 64]), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 12, 64, 128], f32), [192, 64, 128]), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 128], f32), [16, 12, 128, 128]), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 64], f32), [16, 12, 128, 64]), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 12, 64], f32), [16, 128, 768]), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 128, 768], f32), [2048, 768]), {})"
        }
    ],
    "aten.add.Tensor": [
        {
            "count": 1,
            "inputs": "((T([16, 128, 768], f32), T([1, 128, 768], f32)), {})"
        },
        {
            "count": 122,
            "inputs": "((T([16, 128, 768], f32), T([16, 128, 768], f32)), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), 1e-06), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 768], f32), T([768], f32)), {})"
        },
        {
            "count": 1,
            "inputs": "((T([], f32), T([], f32)), {})"
        }
    ],
    "aten.addmm.default": [
        {
            "count": 48,
            "inputs": "((T([768], f32), T([2048, 768], f32), T([768, 768], f32, stride=(1, 768))), {})"
        },
        {
            "count": 12,
            "inputs": "((T([3072], f32), T([2048, 768], f32), T([768, 3072], f32, stride=(1, 768))), {})"
        },
        {
            "count": 12,
            "inputs": "((T([768], f32), T([2048, 3072], f32), T([3072, 768], f32, stride=(1, 3072))), {})"
        },
        {
            "count": 1,
            "inputs": "((T([2], f32), T([16, 768], f32, stride=(98304, 1)), T([768, 2], f32, stride=(1, 768))), {})"
        },
        {
            "count": 1,
            "inputs": "((T([20005], f32), T([2048, 768], f32), T([768, 20005], f32, stride=(1, 768))), {})"
        }
    ],
    "aten.bmm.default": [
        {
            "count": 12,
            "inputs": "((T([192, 128, 64], f32), T([192, 64, 128], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 128], f32), T([192, 128, 64], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 128], f32, stride=(16384, 1, 128)), T([192, 128, 64], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 64], f32), T([192, 64, 128], f32, stride=(8192, 1, 64))), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 64, 128], f32, stride=(8192, 1, 64)), T([192, 128, 128], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([192, 128, 128], f32), T([192, 128, 64], f32, stride=(8192, 1, 128))), {})"
        }
    ],
    "aten.div.Scalar": [
        {
            "count": 24,
            "inputs": "((T([16, 128, 768], f32, stride=(128, 1, 0)), 768), {})"
        }
    ],
    "aten.div.Tensor": [
        {
            "count": 96,
            "inputs": "((T([16, 128, 768], f32), T([16, 128, 1], f32)), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 12, 128, 128], f32), 8.0), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), T([16, 128, 1], f32)), {})"
        }
    ],
    "aten.embedding.default": [
        {
            "count": 1,
            "inputs": "((T([20005, 768], f32), T([16, 128], i64), 0), {})"
        },
        {
            "count": 1,
            "inputs": "((T([3, 768], f32), T([16, 128], i64), 0), {})"
        }
    ],
    "aten.embedding_dense_backward.default": [
        {
            "count": 1,
            "inputs": "((T([16, 128, 768], f32), T([16, 128], i64), 3, 0, False), {})"
        },
        {
            "count": 1,
            "inputs": "((T([16, 128, 768], f32), T([16, 128], i64), 20005, 0, False), {})"
        }
    ],
    "aten.eq.Scalar": [
        {
            "count": 12,
            "inputs": "((T([16, 1, 128, 128], b8), 0), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), 0), {})"
        }
    ],
    "aten.gelu.default": [
        {
            "count": 12,
            "inputs": "((T([16, 128, 3072], f32),), {})"
        }
    ],
    "aten.gelu_backward.default": [
        {
            "count": 12,
            "inputs": "((T([16, 128, 3072], f32), T([16, 128, 3072], f32)), {})"
        }
    ],
    "aten.gt.Scalar": [
        {
            "count": 1,
            "inputs": "((T([16, 128], i64), 0), {})"
        }
    ],
    "aten.masked_fill.Scalar": [
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), T([16, 1, 128, 128], b8), -1000000000.0), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), T([16, 1, 128, 128], b8), 0), {})"
        }
    ],
    "aten.masked_fill_.Scalar": [
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), T([16, 128, 1], b8), 0), {})"
        }
    ],
    "aten.mean.dim": [
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32), [-1], True), {})"
        }
    ],
    "aten.mm.default": [
        {
            "count": 1,
            "inputs": "((T([2048, 20005], f32), T([20005, 768], f32)), {})"
        },
        {
            "count": 1,
            "inputs": "((T([20005, 2048], f32, stride=(1, 20005)), T([2048, 768], f32)), {})"
        },
        {
            "count": 1,
            "inputs": "((T([16, 2], f32), T([2, 768], f32)), {})"
        },
        {
            "count": 1,
            "inputs": "((T([2, 16], f32, stride=(1, 2)), T([16, 768], f32, stride=(98304, 1))), {})"
        },
        {
            "count": 12,
            "inputs": "((T([2048, 768], f32), T([768, 3072], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([768, 2048], f32, stride=(1, 768)), T([2048, 3072], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([2048, 3072], f32), T([3072, 768], f32)), {})"
        },
        {
            "count": 12,
            "inputs": "((T([3072, 2048], f32, stride=(1, 3072)), T([2048, 768], f32)), {})"
        },
        {
            "count": 48,
            "inputs": "((T([2048, 768], f32), T([768, 768], f32)), {})"
        },
        {
            "count": 48,
            "inputs": "((T([768, 2048], f32, stride=(1, 768)), T([2048, 768], f32)), {})"
        }
    ],
    "aten.mul.Scalar": [
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), 2), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), 0.002607561929595828), {})"
        }
    ],
    "aten.mul.Tensor": [
        {
            "count": 24,
            "inputs": "((T([768], f32), T([16, 128, 768], f32)), {})"
        },
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32), T([16, 128, 768], f32)), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 768], f32), T([768], f32)), {})"
        },
        {
            "count": 24,
            "inputs": "((T([16, 128, 1], f32), T([16, 128, 768], f32)), {})"
        }
    ],
    "aten.native_dropout.default": [
        {
            "count": 37,
            "inputs": "((T([16, 128, 768], f32), 0.1, True), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), 0.1, True), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 128, 3072], f32), 0.1, True), {})"
        }
    ],
    "aten.native_dropout_backward.default": [
        {
            "count": 37,
            "inputs": "((T([16, 128, 768], f32), T([16, 128, 768], b8), 1.1111111111111112), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 128, 3072], f32), T([16, 128, 3072], b8), 1.1111111111111112), {})"
        },
        {
            "count": 12,
            "inputs": "((T([16, 12, 128, 128], f32), T([16, 12, 128, 128], b8), 1.1111111111111112), {})"
        }
    ],
    "aten.neg.default": [
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32),), {})"
        }
    ],
    "aten.nll_loss2d_backward.default": [
        {
            "count": 1,
            "inputs": "((T([], f32), T([16, 20005, 1, 128], f32), T([16, 1, 128], i64), None, 1, 0, T([], f32)), {})"
        }
    ],
    "aten.nll_loss2d_forward.default": [
        {
            "count": 1,
            "inputs": "((T([16, 20005, 1, 128], f32), T([16, 1, 128], i64), None, 1, 0), {})"
        }
    ],
    "aten.nll_loss_backward.default": [
        {
            "count": 1,
            "inputs": "((T([], f32), T([16, 2], f32), T([16], i64), None, 1, 0, T([], f32)), {})"
        }
    ],
    "aten.nll_loss_forward.default": [
        {
            "count": 1,
            "inputs": "((T([16, 2], f32), T([16], i64), None, 1, 0), {})"
        }
    ],
    "aten.repeat.default": [
        {
            "count": 1,
            "inputs": "((T([16, 1, 128], b8), [1, 128, 1]), {})"
        }
    ],
    "aten.select_backward.default": [
        {
            "count": 1,
            "inputs": "((T([16, 768], f32), [16, 128, 768], 1, 0), {})"
        }
    ],
    "aten.std.correction": [
        {
            "count": 24,
            "inputs": "((T([16, 128, 768], f32), [-1]), {'correction': 1, 'keepdim': True})"
        }
    ],
    "aten.sub.Tensor": [
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32), T([16, 128, 1], f32)), {})"
        }
    ],
    "aten.sum.dim_IntList": [
        {
            "count": 1,
            "inputs": "((T([2048, 20005], f32), [0], True), {})"
        },
        {
            "count": 1,
            "inputs": "((T([16, 2], f32), [0], True), {})"
        },
        {
            "count": 60,
            "inputs": "((T([2048, 768], f32), [0], True), {})"
        },
        {
            "count": 12,
            "inputs": "((T([2048, 3072], f32), [0], True), {})"
        },
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32), [0, 1], True), {})"
        },
        {
            "count": 48,
            "inputs": "((T([16, 128, 768], f32), [2], True), {})"
        }
    ]
}
```