### PR TITLE
Disable sam_fast custom flash without Triton block pointers

### DIFF
--- a/torchbenchmark/models/sam_fast/__init__.py
+++ b/torchbenchmark/models/sam_fast/__init__.py
@@ -6,6 +6,14 @@ import os
 import cv2
 import numpy as np
 import torch
+import triton.language as tl
+
+# The optional flash_4 kernel requires Triton's legacy block-pointer frontend.
+# Disable it before importing segment_anything_fast so the model uses its SDPA
+# fallback when those APIs are unavailable.
+if not hasattr(tl, "make_block_ptr") or not hasattr(tl, "advance"):
+    os.environ["SEGMENT_ANYTHING_FAST_USE_FLASH_4"] = "0"
+
 from segment_anything_fast.build_sam import sam_model_fast_registry
 from segment_anything_fast.predictor import SamPredictor
 from torchbenchmark import DATA_PATH


### PR DESCRIPTION
The optional `segment-anything-fast` `flash_4` kernel still uses Triton's legacy `tl.make_block_ptr` and `tl.advance` APIs, which were removed by triton-lang/triton#10833. This causes the full `sam_fast` TorchBench model to fail during eager validation with newer Triton revisions.

Detect those APIs before importing `segment_anything_fast` and use its documented `SEGMENT_ANYTHING_FAST_USE_FLASH_4=0` switch when they are unavailable. The benchmark continues exercising the full model through its existing SDPA fallback, while older Triton behavior remains unchanged.

Test plan:
- `python3.12 -m py_compile torchbenchmark/models/sam_fast/__init__.py`
- Verified with Triton 3.7 that the custom kernel remains enabled when both APIs exist
- Simulated missing `tl.advance` and verified the adapter disables the custom kernel before package import