### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/build-nightly-docker.yml
+++ b/.github/workflows/build-nightly-docker.yml
@@ -14,6 +14,9 @@ env:
   DOCKER_IMAGE: 'ghcr.io/pytorch/torchbench:latest'
   HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   build-push-docker:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/clean-nightly-docker.yml
+++ b/.github/workflows/clean-nightly-docker.yml
@@ -5,6 +5,9 @@ on:
     # Cleanup the nightly Docker images every 3 months
     - cron: '0 0 1 */3 *'
 
+permissions:
+  contents: read
+
 jobs:
   clean-push-docker:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.