### PR TITLE
run_benchmark: exit non-zero on import failure

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -38,10 +38,12 @@ def run():
         benchmark = importlib.import_module(
             f"userbenchmark.{available_benchmarks[args.bm_name]}.run"
         )
-        benchmark.run(bm_args)
     except ImportError as e:
         print(f"Failed to import user benchmark module {args.bm_name}, error: {str(e)}")
         traceback.print_exc()
+        raise SystemExit(1)
+
+    benchmark.run(bm_args)
 
 
 if __name__ == "__main__":

--- a/test_run_benchmark.py
+++ b/test_run_benchmark.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+import run_benchmark
+
+
+def test_import_error_in_run_benchmark_exits_nonzero(monkeypatch):
+    monkeypatch.setattr(run_benchmark, "list_benchmarks", lambda: {"fake": "fake"})
+    monkeypatch.setattr(run_benchmark.importlib, "import_module", lambda _: (_ for _ in ()).throw(ImportError("boom")))
+
+    monkeypatch.setattr(sys, "argv", ["run_benchmark.py", "fake"])
+    with pytest.raises(SystemExit) as exc:
+        run_benchmark.run()
+
+    assert exc.value.code == 1
+
+
+def test_run_exception_propagates_outside_import_handling(monkeypatch):
+    def fake_run(_):
+        raise RuntimeError("runtime failure")
+
+    fake_module = types.SimpleNamespace(run=fake_run)
+
+    monkeypatch.setattr(run_benchmark, "list_benchmarks", lambda: {"fake": "fake"})
+    monkeypatch.setattr(run_benchmark.importlib, "import_module", lambda _: fake_module)
+
+    monkeypatch.setattr(sys, "argv", ["run_benchmark.py", "fake"])
+    with pytest.raises(RuntimeError):
+        run_benchmark.run()


### PR DESCRIPTION
## Summary
- Make user benchmark import failures in `run_benchmark.py` exit with a non-zero status (`SystemExit(1)`) so automation doesn’t treat them as success.
- Keep benchmark execution failures bubbling up naturally so real runtime errors remain visible.
- Add regression coverage in `test_run_benchmark.py` for both behaviors.

## Why this matters
When benchmark imports fail, the script currently only logs a traceback and returns success, which can let broken benchmark runs pass CI checks.
