### PR TITLE
fix yolov3 on Windows

### DIFF
--- a/torchbenchmark/models/yolov3/__init__.py
+++ b/torchbenchmark/models/yolov3/__init__.py
@@ -62,8 +62,9 @@ class Model(BenchmarkModel):
         if test == "eval" or self.dargs.accuracy:
             self.model, self.example_inputs = self.prep_eval()
         elif test == "train":
+            coco_data = os.path.join(DATA_DIR, "coco128.data").replace(os.sep, "/")
             train_args = split(
-                f"--data {DATA_DIR}/coco128.data --img 416 --batch {self.batch_size} --nosave --notest \
+                f"--data {coco_data} --img 416 --batch {self.batch_size} --nosave --notest \
                                 --epochs {self.num_epochs} --device {self.device_str} --weights '' \
                                 --train-num-batch {self.train_num_batch} \
                                 --prefetch"


### PR DESCRIPTION
## Fix `yolov3` train mode on Windows (path mangled by `shlex.split`)

### Problem
In `torchbenchmark/models/yolov3/__init__.py` the train args are built by interpolating the absolute `DATA_DIR` into a string parsed with `shlex.split`. In POSIX mode (default), `\` is an escape char, so on Windows the path backslashes are stripped and `--data` points to a non-existent file, making `check_file` fail with `AssertionError`.

### Fix
Use forward slashes (valid on Windows) before `shlex.split`:

```python
coco_data = os.path.join(DATA_DIR, "coco128.data").replace(os.sep, "/")
train_args = split(f"--data {coco_data} --img 416 ...")
```

### Before
```
loading model: 0it [00:00, ?it/s]
loading model: 0it [00:02, ?it/s]
xpu  train yolov3
Traceback (most recent call last):
  File "C:\Users\gta\repositories\pytorch\pytorch\benchmarks\dynamo\common.py", line 4799, in run
    ) = runner.load_model(
        ^^^^^^^^^^^^^^^^^^
  File "C:\Users\gta\repositories\pytorch\pytorch\benchmarks\dynamo\torchbench.py", line 307, in load_model
    benchmark = benchmark_cls(
                ^^^^^^^^^^^^^^
  File "C:\Users\gta\repositories\pytorch\benchmark\torchbenchmark\util\model.py", line 43, in __call__
    obj = type.__call__(cls, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\gta\repositories\pytorch\benchmark\torchbenchmark\models\yolov3\__init__.py", line 71, in __init__
    self.training_loop, self.model, self.example_inputs = prepare_training_loop(
                                                          ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\gta\repositories\pytorch\benchmark\torchbenchmark\models\yolov3\yolo_train.py", line 636, in prepare_training_loop
    opt.data = check_file(opt.data)  # check file
               ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\gta\repositories\pytorch\benchmark\torchbenchmark\models\yolov3\yolo_utils\utils.py", line 51, in check_file
    assert os.path.isfile(file)
           ^^^^^^^^^^^^^^^^^^^^
AssertionError

eager_fail_to_run
```

### After
```
loading model: 0it [00:00, ?it/s]
loading model: 0it [00:10, ?it/s]
xpu  train yolov3
W0722 11:40:23.836000 14048 site-packages\torch\_inductor\cudagraph_utils.py:401] [2/0_1] [__cudagraphs] skipping cudagraphs due to skipping cudagraphs due to multiple devices: device(type='xpu', index=0)
W0722 11:43:58.166000 14048 site-packages\torch\_inductor\cudagraph_utils.py:401] [2/1_1] [__cudagraphs] skipping cudagraphs due to skipping cudagraphs due to multiple devices: device(type='xpu', index=0)
pass
```