### PR TITLE
maybe torch._C._nativer.PyModelRunner not in global import 

### DIFF
--- a/userbenchmark/dynamo/dynamobench/common.py
+++ b/userbenchmark/dynamo/dynamobench/common.py
@@ -42,7 +42,6 @@ import torch._export
 import torch.distributed
 import torch.multiprocessing as mp
 from torch._C import _has_cuda as HAS_CUDA, _has_xpu as HAS_XPU
-from torch._C._nativert import PyModelRunner
 from torch._dynamo.profiler import fx_insert_profiling, Profiler
 from torch._dynamo.testing import (
     dummy_fx_compile,
@@ -1487,6 +1486,7 @@ class NativeRTCache:
                     f, exported_programs={"forward": ep}
                 )
                 filename = f.name
+            from torch._C._nativert import PyModelRunner
             cls.cache[key] = PyModelRunner(filename, "forward")
 
         return cls.cache[key]


### PR DESCRIPTION
fix bug in `pytorch 2.8.0`
`ModuleNotFoundError: No module named 'torch._C._nativert'; 'torch._C' is not a package`


* command
```
TORCHINDUCTOR_UNIQUE_KERNEL_NAMES=1 TORCHINDUCTOR_BENCHMARK_KERNEL=1 python -u userbenchmark/dynamo/dynamobench/torchbench.py  --backend inductor --float16 --performance --only BERT_pytorch  --training
```

* about issue https://github.com/pytorch/benchmark/issues/2631