### PR TITLE
temprature as numpy.float64 is captured as a fake tensor during torch…

### DIFF
--- a/torchbenchmark/models/speech_transformer/speech_transformer/transformer/attention.py
+++ b/torchbenchmark/models/speech_transformer/speech_transformer/transformer/attention.py
@@ -21,7 +21,7 @@ class MultiHeadAttention(nn.Module):
         nn.init.normal_(self.w_vs.weight, mean=0, std=np.sqrt(2.0 / (d_model + d_v)))
 
         self.attention = ScaledDotProductAttention(
-            temperature=np.power(d_k, 0.5), attn_dropout=dropout
+            temperature=float(np.power(d_k, 0.5)), attn_dropout=dropout
         )
         self.layer_norm = nn.LayerNorm(d_model)
 


### PR DESCRIPTION
Description:                                                                                                                                                                                                                                                                                                                                                                       
  ## What                                                                                                                                                                                                                                                                                                                                                                            
  `speech_transformer` fails the `--export` accuracy benchmark with `fail_accuracy`.                                                                                                                                                                                                                                                                                                 
                                                                                    
  ## Why                                                                                                                                                                                                                                                                                                                                                                             
  The attention temperature is set with `np.power(d_k, 0.5)`, which returns a `numpy.float64`. Under `torch.export(strict=True)`, that numpy scalar gets captured as a fake (meta) constant, so the exported module returns a FakeTensor instead of a real output — and the accuracy check rejects it.                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                     
  ## Fix                                                                                                                                                                                                                                                                                                                                                                             
  Cast the temperature to a plain Python `float`:                                                                                                                                                                                                                                                                                                                                    
                                                            
  ```python                                                                                                                                                                                                                                                                                                                                                                          
  temperature=float(np.power(d_k, 0.5))
                                                                                                                                                                                                                                                                                                                                                                                     
  Value is unchanged; it just traces as a normal scalar.    
                                                                                                                                                                                                                                                                                                                                                                                     
  Testing
                                                                                                                                                                                                                                                                                                                                                                                     
  - --export accuracy config now passes (previously fail_accuracy).                                                                                                                                                                                                                                                                                                                  
  - python test.py -v -k speech_transformer — all pass.
  - Not device-specific: confirmed on NVIDIA A100, AMD MI300/MI350X, and CPU.