### PR TITLE
Fix Scribe uploader torchvision schema

### DIFF
--- a/scripts/upload_scribe.py
+++ b/scripts/upload_scribe.py
@@ -89,6 +89,7 @@ class PytorchBenchmarkUploader(ScribeUploader):
                 "git_commit_time",
                 "git_dirty",
                 "pytorch_version",
+                "torchvision_version",
                 "python_version",
                 "machine_kernel",
                 "machine_processor",

--- a/scripts/upload_scribe_v2.py
+++ b/scripts/upload_scribe_v2.py
@@ -122,6 +122,7 @@ class PytorchBenchmarkUploader(ScribeUploader):
                 "git_commit_time",
                 "git_dirty",
                 "pytorch_version",
+                "torchvision_version",
                 "python_version",
                 "machine_kernel",
                 "machine_processor",

--- a/test_upload_scribe.py
+++ b/test_upload_scribe.py
@@ -1,0 +1,11 @@
+import importlib
+
+
+def test_scribe_uploaders_accept_torchvision_version():
+    for module_name in ("scripts.upload_scribe", "scripts.upload_scribe_v2"):
+        module = importlib.import_module(module_name)
+        message = module.PytorchBenchmarkUploader().format_message(
+            {"time": 1, "torchvision_version": "0.18.0"}
+        )
+
+        assert message["normal"]["torchvision_version"] == "0.18.0"


### PR DESCRIPTION
## Summary
- Add `torchvision_version` back to the normal schema in both Scribe uploaders.
- Add a regression test that formats `torchvision_version` through both uploaders.

## Why this matters
`conftest.py` still records `torchvision_version`, and both uploaders include it in outgoing messages. Without the schema entry, `format_message()` raises before upload.

## Validation
Not run locally.
