### PR TITLE
fix(huggingface): resolve the config class for eval() explicitly (#2703)

### DIFF
--- a/torchbenchmark/util/framework/huggingface/basic_configs.py
+++ b/torchbenchmark/util/framework/huggingface/basic_configs.py
@@ -300,8 +300,11 @@ def download_model(model_name):
         return m.groups()[0]
 
     config_cls_name = _extract_config_cls_name(HUGGINGFACE_MODELS[model_name][2])
-    exec(f"from transformers import {config_cls_name}")
-    config = eval(HUGGINGFACE_MODELS[model_name][2])
+    # Evaluate the constructor against an explicit namespace. `exec("from ... import
+    # X")` writes into a snapshot of the function locals, which `eval()` no longer
+    # sees as of Python 3.13 (PEP 667), so the class name was not resolvable.
+    config_ns = {config_cls_name: getattr(transformers, config_cls_name)}
+    config = eval(HUGGINGFACE_MODELS[model_name][2], config_ns)
     model_cls = getattr(transformers, HUGGINGFACE_MODELS[model_name][3])
     kwargs = {}
     if model_name in HUGGINGFACE_MODELS_REQUIRING_TRUST_REMOTE_CODE:


### PR DESCRIPTION
Fixes #2703.

## Problem

`download_model()` imports the config class with `exec()` and then builds it with `eval()`:

```python
# torchbenchmark/util/framework/huggingface/basic_configs.py:302-304
config_cls_name = _extract_config_cls_name(HUGGINGFACE_MODELS[model_name][2])
exec(f"from transformers import {config_cls_name}")
config = eval(HUGGINGFACE_MODELS[model_name][2])
```

As of Python 3.13, [PEP 667](https://peps.python.org/pep-0667/) makes `locals()` in an optimized (function) scope return an **independent snapshot**, so `exec()` writes the imported name into a dict the following `eval()` never reads. Every entry in `HUGGINGFACE_MODELS` then fails:

```
NameError: name 'AutoConfig' is not defined
```

On 3.12 and earlier, both calls shared a single locals dict, so the name happened to be visible — which is why this has gone unnoticed.

## Fix

Drop the `exec()` and evaluate the constructor against an explicit namespace built with `getattr(transformers, ...)` — the same lookup the very next line already uses for the model class:

```python
config_ns = {config_cls_name: getattr(transformers, config_cls_name)}
config = eval(HUGGINGFACE_MODELS[model_name][2], config_ns)
```

`transformers` is already imported at module level, and all seven config classes referenced by the table (`AutoConfig`, `BertConfig`, `BigBirdConfig`, `LlamaConfig`, `PhiConfig`, `ReformerConfig`, `WhisperConfig`) are top-level `transformers` exports. This also stops the import leaking into the caller's scope.

## Verification

The real `download_model` was AST-extracted from this file and replayed over **all 31 entries** of `HUGGINGFACE_MODELS` against a stub `transformers` module, on both interpreters:

| | Python 3.13.13 | Python 3.12.10 |
| --- | --- | --- |
| before | **0 / 31 ok** — all `NameError: name 'AutoConfig' is not defined` | 31 / 31 ok |
| after | **31 / 31 ok** | 31 / 31 ok |

So the failure reproduces exactly as reported on 3.13, the fix clears it, and 3.12 behaviour is unchanged.

`black --line-length 88` reports the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
