### PR TITLE
Remove visdom dependency from pytorch_CycleGAN_and_pix2pix

### DIFF
--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/__init__.py
@@ -49,7 +49,7 @@ class Model(BenchmarkModel):
 
         if self.test == "train":
             train_args = (
-                f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --display_id 0 --n_epochs 3 "
+                f"--tb_device {self.device} --dataroot {data_root}/datasets/horse2zebra --name horse2zebra --model cycle_gan --n_epochs 3 "
                 + f"--n_epochs_decay 3 {device_type_arg} {device_arg} {checkpoints_arg}"
             )
             self.training_loop = prepare_training_loop(train_args.split(" "))

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/install.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/install.py
@@ -2,7 +2,7 @@ from utils import s3_utils
 from utils.python_utils import pip_install_requirements
 
 if __name__ == "__main__":
+    pip_install_requirements()
     s3_utils.checkout_s3_data(
         "INPUT_TARBALLS", "pytorch_CycleGAN_and_pix2pix_inputs.tar.gz", decompress=True
     )
-    pip_install_requirements()

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/train_options.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/options/train_options.py
@@ -21,33 +21,6 @@ class TrainOptions(BaseOptions):
             help="frequency of showing training results on screen",
         )
         parser.add_argument(
-            "--display_ncols",
-            type=int,
-            default=4,
-            help="if positive, display all images in a single visdom web panel with certain number of images per row.",
-        )
-        parser.add_argument(
-            "--display_id", type=int, default=1, help="window id of the web display"
-        )
-        parser.add_argument(
-            "--display_server",
-            type=str,
-            default="http://localhost",
-            help="visdom server of the web display",
-        )
-        parser.add_argument(
-            "--display_env",
-            type=str,
-            default="main",
-            help='visdom display environment name (default is "main")',
-        )
-        parser.add_argument(
-            "--display_port",
-            type=int,
-            default=8097,
-            help="visdom port of the web display",
-        )
-        parser.add_argument(
             "--update_html_freq",
             type=int,
             default=1000,

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/requirements.txt
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/requirements.txt
@@ -1,2 +1,1 @@
 dominate>=2.3.1
-visdom>=0.1.8.3

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/test_cyclegan.py
@@ -47,9 +47,6 @@ def get_model(args, device):
     opt.no_flip = (
         True  # no flip; comment this line if results on flipped images are needed.
     )
-    opt.display_id = (
-        -1
-    )  # no visdom display; the test code saves the results to a HTML file.
     model = create_model(opt)  # create a model given opt.model and other options
     if len(opt.gpu_ids) > 0:
         # When opt.gpu_ids > 0, netG is converted to torch.nn.DataParallel
@@ -82,9 +79,6 @@ if __name__ == "__main__":
     opt.no_flip = (
         True  # no flip; comment this line if results on flipped images are needed.
     )
-    opt.display_id = (
-        -1
-    )  # no visdom display; the test code saves the results to a HTML file.
     dataset = create_dataset(
         opt
     )  # create a dataset given opt.dataset_mode and other options

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/train_cyclegan.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/train_cyclegan.py
@@ -99,10 +99,6 @@ def prepare_training_loop(args):
                     visualizer.print_current_losses(
                         epoch, epoch_iter, losses, t_comp, t_data
                     )
-                    if opt.display_id > 0:
-                        visualizer.plot_current_losses(
-                            epoch, float(epoch_iter) / dataset_size, losses
-                        )
 
                 if (
                     total_iters % opt.save_latest_freq == 0

--- a/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/util/visualizer.py
+++ b/torchbenchmark/models/pytorch_CycleGAN_and_pix2pix/util/visualizer.py
@@ -1,18 +1,8 @@
 import ntpath
 import os
-import sys
 import time
-from subprocess import PIPE, Popen
-
-import numpy as np
 
 from . import html, util
-
-
-if sys.version_info[0] == 2:
-    VisdomExceptionBase = Exception
-else:
-    VisdomExceptionBase = ConnectionError
 
 
 def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):
@@ -48,7 +38,7 @@ def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):
 class Visualizer:
     """This class includes several functions that can display/save images and print/save logging information.
 
-    It uses a Python library 'visdom' for display, and a Python library 'dominate' (wrapped in 'HTML') for creating HTML files with images.
+    It uses a Python library 'dominate' (wrapped in 'HTML') for creating HTML files with images.
     """
 
     def __init__(self, opt):
@@ -57,28 +47,14 @@ class Visualizer:
         Parameters:
             opt -- stores all the experiment flags; needs to be a subclass of BaseOptions
         Step 1: Cache the training/test options
