### PR TITLE
Retry for torch_multimodal_clip download

### DIFF
--- a/torchbenchmark/models/torch_multimodal_clip/install.py
+++ b/torchbenchmark/models/torch_multimodal_clip/install.py
@@ -33,9 +33,7 @@ def download(output_filename, uri):
                         chunk_size=8192
                     ):  # Define the chunk size to be used
                         f.write(chunk)
-                print(
-                    f"Successfully downloaded {output_filename}"
-                )
+                print(f"Successfully downloaded {output_filename}")
                 return
             elif response.status_code == 429:
                 if attempt < max_retries - 1:
@@ -61,9 +59,7 @@ def download(output_filename, uri):
                 time.sleep(retry_delay)
                 retry_delay *= 2
             else:
-                print(
-                    f"Failed to download file after {max_retries} attempts: {e}"
-                )
+                print(f"Failed to download file after {max_retries} attempts: {e}")
 
 
 def download_data(data_folder):


### PR DESCRIPTION
Test:
```
python install.py
Rate limited (429). Retrying in 3 seconds... (attempt 1/10)
Rate limited (429). Retrying in 6 seconds... (attempt 2/10)
Rate limited (429). Retrying in 12 seconds... (attempt 3/10)
Rate limited (429). Retrying in 24 seconds... (attempt 4/10)
Successfully downloaded /data/users/atalman/benchmark/torchbenchmark/models/torch_multimodal_clip/.data/pizza.jpg
```

1. More realistic headers
2. Retries when trying to download the image