### PR TITLE
Update pynvml to nvidia-ml-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml
 numpy
 opencv-python
 submitit
-pynvml>=12.0.0
+nvidia-ml-py>=13.0.0
 pandas
 scipy
 numba>=0.57.0

--- a/torchbenchmark/_components/model_analyzer/requirements.txt
+++ b/torchbenchmark/_components/model_analyzer/requirements.txt
@@ -1,2 +1,2 @@
 numba
-pynvml
+nvidia-ml-py


### PR DESCRIPTION
NVIDIA now provides `pynvml` through `nvidia-ml-py`, and gives noisy warnings to users of the old package.