### PR TITLE
Change location of torch_multimodal_clip data to aws s3

### DIFF
--- a/torchbenchmark/models/torch_multimodal_clip/install.py
+++ b/torchbenchmark/models/torch_multimodal_clip/install.py
@@ -64,6 +64,7 @@ def download(output_filename, uri):
 
 def download_data(data_folder):
     # CC-0 image from wikipedia page on pizza so legal to use
+    # Original URL: https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Pizza-3007395.jpg/2880px-Pizza-3007395.jpg
     download(
         os.path.join(data_folder, "pizza.jpg"),
         "https://ossci-assets.s3.us-east-1.amazonaws.com/2880px-Pizza-3007395.jpg",


### PR DESCRIPTION
As BE change we should consider moving most of the data in torchbench to aws s3