### PR TITLE
Move profiler trace collection out of timed loop to avoid polluting perf numbers (#2684)

### DIFF
--- a/userbenchmark/dynamo/dynamobench/common.py
+++ b/userbenchmark/dynamo/dynamobench/common.py
@@ -1069,66 +1069,87 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
     tolerance = args.xla_tolerance if args.trace_on_xla else 1e-4
     torch._dynamo.config.repro_tolerance = tolerance
 
-    with maybe_profile(args.export_profiler_trace, **args.profile_details) as p:
-        if args.export_aot_inductor:
-            frozen_model_iter_fn = export_aot_inductor(
-                model, example_inputs, args.inductor_compile_mode
-            )
-        elif args.export_nativert:
-            frozen_model_iter_fn = export_nativert(model, example_inputs)
-        elif args.torchscript_jit_trace:
-            frozen_model_iter_fn = torchscript_jit_trace(model, example_inputs)
-        elif args.aot_precompile:
-            frozen_model_iter_fn = aot_precompile(model, example_inputs)
+    if args.export_aot_inductor:
+        frozen_model_iter_fn = export_aot_inductor(
+            model, example_inputs, args.inductor_compile_mode
+        )
+    elif args.export_nativert:
+        frozen_model_iter_fn = export_nativert(model, example_inputs)
+    elif args.torchscript_jit_trace:
+        frozen_model_iter_fn = torchscript_jit_trace(model, example_inputs)
+    elif args.aot_precompile:
+        frozen_model_iter_fn = aot_precompile(model, example_inputs)
+    else:
+        if kwargs["hf_llm"]:
+            # If it's an llm, we want to optimize model.forward, and use
+            # the generate function
+            model.forward = torch._dynamo.run(model)
+            frozen_model_iter_fn = model_iter_fn
         else:
-            if kwargs["hf_llm"]:
-                # If it's an llm, we want to optimize model.forward, and use
-                # the generate function
-                model.forward = torch._dynamo.run(model)
-                frozen_model_iter_fn = model_iter_fn
-            else:
-                frozen_model_iter_fn = torch._dynamo.run(model_iter_fn)
+            frozen_model_iter_fn = torch._dynamo.run(model_iter_fn)
 
-        for rep in trange(args.repeat, desc="running benchmark"):
-            inputs = (
-                randomize_input(copy.deepcopy(example_inputs))
-                if should_randomize_input
-                else example_inputs
+    for rep in trange(args.repeat, desc="running benchmark"):
+        inputs = (
+            randomize_input(copy.deepcopy(example_inputs))
+            if should_randomize_input
+            else example_inputs
+        )
+        # need call mark_step to perform the computation
+        # on randomize_input. Otherwise the first call using the
+        # inputs will incur high penalty then the next one.
+        maybe_mark_step(args)
+
+        # interleave the runs to handle frequency scaling and load changes
+        with torch.compiler.set_stance("force_eager"):
+            timings[rep, 0], expected_output = timed(
+                model,
+                model_iter_fn,
+                inputs,
+                return_result=True,
+                times=times,
+                collect_outputs=args.collect_outputs,
+                batch_size=kwargs.get("batch_size"),
             )
-            # need call mark_step to perform the computation
-            # on randomize_input. Otherwise the first call using the
-            # inputs will incur high penalty then the next one.
-            maybe_mark_step(args)
 
-            # interleave the runs to handle frequency scaling and load changes
+        # call mark_step between the 2 calls to make the comparison fair.
+        maybe_mark_step(args)
+
+        timings[rep, 1], actual_output = timed(
+            model,
+            frozen_model_iter_fn,
+            inputs,
+            return_result=True,
+            times=times,
+            collect_outputs=args.collect_outputs,
+        )
+
+    # Collect profiler trace in a separate run so that profiler overhead
+    # does not pollute the wall-clock performance numbers above.
+    if args.export_profiler_trace:
+        inputs = example_inputs
+        with maybe_profile(True, **args.profile_details) as p:
             with (
                 maybe_mark_profile(p=p, mark="expected"),
                 torch.compiler.set_stance("force_eager"),
             ):
-                timings[rep, 0], expected_output = timed(
+                timed(
                     model,
                     model_iter_fn,
                     inputs,
-                    return_result=True,
+                    return_result=False,
                     times=times,
-                    collect_outputs=args.collect_outputs,
-                    batch_size=kwargs.get("batch_size"),
+                    collect_outputs=False,
                 )
-
-            # call mark_step between the 2 calls to make the comparison fair.
-            maybe_mark_step(args)
-
             with maybe_mark_profile(p=p, mark="actual"):
-                timings[rep, 1], actual_output = timed(
+                timed(
                     model,
                     frozen_model_iter_fn,
                     inputs,
-                    return_result=True,
+                    return_result=False,
                     times=times,
-                    collect_outputs=args.collect_outputs,
+                    collect_outputs=False,
                 )
 
-    if args.export_profiler_trace:
         name = args.profiler_trace_name + "_" + model.name
         if hasattr(args, "rank"):
             name += f"_rank_{args.rank}"


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/181043


D100006805 added Chrome profiler trace collection to the inductor perf nightly benchmarks. However, the torch.profiler.profile() context wraps the entire timed loop, which means _is_profiler_enabled is True during all timed iterations. This causes:

Inflated wall-clock numbers: Every kernel launch pays ~1-2µs extra for _RecordFunctionFast enter/exit, adding ~150-300µs per forward pass on models with many kernels (e.g., mobilenet_v2 with 153 kernels).

Fix: Move profiler trace collection to a separate extra iteration after the timed loop. The timed loop runs without profiler overhead, producing clean perf numbers. The profiler trace is then collected in one additional eager + compiled run, preserving the same trace quality.

Before: profiler wraps timed loop → perf numbers include profiler overhead After: timed loop runs clean → profiler trace collected separately

Local validation on mobilenet_v2 (H100, mode/opt, --disable-cudagraphs):

Mode                               	Before (profiler in timed loop)	After (profiler separate)
--export-profiler-trace	 1.868x	                                       2.168x
No profiler	                      2.193x	                                       2.203x

Reviewed By: huydhn, PaulZhang12

Differential Revision: D101894273


