### PR TITLE
Set the right dependency name for GAT, GCN, and SAGE pyg-library

### DIFF
--- a/torchbenchmark/canary_models/gat/requirements.txt
+++ b/torchbenchmark/canary_models/gat/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib
+pyg-library
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/gcn/requirements.txt
+++ b/torchbenchmark/canary_models/gcn/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib
+pyg-library
 torch_scatter
 torch_sparse
 pyg-nightly

--- a/torchbenchmark/canary_models/sage/requirements.txt
+++ b/torchbenchmark/canary_models/sage/requirements.txt
@@ -1,4 +1,4 @@
-pyg_lib
+pyg-library
 torch_scatter
 torch_sparse
 pyg-nightly


### PR DESCRIPTION
It's called https://pypi.org/project/pyg-library now, I'm not sure if we even need to keep these canary models, but this is an easy tweak