-        Step 2: connect to a visdom server
-        Step 3: create an HTML object for saveing HTML filters
-        Step 4: create a logging file to store training losses
+        Step 2: create an HTML object for saveing HTML filters
+        Step 3: create a logging file to store training losses
         """
         self.opt = opt  # cache the option
-        self.display_id = opt.display_id
         self.use_html = opt.isTrain and not opt.no_html
         self.win_size = opt.display_winsize
         self.name = opt.name
-        self.port = opt.display_port
         self.saved = False
-        if (
-            self.display_id > 0
-        ):  # connect to a visdom server given <display_port> and <display_server>
-            import visdom
-
-            self.ncols = opt.display_ncols
-            self.vis = visdom.Visdom(
-                server=opt.display_server, port=opt.display_port, env=opt.display_env
-            )
-            if not self.vis.check_connection():
-                self.create_visdom_connections()
 
         if self.use_html:  # create an HTML object at <checkpoints_dir>/web/; images will be saved under <checkpoints_dir>/web/images/
             self.web_dir = os.path.join(opt.checkpoints_dir, opt.name, "web")
@@ -96,85 +72,14 @@ class Visualizer:
         """Reset the self.saved status"""
         self.saved = False
 
-    def create_visdom_connections(self):
-        """If the program could not connect to Visdom server, this function will start a new server at port < self.port >"""
-        cmd = sys.executable + " -m visdom.server -p %d &>/dev/null &" % self.port
-        print("\n\nCould not connect to Visdom server. \n Trying to start a server....")
-        print("Command: %s" % cmd)
-        Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
-
     def display_current_results(self, visuals, epoch, save_result):
-        """Display current results on visdom; save current results to an HTML file.
+        """Save current results to an HTML file.
 
         Parameters:
             visuals (OrderedDict) - - dictionary of images to display or save
             epoch (int) - - the current epoch
             save_result (bool) - - if save the current results to an HTML file
         """
-        if self.display_id > 0:  # show images in the browser using visdom
-            ncols = self.ncols
-            if ncols > 0:  # show all the images in one visdom panel
-                ncols = min(ncols, len(visuals))
-                h, w = next(iter(visuals.values())).shape[:2]
-                table_css = """<style>
-                        table {border-collapse: separate; border-spacing: 4px; white-space: nowrap; text-align: center}
-                        table td {width: % dpx; height: % dpx; padding: 4px; outline: 4px solid black}
-                        </style>""" % (
-                    w,
-                    h,
-                )  # create a table css
-                # create a table of images.
-                title = self.name
-                label_html = ""
-                label_html_row = ""
-                images = []
-                idx = 0
-                for label, image in visuals.items():
-                    image_numpy = util.tensor2im(image)
-                    label_html_row += "<td>%s</td>" % label
-                    images.append(image_numpy.transpose([2, 0, 1]))
-                    idx += 1
-                    if idx % ncols == 0:
-                        label_html += "<tr>%s</tr>" % label_html_row
-                        label_html_row = ""
-                white_image = np.ones_like(image_numpy.transpose([2, 0, 1])) * 255
-                while idx % ncols != 0:
-                    images.append(white_image)
-                    label_html_row += "<td></td>"
-                    idx += 1
-                if label_html_row != "":
-                    label_html += "<tr>%s</tr>" % label_html_row
-                try:
-                    self.vis.images(
-                        images,
-                        nrow=ncols,
-                        win=self.display_id + 1,
-                        padding=2,
-                        opts=dict(title=title + " images"),
-                    )
-                    label_html = "<table>%s</table>" % label_html
-                    self.vis.text(
-                        table_css + label_html,
-                        win=self.display_id + 2,
-                        opts=dict(title=title + " labels"),
-                    )
-                except VisdomExceptionBase:
-                    self.create_visdom_connections()
-
-            else:  # show each image in a separate visdom panel;
-                idx = 1
-                try:
-                    for label, image in visuals.items():
-                        image_numpy = util.tensor2im(image)
-                        self.vis.image(
-                            image_numpy.transpose([2, 0, 1]),
-                            opts=dict(title=label),
-                            win=self.display_id + idx,
-                        )
-                        idx += 1
-                except VisdomExceptionBase:
-                    self.create_visdom_connections()
-
         if self.use_html and (
             save_result or not self.saved
         ):  # save images to an HTML file if they haven't been saved.
@@ -203,35 +108,6 @@ class Visualizer:
                     links.append(img_path)
                 webpage.add_images(ims, txts, links, width=self.win_size)
             webpage.save()
-
-    def plot_current_losses(self, epoch, counter_ratio, losses):
-        """display the current losses on visdom display: dictionary of error labels and values
-
-        Parameters:
-            epoch (int)           -- current epoch
-            counter_ratio (float) -- progress (percentage) in the current epoch, between 0 to 1
-            losses (OrderedDict)  -- training losses stored in the format of (name, float) pairs
-        """
-        if not hasattr(self, "plot_data"):
-            self.plot_data = {"X": [], "Y": [], "legend": list(losses.keys())}
-        self.plot_data["X"].append(epoch + counter_ratio)
-        self.plot_data["Y"].append([losses[k] for k in self.plot_data["legend"]])
-        try:
-            self.vis.line(
-                X=np.stack(
-                    [np.array(self.plot_data["X"])] * len(self.plot_data["legend"]), 1
-                ),
-                Y=np.array(self.plot_data["Y"]),
-                opts={
-                    "title": self.name + " loss over time",
-                    "legend": self.plot_data["legend"],
-                    "xlabel": "epoch",
-                    "ylabel": "loss",
-                },
-                win=self.display_id,
-            )
-        except VisdomExceptionBase:
-            self.create_visdom_connections()
 
     # losses: same format as |losses| of plot_current_losses
     def print_current_losses(self, epoch, iters, losses, t_comp, t_data):


### PR DESCRIPTION
Stacked PRs:
 * __->__#2666


--- --- ---

1. Swap install order for pytorch_CycleGAN_and_pix2pix_inputs. So that if S3 fails, imports at least still work and its more obvious what the error is.
2. This reveals the root cause, visdom 0.2.4's setup.py uses pkg_resources (from setuptools), which is no longer bundled by default in Python 3.12 build environments. So installing requirements was failing. It looks like the visdom dependency was not used in the actual benchmark, so I cleaned up the deps instead of adding pkg_resources in.

will address https://github.com/pytorch/pytorch/issues/174919 once pin is bumped